### PR TITLE
Remove -l arg from get_shell_path()

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -511,7 +511,7 @@ def get_shell_path(env):
 
         if shell in ('bash', 'zsh', 'ksh', 'sh'):
             return extract_path(
-                (shell_path, '-l', '-c', 'echo $PATH')
+                (shell_path, '-c', 'echo $PATH')
             )
         elif shell == 'fish':
             return extract_path(


### PR DESCRIPTION
Gotta say this is one of the weirdest bugs I've ever seen. What was happening is that none of my linter executables were being found, so I started debugging only to find the string "Marijuana will be legal some day, because the many law students" prepended to my path! WTF!

Well it turns out I have fortune cookies turned on. Maybe that's a default in Ubunutu.

So, anyway. Is it possible to turn off the login shell arg?
