### PR TITLE
Removed use of non-existent has_setting() call

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -267,8 +267,8 @@ class SublimelinterToggleSettingCommand(sublime_plugin.WindowCommand):
         if args.get('checked', False):
             return True
 
-        if persist.settings.has_setting(args['setting']):
-            setting = persist.settings.get(args['setting'], None)
+        setting = persist.settings.get(args['setting'], None)
+        if setting is not None:            
             return setting is not None and setting is not args['value']
         else:
             return args['value'] is not None


### PR DESCRIPTION
Pressing ctrl-shift-p to open the pallet caused SublimeLinter3 to throw an AttributeError for has_settings at line 270.
