### PR TITLE
Added html.parser.unescape

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -20,6 +20,7 @@ import subprocess
 import tempfile
 from threading import Thread
 import time
+import html.parser
 
 import sublime
 import sublime_plugin
@@ -233,6 +234,8 @@ class SublimelinterShowAllErrors(sublime_plugin.TextCommand):
 
                 # Insert an arrow at the column in the stripped line
                 code = visible_line[:column] + '➜' + visible_line[column:]
+                html_parser = html.parser.HTMLParser()
+                message = html_parser.unescape(message)
                 options.append(['{}  {}'.format(lineno + 1, message), code])
 
         self.viewport_pos = view.viewport_position()

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -25,6 +25,7 @@ import os
 import re
 import shlex
 import sublime
+import html.parser
 
 from . import highlight, persist, util
 
@@ -1161,6 +1162,9 @@ class Linter(metaclass=LinterMeta):
 
         # Strip trailing CR, space and period
         error = ((col or 0), str(error).rstrip('\r .'))
+
+        html_parser = html.parser.HTMLParser()
+        error = html_parser.unescape(error)
 
         if line in self.errors:
             self.errors[line].append(error)

--- a/sublimelinter.py
+++ b/sublimelinter.py
@@ -12,6 +12,7 @@
 
 import os
 import re
+import html.parser
 
 import sublime
 import sublime_plugin
@@ -338,6 +339,9 @@ class SublimeLinter(sublime_plugin.EventListener):
                     status += '; '.join(line_errors)
                 else:
                     status = '%i error%s' % (count, plural)
+
+                html_parser = html.parser.HTMLParser()
+                status = html_parser.unescape(status)
 
                 view.set_status('sublimelinter', status)
             else:


### PR DESCRIPTION
Some linters (for example phpcs) output messages in html-entities if there are non-latin characters in them.
Added unescaping before outputing message.
