### PR TITLE
Rename linter "SublimeLinter-contrib-..." in install.txt

### DIFF
--- a/linter-plugin-template/messages/install.txt
+++ b/linter-plugin-template/messages/install.txt
@@ -1,4 +1,4 @@
-SublimeLinter-__linter__
+SublimeLinter-contrib-__linter__
 -------------------------------
 This linter plugin for SublimeLinter provides an interface to __linter__.
 
@@ -7,4 +7,4 @@ This linter plugin for SublimeLinter provides an interface to __linter__.
 Before this plugin will activate, you *must*
 follow the installation instructions here:
 
-https://github.com/__user__/SublimeLinter-__linter__
+https://github.com/__user__/SublimeLinter-contrib-__linter__


### PR DESCRIPTION
Corrects naming convention in the `messages/install.txt` file adding "-contrib-". This was done most places in the linter-plugin-template and just seems to have been missed here.
