### PR TITLE
Update Windows key binding to be consistent with the Docs

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,6 @@
 [
-    { "keys": ["ctrl+k", "l"], "command": "sublimelinter_lint" },
-    { "keys": ["ctrl+k", "n"], "command": "sublimelinter_goto_error", "args": {"direction": "next"} },
-    { "keys": ["ctrl+k", "p"], "command": "sublimelinter_goto_error", "args": {"direction": "previous"} },
-    { "keys": ["ctrl+k", "a"], "command": "sublimelinter_show_all_errors" }
+    { "keys": ["ctrl+k", "ctrl+l"], "command": "sublimelinter_lint" },
+    { "keys": ["ctrl+k", "ctrl+n"], "command": "sublimelinter_goto_error", "args": {"direction": "next"} },
+    { "keys": ["ctrl+k", "ctrl+p"], "command": "sublimelinter_goto_error", "args": {"direction": "previous"} },
+    { "keys": ["ctrl+k", "ctrl+a"], "command": "sublimelinter_show_all_errors" }
 ]


### PR DESCRIPTION
Based on the docs:
http://sublimelinter.readthedocs.org/en/latest/navigating.html#accessing-navigation-commands

Currently pressing `ctrl+k, ctrl+n` will open a new tab in ST3 instead of triggering the action.
