### PR TITLE
Prevent misbehaving plugins crash on startup when resolving versioning command fails

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1487,6 +1487,11 @@ class Linter(metaclass=LinterMeta):
             cmd = list(cls.executable_path)
 
         cmd += args
+
+        if None in cmd:
+            persist.printf("WARNING: Could not get executable versioning command for {}".format(cls.name))
+            return None
+
         persist.debug('{} version query: {}'.format(cls.name, ' '.join(cmd)))
 
         version = util.communicate(cmd, output_stream=util.STREAM_BOTH)


### PR DESCRIPTION
I had some issues with flake8 and pep257 which where not correctly installed on my system. 

The resolving of `cmd` crashed because it did not get correctly binary names (got None instead).
This workaround will gracefully handle such situations and give some user readable output why the plugin load is not working. 

Here are some debug prints from the actual state what was going:

```
SublimeLinter: import of pep257 module in pep257 failed, linter will not run using built in python 
SublimeLinter: WARNING: import of flake8.engine module in flake8 failed, linter will not work with python 3 code 
SublimeLinter: [None, None] 
SublimeLinter: ['--version'] 
SublimeLinter: <class 'SublimeLinter-pep257.linter.PEP257'> 
SublimeLinter: ERROR: could not launch [None, None, '--version'] 
SublimeLinter: reason: expect bytes or str, not NoneType 
SublimeLinter: PATH: /Users/mikko/.rvm/gems/ruby-1.9.3-p286/bin:/Users/mikko/.rvm/gems/ruby-1.9.3-p286@global/bin:/Users/mikko/.rvm/rubies/ruby-1.9.3-p286/bin:/Users/mikko/.rvm/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/X11/bin 
SublimeLinter: WARNING: no pep257 version could be extracted from:
```
