### PR TITLE
Fix is_settings_file (Fixed #81)

### DIFF
--- a/sublimelinter.py
+++ b/sublimelinter.py
@@ -292,6 +292,9 @@ class SublimeLinter(sublime_plugin.EventListener):
 
         if not filename:
             return False
+        
+        if not filename.startswith(sublime.packages_path()):
+            return False
 
         dirname, filename = os.path.split(filename)
         dirname = os.path.basename(dirname)


### PR DESCRIPTION
Return True only if config file located in current sublime instance
