### PR TITLE
Adds hide_warnings_from_all_errors setting

### DIFF
--- a/Context.sublime-menu.template
+++ b/Context.sublime-menu.template
@@ -36,6 +36,14 @@
                 "command": "sublimelinter_show_all_errors"
             },
             {
+                "caption": "Hide Warnings in All Errors",
+                "command": "sublimelinter_toggle_setting", "args":
+                {
+                    "setting": "hide_warnings_from_all_errors",
+                    "checked": true
+                }
+            },
+            {
                 "caption": "Show Errors on Save",
                 "command": "sublimelinter_toggle_setting", "args":
                 {

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -94,6 +94,22 @@
         "command": "sublimelinter_show_all_errors"
     },
     {
+        "caption": "SublimeLinter: Hide Warnings in All Errors",
+        "command": "sublimelinter_toggle_setting", "args":
+        {
+            "setting": "hide_warnings_from_all_errors",
+            "value": true
+        }
+    },
+    {
+        "caption": "SublimeLinter: Show Warnings in All Errors",
+        "command": "sublimelinter_toggle_setting", "args":
+        {
+            "setting": "hide_warnings_from_all_errors",
+            "value": false
+        }
+    },
+    {
         "caption": "SublimeLinter: Show Errors on Save",
         "command": "sublimelinter_toggle_setting", "args":
         {

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -5,6 +5,7 @@
         "error_color": "D02000",
         "gutter_theme": "Packages/SublimeLinter/gutter-themes/Default/Default.gutter-theme",
         "gutter_theme_excludes": [],
+        "hide_warnings_from_all_errors": false,
         "lint_mode": "background",
         "mark_style": "outline",
         "no_column_highlights_line": false,

--- a/commands.py
+++ b/commands.py
@@ -44,7 +44,7 @@ def error_command(method):
         vid = self.view.id()
 
         if vid in persist.errors and persist.errors[vid]:
-            method(self, self.view, persist.errors[vid], **kwargs)
+            method(self, self.view, persist.errors[vid], persist.highlights[vid], **kwargs)
         else:
             sublime.message_dialog('No lint errors.')
 
@@ -212,7 +212,7 @@ class SublimelinterGotoErrorCommand(GotoErrorCommand):
     """A command that selects the next/previous error."""
 
     @error_command
-    def run(self, view, errors, **kwargs):
+    def run(self, view, errors, highlights, **kwargs):
         """Run the command."""
         self.goto_error(view, errors, **kwargs)
 
@@ -222,13 +222,18 @@ class SublimelinterShowAllErrors(sublime_plugin.TextCommand):
     """A command that shows a quick panel with all of the errors in the current view."""
 
     @error_command
-    def run(self, view, errors):
+    def run(self, view, errors, highlights):
         """Run the command."""
         self.errors = errors
+        self.highlights = highlights
         self.points = []
         options = []
 
         for lineno, line_errors in sorted(errors.items()):
+            if persist.settings.get("hide_warnings_from_all_errors", False):
+                if self.highlights.line_type(lineno) != highlight.ERROR:
+                    continue
+
             line = view.substr(view.full_line(view.text_point(lineno, 0))).rstrip('\n\r')
 
             # Strip whitespace from the front of the line, but keep track of how much was

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -116,6 +116,21 @@ class HighlightSet:
         for highlight in self.all:
             highlight.reset()
 
+    def line_type(self, line):
+        """Return the primary error type for the given line number."""
+        if not self.all:
+            return None
+
+        line_type = None
+        for highlight in self.all:
+            if line_type == ERROR:
+                continue
+            _line_type = highlight.lines.get(line)
+            if _line_type != WARNING and line_type == WARNING:
+                continue
+            line_type = _line_type
+        return line_type
+
 
 class Highlight:
 


### PR DESCRIPTION
Setting `"hide_warnings_from_all_errors": true` in your
SublimeLinter.sublime-settings will now cause warnings to not
display when using the Show All Errors command.

This is the same command used when `"show_errors_on_save"` is set
to `true`, so enabling it will also cause warnings to not show
in the popup errors panel on save.
