### PR TITLE
Added option to use variable $project_path in any part of config when it...

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1714,6 +1714,10 @@ class Linter(metaclass=LinterMeta):
         elif not code:
             cmd.append(self.filename)
 
+        project_file_path = sublime.active_window().project_file_name()
+        project_path = os.path.dirname(project_file_path)
+        cmd = [arg.replace('$project_path', project_path) for arg in cmd]
+
         return util.communicate(
             cmd,
             code,
@@ -1722,6 +1726,11 @@ class Linter(metaclass=LinterMeta):
 
     def tmpfile(self, cmd, code, suffix=''):
         """Run an external executable using a temp file to pass code and return its output."""
+
+        project_file_path = sublime.active_window().project_file_name()
+        project_path = os.path.dirname(project_file_path)
+        cmd = [arg.replace('$project_path', project_path) for arg in cmd]
+
         return util.tmpfile(
             cmd,
             code,
@@ -1732,6 +1741,11 @@ class Linter(metaclass=LinterMeta):
 
     def tmpdir(self, cmd, files, code):
         """Run an external executable using a temp dir filled with files and return its output."""
+
+        project_file_path = sublime.active_window().project_file_name()
+        project_path = os.path.dirname(project_file_path)
+        cmd = [arg.replace('$project_path', project_path) for arg in cmd]
+
         return util.tmpdir(
             cmd,
             files,


### PR DESCRIPTION
... related to running exteral toolkit.

It gives option to use project-related settings relative to project root. For example we can specify path
for phpmd ruleset xml "args": [ "$project_path/phpmd-ruleset.xml" ]. In that case also settings will be linked
to project root and sublime project file will not contain full paths, so project will work fine from any location.
