### PR TITLE
Report (Open Files) lines number are wrong

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1170,7 +1170,7 @@ class SublimelinterReportCommand(sublime_plugin.WindowCommand):
 
                         for line, messages in items:
                             for col, message in messages:
-                                out += '    {:>{width}}: {}\n'.format(line, message, width=width)
+                                out += '    {:>{width}}: {}\n'.format(line + 1, message, width=width)
 
                 output.insert(edit, output.size(), out)
 


### PR DESCRIPTION
The report generated by this command are all lines number off by 1 (one line before the actual line, eg. 2240 instead of 2241).
