### PR TITLE
Fixed exception bug in NodeLinter.get_pkg_bin_cmd

### DIFF
--- a/lint/node_linter.py
+++ b/lint/node_linter.py
@@ -133,4 +133,4 @@ class NodeLinter(linter.Linter):
         """
 
         pkg = json.load(open(pkgpath))
-        return pkg['bin'][cmd] if pkg['bin'] and cmd in pkg['bin'] else None
+        return pkg['bin'][cmd] if 'bin' in pkg and cmd in pkg['bin'] else None


### PR DESCRIPTION
I made a stupid error in NodeLinter. This fixes it. I assumed I could do `if pkg['bin'][cmd]` when I should have done `if cmd in pkg['bin']`
