### PR TITLE
Rvm performance via use_rvm_auto_ruby setting

### DIFF
--- a/docs/defines.inc
+++ b/docs/defines.inc
@@ -16,6 +16,7 @@
 .. |cmd| replace:: Command Palette (:kbd:`cmd+shift+p` on Mac OS X, :kbd:`ctrl+shift+p` on Linux/Windows)
 .. |path| replace:: ``PATH``
 .. |regex| replace:: If you need help constructing, testing or debugging a regular expression, `regular expressions 101 <https://regex101.com/>`__ provides an easy way to do so.
+.. |customenv| replace:: For more information on how to customize Sublime Text's environment on Mac OS, see `this gist <https://gist.github.com/smanolloff/54a787f661a3b8b5af10541f5cc5fa2c>`__
 
 .. |_sl| replace:: `SublimeLinter <https://github.com/SublimeLinter/SublimeLinter3>`__
 .. |_org| replace:: `SublimeLinter organization <https://github.com/SublimeLinter>`__

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -143,3 +143,16 @@ In :ref:`debug mode <debug-mode>`, |sl| logs each occurrence of an ignore match.
 .. note::
 
    |regex|
+
+
+use_rvm_auto_ruby
+-----------------
+This is a ruby-specific linter setting and allows to override the default behavior when RVM is installed on the system.
+
+By default, SublimeLinter will try to use ``rvm-auto-ruby`` executable for linting. Although this guarantees that the latest RVM-activated ruby will be used for linting, it has the downside of being too slow (it reinitializes the RVM environment on every invocation, which has a noticeable performance impact.)
+
+If you do not wish to use ``rvm-auto-ruby`` (for example, you have set up your sublime environment with the correct ruby paths), set this value to false.
+
+.. note::
+
+   |customenv|

--- a/docs/ruby_linter.rst
+++ b/docs/ruby_linter.rst
@@ -30,7 +30,7 @@ The following forms are valid for the first argument of ``cmd``:
 If ``rbenv`` is installed and the gem is also under ``rbenv`` control,
 the gem will be executed directly. Otherwise ``(ruby [, gem])`` will be executed.
 
-If ``rvm-auto-ruby`` is installed, ``(rvm-auto-ruby [, gem])`` will be executed.
+If ``rvm-auto-ruby`` is installed, ``(rvm-auto-ruby [, gem])`` will be executed unless the ``use_rvm_auto_ruby`` linter setting is explicitly set to false.
 
 Otherwise ``ruby`` or ``gem`` will be executed.
 

--- a/lint/ruby_linter.py
+++ b/lint/ruby_linter.py
@@ -76,7 +76,7 @@ class RubyLinter(linter.Linter):
         be returned.
 
         If rvm-auto-ruby is installed, [rvm-auto-ruby <, gem>] will be
-        returned.
+        returned unless the 'use_rvm_auto_ruby' linter setting is set to false.
 
         Otherwise [ruby] or [gem] will be returned.
 
@@ -85,7 +85,7 @@ class RubyLinter(linter.Linter):
         ruby = None
         rbenv = util.which('rbenv')
 
-        if not rbenv:
+        if not rbenv and cls.settings().get('use_rvm_auto_ruby', True):
             ruby = util.which('rvm-auto-ruby')
 
         if not ruby:

--- a/lint/util.py
+++ b/lint/util.py
@@ -558,6 +558,22 @@ def get_shell_path(env):
 
     return p
 
+def merge_lists(a, b):
+    """
+    Merge two lists by removing duplicates.
+
+    This method differs from list(set(a + b)) by preserving the original ordering.
+
+    """
+    newlist=[]
+    for i in a:
+        newlist.append(i)
+    for z in b:
+        if z not in newlist:
+            newlist.append(z)
+
+    return newlist
+
 
 @lru_cache(maxsize=None)
 def get_environment_variable(name):
@@ -644,7 +660,9 @@ def create_environment():
     env.update(os.environ)
 
     if os.name == 'posix':
-        env['PATH'] = get_shell_path(os.environ)
+        default_paths = env['PATH'].split(':')
+        computed_paths = get_shell_path(os.environ).split(':')
+        env['PATH'] = ':'.join(merge_lists(default_paths, computed_paths))
 
     paths = persist.settings.get('paths', {})
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -558,14 +558,16 @@ def get_shell_path(env):
 
     return p
 
+
 def merge_lists(a, b):
     """
-    Merge two lists by removing duplicates.
+    Merge two lists `a` and `b` by removing duplicates (from `b`)
 
     This method differs from list(set(a + b)) by preserving the original ordering.
 
     """
-    newlist=[]
+
+    newlist = []
     for i in a:
         newlist.append(i)
     for z in b:
@@ -660,9 +662,9 @@ def create_environment():
     env.update(os.environ)
 
     if os.name == 'posix':
-        default_paths = env['PATH'].split(':')
-        computed_paths = get_shell_path(os.environ).split(':')
-        env['PATH'] = ':'.join(merge_lists(default_paths, computed_paths))
+        default_paths = filter(None, env['PATH'].split(os.pathsep))
+        computed_paths = filter(None, get_shell_path(os.environ).split(os.pathsep))
+        env['PATH'] = os.pathsep.join(merge_lists(computed_paths, default_paths))
 
     paths = persist.settings.get('paths', {})
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -561,7 +561,7 @@ def get_shell_path(env):
 
 def merge_lists(a, b):
     """
-    Merge two lists `a` and `b` by removing duplicates (from `b`)
+    Merge two lists `a` and `b` by removing duplicates (from `b`).
 
     This method differs from list(set(a + b)) by preserving the original ordering.
 


### PR DESCRIPTION
Add a `use_rvm_auto_ruby` boolean setting.

By default, SublimeLinter will try to use `rvm-auto-ruby` executable for linting. Although this guarantees that the latest RVM-activated ruby will be used, it has the downside of being too slow (it re-initializes the RVM environment on every invocation, which has a noticeable performance impact).

The rationale of this PR would be: RVM installed should not mean that `rvm-auto-ruby` is the only means of executing RVM-enabled ruby for linting. In my case, I do have RVM, but I initialize it only once, at Sublime boot, so paths are already in place and the linter will lint using the "correct" ruby without the need of any magic tricks -- it has the correct environment already set. See this gist:

http://gist.github.com/smanolloff/54a787f661a3b8b5af10541f5cc5fa2c