### PR TITLE
Add ${root} setting token

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -66,8 +66,9 @@ After the default, user and project settings are merged, SublimeLinter iterates 
 =================== =========================================================================
 Token               Value
 =================== =========================================================================
-${sublime}          The full path to the Sublime Text packages directory
-${project}          The full path to the project’s parent directory, if available.
+${sublime}          The full path to the Sublime Text packages directory.
+${project}          The full path to the project file's parent directory, if available.
+${root}             The full path to the root folder of the current view in project or folder mode. Falls back to `${directory}` in single file mode.
 ${directory}        The full path to the parent directory of the current view’s file.
 ${home}             The full path to the current user’s home directory.
 ${env:x}            The environment variable 'x'.
@@ -77,11 +78,11 @@ Please note:
 
 - Directory paths do **not** include a trailing directory separator.
 
-- ``${project}`` and ``${directory}`` expansion are dependent on a file being open in a window, and thus may not work when running lint reports.
+- ``${project}``, ``${root}`` and ``${directory}`` expansions are dependent on a file being open in a window, and thus may not work when running lint reports.
 
 - The environment variables available to the ``${env:x}`` token are those available within the Sublime Text python context, which is a very limited subset of those available within a command line shell.
 
-Project and parent directory paths are especially useful if you want to load specific configuration files for a linter.
+Project, root and parent directory paths are especially useful if you want to load specific configuration files for a linter.
 For example, you could use the ``${project}`` and ``${home}`` tokens in your project settings:
 
 .. code-block:: json

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -482,6 +482,10 @@ class Linter(metaclass=LinterMeta):
         window = self.view.window()
         if window:
             view = window.active_view()
+            window_vars = window.extract_variables()
+            directory = (
+                os.path.dirname(view.file_name()).replace('\\', '/') if
+                view and view.file_name() else "FILE NOT ON DISK")
 
             if not view or not view.file_name():
                 return
@@ -515,10 +519,12 @@ class Linter(metaclass=LinterMeta):
 
             expressions.append({
                 'token': '${directory}',
-                'value': (
-                    os.path.dirname(view.file_name()).replace('\\', '/') if
-                    view and view.file_name() else "FILE NOT ON DISK"
-                )
+                'value': directory
+            })
+
+            expressions.append({
+                'token': '${root}',
+                'value': window_vars.get('folder', None) or directory
             })
 
         expressions.append({


### PR DESCRIPTION
It gives the ability to `chdir` to root folder of a view when SublimeText is open in folder or project mode.

I used the var `folder` from [window variables](https://www.sublimetext.com/docs/3/api_reference.html#sublime.Window).

In the case of the Rubocop linter, `rubocop` uses the `.ruby-version` file [to set the targeted ruby version](https://rubocop.readthedocs.io/en/latest/configuration/#setting-the-target-ruby-version). Since the command is not run from the root folder of the project, and that the project file is not necessarly inside the root folder, `${root}` was needed to `chdir` in the right folder containing the `.ruby-version` file.