### PR TITLE
Lint the visible views from the active window on startup

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -68,17 +68,17 @@ def plugin_loaded():
 
 def visible_views():
     """Yield all visible views of the active window."""
-    w = sublime.active_window()
+    window = sublime.active_window()
 
     # Priority for the active view
-    av = w.active_view()
-    yield av
+    active_view = window.active_view()
+    yield active_view
 
-    ng = w.num_groups()
-    for gid in range(ng):
-        v = w.active_view_in_group(gid)
-        if v != av:
-            yield v
+    num_groups = window.num_groups()
+    for group_id in range(num_groups):
+        view = window.active_view_in_group(group_id)
+        if view != active_view:
+            yield view
 
 
 class Listener:

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -60,12 +60,25 @@ def plugin_loaded():
     if window:
         plugin.on_activated_async(window.active_view())
 
-    # Load and lint all views on startup
+    # Lint the visible views from the active window on startup
     if persist.settings.get("lint_mode") in ("background", "load_save"):
-        for window in sublime.windows():
-            for view in window.views():
-                plugin.check_syntax(view)
-        plugin.lint_all_views()
+        for view in visible_views():
+            plugin.hit(view)
+
+
+def visible_views():
+    """Yield all visible views of the active window."""
+    w = sublime.active_window()
+
+    # Priority for the active view
+    av = w.active_view()
+    yield av
+
+    ng = w.num_groups()
+    for gid in range(ng):
+        v = w.active_view_in_group(gid)
+        if v != av:
+            yield v
 
 
 class Listener:


### PR DESCRIPTION
This is still an improvement over SL3 which only linted(?) the active (focused) view. 

It is way better for startup of course. But since Sublime never opens a panel on startup, we have plenty of time after startup where we can lazy lint other views. If at all.

