### PR TITLE
Queue replacement

### DIFF
--- a/lint/queue.py
+++ b/lint/queue.py
@@ -1,116 +1,70 @@
-"""This module provides a threaded queue for lint requests."""
+import sublime
 
-from queue import Queue, Empty
-import threading
-import traceback
+from . import persist
+
 import time
 
-from . import persist, util
+
+# Map from view_id to timestamp of last 'hit' (e.g. an edit)
+last_seen = {}
 
 
+# For compatibility this is a class with unchanged API from SL3.
 class Daemon:
-    """
-    This class provides a threaded queue that dispatches lints.
-
-    The following operations can be added to the queue:
-
-    hit - Queue a lint for a given view
-    delay - Queue a delay for a number of milliseconds
-    reload - Indicates the main plugin was reloaded
-
-    """
-
-    MIN_DELAY = 0.1
-    running = False
-    callback = None
-    q = Queue()
-    last_runs = {}
-
     def start(self, callback):
-        """Start the daemon thread that runs loop."""
-        self.callback = callback
-
-        if self.running:
-            self.q.put('reload')
-        else:
-            self.running = True
-            threading.Thread(target=self.loop).start()
-
-    def loop(self):
-        """Continually check the queue for new items and process them."""
-        last_runs = {}
-
-        while True:
-            try:
-                try:
-                    item = self.q.get(block=True, timeout=self.MIN_DELAY)
-                except Empty:
-                    pass  # no immediate task to handle
-                else:
-                    if isinstance(item, tuple):
-                        view_id, timestamp, delay = item
-                        if view_id in self.last_runs and timestamp < self.last_runs[view_id]:
-                            continue
-                        last_runs[view_id] = timestamp, delay
-
-                    elif isinstance(item, (int, float)):
-                        time.sleep(item)
-
-                    elif isinstance(item, str) and item == 'reload':
-                        util.printf('daemon detected a reload')
-                        self.last_runs.clear()
-                        last_runs.clear()
-                    else:
-                        util.printf('unknown message sent to daemon:', item)
-                    continue
-
-                for view_id, (timestamp, delay) in last_runs.copy().items():
-                    # Lint the view if we have gone past the time
-                    # at which the lint wants to run.
-                    if time.monotonic() > timestamp + delay:
-                        self.last_runs[view_id] = time.monotonic()
-                        del last_runs[view_id]
-                        self.lint(view_id, timestamp)
-
-            except Exception:
-                util.printf('error in SublimeLinter daemon:')
-                util.printf('-' * 20)
-                util.printf(traceback.format_exc())
-                util.printf('-' * 20)
+        self._callback = callback
 
     def hit(self, view):
-        """Add a lint request to the queue, return the time at which the request was enqueued."""
-        timestamp = time.monotonic()
-        self.q.put((view.id(), timestamp, self.get_delay(view)))
-        return timestamp
+        assert self._callback, "Queue: Can't hit before start."
 
-    def delay(self, milliseconds=100):
-        """Add a millisecond delay to the queue."""
-        self.q.put(milliseconds / 1000.0)
+        vid = view.id()
+        delay = get_delay()  # [seconds]
+        return queue_lint(vid, delay, self._callback)
 
-    def lint(self, view_id, timestamp):
-        """
-        Call back into the main plugin to lint the given view.
 
-        timestamp is used to determine if the view has been modified
-        since the lint was requested.
+def queue_lint(vid, delay, callback):
+    hit_time = time.monotonic()
 
-        """
-        self.callback(view_id, timestamp)
+    def worker():
+        last_hit = last_seen[vid]
+        del last_seen[vid]
 
-    def get_delay(self, view):
-        """
-        Return the delay between a lint request and when it will be processed.
+        # If we have a newer hit than this one, we debounce
+        if last_hit > hit_time:
+            print('WORKER DELAY', vid, hit_time)
+            queue_lint(vid, last_hit - hit_time, callback)
+            return
 
-        If the lint mode is not background, there is no delay. Otherwise, if
-        a "delay" setting is not available in any of the settings, MIN_DELAY is used.
-        """
-        if persist.settings.get('lint_mode') != 'background':
-            return 0
+        print('WORKER EXEC', vid, hit_time)
+        callback(vid, hit_time)
 
-        delay = persist.settings.get('delay', self.MIN_DELAY)
+    # We cannot fire rapidly `set_timeout_async` or Sublime will miss some
+    # events eventually. So we use a membership test `vid in last_seen` to tell
+    # if we already queued an async worker or not.
+    if vid not in last_seen:
+        print('QUEUE LINT', vid, hit_time, delay * 1000)
+        sublime.set_timeout_async(worker, delay * 1000)
 
-        return delay
+    # We store the last hit_time in any case. This will invalidate the worker
+    # if we have an old one running. The worker needs to debounce and schedule
+    # a new task with a fixed delay accordingly.
+    last_seen[vid] = hit_time
+    return hit_time
+
+
+MIN_DELAY = 0.1
+
+
+def get_delay():
+    """Return the delay between a lint request and when it will be processed.
+
+    If the lint mode is not background, there is no delay. Otherwise, if
+    a "delay" setting is not available in any of the settings, MIN_DELAY is used.
+    """
+    if persist.settings.get('lint_mode') != 'background':
+        return 0
+
+    return persist.settings.get('delay', MIN_DELAY)
 
 
 queue = Daemon()

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -62,6 +62,12 @@ def plugin_loaded():
         for view in visible_views():
             plugin.hit(view)
 
+    # Sublime will fall asleep, and not execute our queued tasks until the
+    # user 'does' something. If we enqueue two empty tasks in a nested way,
+    # everything is fine.
+    sublime.set_timeout_async(
+        lambda: sublime.set_timeout_async(lambda: ..., 10), 10)
+
 
 def visible_views():
     """Yield all visible views of the active window."""
@@ -208,8 +214,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         util.apply_to_all_views(apply)
 
     def lint(self, view_id, hit_time=None, callback=None):
-        """
-        Lint the view with the given id.
+        """Lint the view with the given id.
 
         This method is called asynchronously by queue.Daemon when a lint
         request is pulled off the queue.
@@ -222,11 +227,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         callback is the method to call when the lint is finished. If not
         provided, it defaults to highlight().
         """
-        # If the view has been modified since the lint was triggered,
-        # don't lint again.
-        if hit_time and persist.last_hit_times.get(view_id, 0) > hit_time:
-            return
-
         view = Linter.get_view(view_id)
 
         if not view:


### PR DESCRIPTION
The old queue implementation used its own `threading.Thread` to do async
background work. It had to use polling for that.

Here, we use the builtin async threading that comes with Sublime. This has
the advantage that we respect the event system of Sublime. Sublime may
decide that it is busy right now, and will therefore delay our workers.

It is also an easier and shorter implementation.

A small trick is applied for startup so that the initial linting of the
visible views actually occurs even without user interaction.