### PR TITLE
[beta] Fix bug in match dictionary

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1388,9 +1388,11 @@ class Linter(metaclass=LinterMeta):
         if not match:
             persist.debug('No match for regex: {}'.format(self.regex.pattern))
         else:
-            match_dict.update({key: value
-                for key, value in match.groupdict().items()
-                if key in match_dict})
+            match_dict.update({
+                k: v
+                for k, v in match.groupdict().items()
+                if k in match_dict
+            })
             match_dict["match"] = match
 
             # normalize line and col if necessary

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1388,7 +1388,7 @@ class Linter(metaclass=LinterMeta):
         if not match:
             persist.debug('No match for regex: {}'.format(self.regex.pattern))
         else:
-            match_dict.update(match.groupdict())
+            match_dict.update({key: value for key, value in match.groupdict().items() if key in match_dict})
             match_dict["match"] = match
 
             # normalize line and col if necessary

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1388,7 +1388,9 @@ class Linter(metaclass=LinterMeta):
         if not match:
             persist.debug('No match for regex: {}'.format(self.regex.pattern))
         else:
-            match_dict.update({key: value for key, value in match.groupdict().items() if key in match_dict})
+            match_dict.update({key: value
+                for key, value in match.groupdict().items()
+                if key in match_dict})
             match_dict["match"] = match
 
             # normalize line and col if necessary


### PR DESCRIPTION
A bug was introduced in af5527935df20303ae4afbdf8476aafb33cde0ac which causes an error when an individual linter's regex matches groups that are not defined in the [MATCH_DICT](https://github.com/SublimeLinter/SublimeLinter/blob/af5527935df20303ae4afbdf8476aafb33cde0ac/lint/linter.py#L19-L29).

For example, this happens in both the [pylint](https://github.com/SublimeLinter/SublimeLinter-pylint) and [php](https://github.com/SublimeLinter/SublimeLinter-php) linters.

The pylint linter matches a [`code` group](https://github.com/SublimeLinter/SublimeLinter-pylint/blob/bc29a397d7eedbf02711ae5db9a2553a02ad5408/linter.py#L33) and the php linter matches a [`type` group](https://github.com/SublimeLinter/SublimeLinter-php/blob/cd81fe9c6e7bb664722b35716ef72a7930905958/linter.py#L21)

This pull request fixes the bug by only updating the dictionary to be passed to the tuple with keys that are already available on it. The match object from the linter supplied regex will still continue to work and allow it to perform linter-specific actions using that information, but the tuple will only be provided with the groups that are relevant to it.