### PR TITLE
Replacement for the new queue

### DIFF
--- a/lint/queue.py
+++ b/lint/queue.py
@@ -38,9 +38,6 @@ def queue_lint(vid, delay, callback):
     return hit_time
 
 
-MIN_DELAY = 0.1
-
-
 def get_delay():
     """Return the delay between a lint request and when it will be processed.
 
@@ -50,7 +47,7 @@ def get_delay():
     if persist.settings.get('lint_mode') != 'background':
         return 0
 
-    return persist.settings.get('delay', MIN_DELAY)
+    return persist.settings.get('delay')
 
 
 queue = Daemon()

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -63,12 +63,6 @@ def plugin_loaded():
         for view in visible_views():
             plugin.hit(view)
 
-    # Sublime will fall asleep, and not execute our queued tasks until the
-    # user 'does' something. If we enqueue two empty tasks in a nested way,
-    # everything is fine.
-    sublime.set_timeout_async(
-        lambda: sublime.set_timeout_async(lambda: ..., 10), 10)
-
 
 def visible_views():
     """Yield all visible views of the active window."""

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -222,6 +222,10 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         callback is the method to call when the lint is finished. If not
         provided, it defaults to highlight().
         """
+        # If this is not the latest 'hit' we're processing abort early.
+        if hit_time and persist.last_hit_times.get(view_id, 0) > hit_time:
+            return
+
         view = Linter.get_view(view_id)
 
         if not view:


### PR DESCRIPTION
Now, the strategy is just to use the Python standard library.  