### PR TITLE
Small refactor in highlight

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1182,7 +1182,7 @@ class Linter(metaclass=LinterMeta):
             return
 
         view.erase_status(STATUS_KEY)
-        highlight.Highlight.clear(view)
+        highlight.clear_view(view)
         persist.errors.pop(view.id(), None)
 
     def clear(self):

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -17,7 +17,6 @@ if 'plugin_is_loaded' not in globals():
     errors = None
 
     highlights = {}
-    region_store = None
 
     # A mapping between linter class names and linter classes
     linter_classes = {}

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -16,8 +16,6 @@ if 'plugin_is_loaded' not in globals():
     # A mapping between view ids and errors, which are line:(col, message) dicts
     errors = None
 
-    highlights = {}
-
     # A mapping between linter class names and linter classes
     linter_classes = {}
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -8,7 +8,8 @@ import sublime_plugin
 
 from .lint import events
 from .lint.linter import Linter
-from .lint.highlight import HighlightSet, RegionStore
+from .lint import highlight
+from .lint.highlight import HighlightSet
 from .lint.queue import queue
 from .lint import persist, util, style
 from .lint.error import ErrorStore
@@ -50,7 +51,6 @@ def plugin_loaded():
     util.create_tempdir()
 
     persist.errors = ErrorStore()
-    persist.region_store = RegionStore()
 
     for linter in persist.linter_classes.values():
         linter.initialize()
@@ -281,7 +281,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
                 if other_view.buffer_id() == buffer_id:
                     vid = other_view.id()
                     persist.highlights[vid] = highlights
-                    highlights.clear(other_view)
+                    highlight.clear_view(other_view)
                     highlights.draw(other_view)
                     persist.errors[vid] = errors
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -146,7 +146,6 @@ class Listener:
             self.linted_views,
             self.view_syntax,
             persist.errors,
-            persist.highlights,
             persist.view_linters,
             persist.views,
             persist.last_hit_times
@@ -258,7 +257,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
             return
 
         errors = {}
-        highlights = persist.highlights[vid] = HighlightSet()
+        highlights = HighlightSet()
 
         for linter in linters:
             if linter.highlight:
@@ -280,7 +279,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
             for other_view in window.views():
                 if other_view.buffer_id() == buffer_id:
                     vid = other_view.id()
-                    persist.highlights[vid] = highlights
                     highlight.clear_view(other_view)
                     highlights.draw(other_view)
                     persist.errors[vid] = errors


### PR DESCRIPTION
Remove some cruft from `highlight.py`

- The `reset` methods were unused
- The `clear` methods were duplicated
- `persist.highlights` is unused
- The RegionStore is a singleton, only used within *highlight.py* itself, so I removed it from *persist* as well.