### PR TITLE
Implement simple cleanup for the queue

### DIFF
--- a/lint/queue.py
+++ b/lint/queue.py
@@ -4,8 +4,6 @@ from collections import defaultdict
 import time
 import threading
 
-# TODO: Both `timers` and `running` herein grow unbounded. T.i. a proper
-# cleanup must be implemented.
 
 # Map from view_id to threading.Timer objects
 timers = {}
@@ -23,6 +21,9 @@ class Daemon:
         vid = view.id()
         delay = get_delay()  # [seconds]
         return queue_lint(vid, delay, self._callback)
+
+    def cleanup(self, vid):
+        cleanup(vid)
 
 
 def queue_lint(vid, delay, callback):  # <-serial execution
@@ -42,6 +43,15 @@ def queue_lint(vid, delay, callback):  # <-serial execution
     timer.start()
 
     return hit_time
+
+
+def cleanup(vid):
+    try:
+        timers.pop(vid).cancel()
+    except KeyError:
+        pass
+
+    running.pop(vid, None)
 
 
 def get_delay():

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -151,6 +151,7 @@ class Listener:
             else:
                 d.pop(vid, None)
 
+        queue.cleanup(vid)
         panel.fill_panel(view.window(), update=True)
 
     def on_hover(self, view, point, hover_zone):


### PR DESCRIPTION
Since we have a good signal when views actually get unreachable, we just
use that `on_pre_close` to trigger a clearance.