### PR TITLE
Refactor `Linter.lint_view`

### DIFF
--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -35,7 +35,7 @@ class NodeLinter(linter.Linter):
         if self.manifest_path:
             self.read_manifest(path.getmtime(self.manifest_path))
 
-    def lint(self, hit_time):
+    def lint(self, code, hit_time):
         """Check NodeLinter options then run lint."""
         settings = self.get_view_settings()
 
@@ -54,7 +54,7 @@ class NodeLinter(linter.Linter):
             if disable_if_not_dependency and not is_dep:
                 self.disabled = True
 
-        return super(NodeLinter, self).lint(hit_time)
+        return super(NodeLinter, self).lint(code, hit_time)
 
     def is_dependency(self):
         """Check package.json to see if linter is a dependency."""

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -54,7 +54,7 @@ class NodeLinter(linter.Linter):
             if disable_if_not_dependency and not is_dep:
                 self.disabled = True
 
-        super(NodeLinter, self).lint(hit_time)
+        return super(NodeLinter, self).lint(hit_time)
 
     def is_dependency(self):
         """Check package.json to see if linter is a dependency."""

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -41,42 +41,6 @@ def clear_view(view):
         view.erase_regions(key)
 
 
-class VirtualView:
-    def __init__(self, code=''):
-        self._code = code
-        self._newlines = newlines = [0]
-        last = -1
-
-        while True:
-            last = code.find('\n', last + 1)
-
-            if last == -1:
-                break
-
-            newlines.append(last + 1)
-
-        newlines.append(len(code))
-
-    def full_line(self, line):
-        """Return the start/end character positions for the given line."""
-        start = self._newlines[line]
-        end = self._newlines[min(line + 1, len(self._newlines) - 1)]
-
-        return start, end
-
-    def select_line(self, line):
-        """Return code for the given line."""
-        start, end = self.full_line(line)
-        return self._code[start:end]
-
-    # Actual Sublime API would look like:
-    # def full_line(self, region)
-    # def full_line(self, point) => Region
-    # def substr(self, region)
-    # def text_point(self, row, col) => Point
-    # def rowcol(self, point) => (row, col)
-
-
 def get_line_start(view, line):
     return view.text_point(line, 0)
 

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -212,6 +212,12 @@ class Highlight:
 
         pos += start
         region = sublime.Region(pos, pos + length)
+
+        self.add_mark(error_type, style, region)
+
+        return length
+
+    def add_mark(self, error_type, style, region):
         other_type = ERROR if error_type == WARNING else WARNING
 
         for scope, marks in self.marks[other_type].items():
@@ -219,13 +225,13 @@ class Highlight:
             for i, mark in enumerate(marks):
                 if (mark.a, mark.b) == (region.a, region.b):
                     if error_type == WARNING:
-                        return length
+                        # ABORT! We found an error on the exact same position
+                        return
                     else:
                         self.marks[other_type][scope].pop(i - i_offset)
                         i_offset += 1
 
         self.marks[error_type].setdefault(style, []).append(region)
-        return length
 
     def near(self, line, near, error_type=ERROR, word_re=None, style=None):
         """

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -76,11 +76,15 @@ class VirtualView:
     # def rowcol(self, point) => (row, col)
 
 
+def get_line_start(view, line):
+    return view.text_point(line, 0)
+
+
 class Highlight:
     """This class maintains error marks and knows how to draw them."""
 
-    def __init__(self, code=''):
-        self.vv = VirtualView(code)
+    def __init__(self, view):
+        self.view = view
 
         # Dict[error_type, Dict[style, List[region]]]
         self.marks = defaultdict(lambda: defaultdict(list))
@@ -100,7 +104,7 @@ class Highlight:
         raise Exception('`near` has been removed')
 
     def add_error(self, line, start, end, error_type, style, **kwargs):
-        line_start, _ = self.vv.full_line(line)
+        line_start = get_line_start(self.view, line)
         region = sublime.Region(line_start + start, line_start + end)
         self.add_mark(error_type, style, region)
         self.line(line, error_type, style)
@@ -188,7 +192,7 @@ class Highlight:
             for line, style in self.lines[error_type].items():
                 if not self.style_store.has_style(style):
                     continue
-                pos, _ = self.vv.full_line(line)
+                pos = get_line_start(self.view, line)
                 region = sublime.Region(pos, pos)
                 gutter_regions.setdefault(style, []).append(region)
 

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -168,9 +168,6 @@ class Highlight:
 
     def line(self, line, error_type, style=None):
         """Record the given line as having the given error type."""
-        self.overwrite_line(line, error_type, style)
-
-    def overwrite_line(self, line, error_type, style):
         # Errors override warnings on the same line
         if error_type == WARNING:
             if line in self.lines[ERROR]:

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -3,6 +3,7 @@ import re
 import sublime
 
 from . import persist
+from . import style as style_stores
 from .style import HighlightStyleStore
 from .const import PROTECTED_REGIONS_KEY, WARNING, ERROR, WARN_ERR, INBUILT_ICONS
 
@@ -103,12 +104,15 @@ class Highlight:
         """Mark a range of text near a given word."""
         raise Exception('`near` has been removed')
 
-    def add_error(self, line, start, end, error_type, style, **kwargs):
+    def add_error(self, line, start, end, error_type, code, linter, **kwargs):
         line_start = get_line_start(self.view, line)
         region = sublime.Region(line_start + start, line_start + end)
+
+        store = style_stores.get_linter_style_store(linter)
+        style = store.get_style(code, error_type)
+
         self.add_mark(error_type, style, region)
         self.line(line, error_type, style)
-        return region
 
     def add_mark(self, error_type, style, region):
         other_type = ERROR if error_type == WARNING else WARNING

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -90,13 +90,6 @@ class Highlight:
         # Dict[error_type, Dict[lineno, style]]
         self.lines = defaultdict(dict)
 
-        # These are used when highlighting embedded code
-        # The embedded code is linted as if it begins
-        # at (0, 0), but we need to keep track of where
-        # the actual start is within the source.
-        self.line_offset = 0
-        self.char_offset = 0
-
         # Linting runs asynchronously on a snapshot of the code.
         # Marks are added to the code during that asynchronous linting,
         # and the markup code needs to calculate character positions given
@@ -134,17 +127,9 @@ class Highlight:
         Return the start/end character positions for the given line.
 
         This returns *real* character positions (relative to the beginning
-        of self.code) base on the *virtual* line number (adjusted by the
-        self.line_offset).
+        of self.code) base on the *virtual* line number.
         """
-        if line == 0:
-            char_offset = self.char_offset
-        else:
-            char_offset = 0
-
-        line += self.line_offset
-        start = self.newlines[line] + char_offset
-
+        start = self.newlines[line]
         end = self.newlines[min(line + 1, len(self.newlines) - 1)]
 
         return start, end
@@ -183,7 +168,6 @@ class Highlight:
 
     def line(self, line, error_type, style=None):
         """Record the given line as having the given error type."""
-        line += self.line_offset
         self.overwrite_line(line, error_type, style)
 
     def overwrite_line(self, line, error_type, style):

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -257,21 +257,17 @@ class Highlight:
 
         if match:
             start = match.start(1)
-        else:
-            start = -1
-
-        if start != -1:
-            length = self.range(
+            self.range(
                 line,
                 start,
-                len(near),
+                length=len(near),
                 error_type=error_type,
                 word_re=word_re,
                 style=style
             )
-            return start, length
+            return start, len(near)
         else:
-            return 0, 0
+            return 0, 0  # Probably a bug. Why should we fall through here?
 
     def update(self, other):
         """

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -99,9 +99,9 @@ class Highlight:
         """Mark a range of text near a given word."""
         raise Exception('`near` has been removed')
 
-    def add_error(self, line, start, end, error_type, style):
-        a, b = self.vv.full_line(line)
-        region = sublime.Region(a + start, a + end)
+    def add_error(self, line, start, end, error_type, style, **kwargs):
+        line_start, _ = self.vv.full_line(line)
+        region = sublime.Region(line_start + start, line_start + end)
         self.add_mark(error_type, style, region)
         self.line(line, error_type, style)
         return region

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -40,50 +40,6 @@ def clear_view(view):
         view.erase_regions(key)
 
 
-class HighlightSet:
-    """This class maintains a set of Highlight objects and performs bulk operations on them."""
-
-    def __init__(self):
-        self.all = set()
-
-    def add(self, highlight):
-        """Add a Highlight to the set."""
-        self.all.add(highlight)
-
-    def draw(self, view):
-        """
-        Draw all of the Highlight objects in our set.
-
-        Rather than draw each Highlight object individually, the marks in each
-        object are aggregated into a new Highlight object, and that object
-        is then drawn for the given view.
-        """
-        if not self.all:
-            return
-
-        all = Highlight()
-
-        for highlight in self.all:
-            all.update(highlight)
-
-        all.draw(view)
-
-    def line_type(self, line):
-        """Return the primary error type for the given line number."""
-        if not self.all:
-            return None
-
-        line_type = None
-        for highlight in self.all:
-            if line_type == ERROR:
-                continue
-            _line_type = highlight.lines.get(line)
-            if _line_type != WARNING and line_type == WARNING:
-                continue
-            line_type = _line_type
-        return line_type
-
-
 class VirtualView:
     def __init__(self, code=''):
         self._code = code

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -241,15 +241,9 @@ class Highlight:
         The position at which near is found is returned, or zero if there
         is no match.
         """
-        if not near:
-            return
-
         start, end = self.full_line(line)
         text = self.code[start:end]
         near = self.strip_quotes(near)
-
-        if near == '':
-            return 0
 
         # Add \b fences around the text if it begins/ends with a word character
         fence = ['', '']

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -84,6 +84,42 @@ class HighlightSet:
         return line_type
 
 
+class VirtualView:
+    def __init__(self, code=''):
+        self._code = code
+        self._newlines = newlines = [0]
+        last = -1
+
+        while True:
+            last = code.find('\n', last + 1)
+
+            if last == -1:
+                break
+
+            newlines.append(last + 1)
+
+        newlines.append(len(code))
+
+    def full_line(self, line):
+        """Return the start/end character positions for the given line."""
+        start = self._newlines[line]
+        end = self._newlines[min(line + 1, len(self._newlines) - 1)]
+
+        return start, end
+
+    def select_line(self, line):
+        """Return code for the given line."""
+        start, end = self.full_line(line)
+        return self._code[start:end]
+
+    # Actual Sublime API would look like:
+    # def full_line(self, region)
+    # def full_line(self, point) => Region
+    # def substr(self, region)
+    # def text_point(self, row, col) => Point
+    # def rowcol(self, point) => (row, col)
+
+
 class Highlight:
     """This class maintains error marks and knows how to draw them."""
 

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -210,12 +210,13 @@ class Highlight:
             else:
                 length = 1
 
-        pos += start
-        region = sublime.Region(pos, pos + length)
-
+        region = self.get_region_at(pos + start, length)
         self.add_mark(error_type, style, region)
 
         return length
+
+    def get_region_at(self, pos, length):
+        return sublime.Region(pos, pos + length)
 
     def add_mark(self, error_type, style, region):
         other_type = ERROR if error_type == WARNING else WARNING
@@ -262,16 +263,13 @@ class Highlight:
         match = re.search(pattern, text)
 
         if match:
-            start = match.start(1)
-            self.range(
-                line,
-                start,
-                length=len(near),
-                error_type=error_type,
-                word_re=word_re,
-                style=style
-            )
-            return start, len(near)
+            col = match.start(1)
+            length = len(near)
+
+            region = self.get_region_at(col + start, length)
+            self.add_mark(error_type, style, region)
+
+            return col, length
         else:
             return 0, 0  # Probably a bug. Why should we fall through here?
 

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -91,16 +91,6 @@ class Highlight:
         # Dict[error_type, Dict[lineno, style]]
         self.lines = defaultdict(dict)
 
-    @staticmethod
-    def strip_quotes(text):
-        """Return text stripped of enclosing single/double quotes."""
-        first = text[0]
-
-        if first in ('\'', '"') and text[-1] == first:
-            text = text[1:-1]
-
-        return text
-
     def range(self, line, pos, length=-1, near=None, error_type=ERROR, word_re=None, style=None):
         """Mark a range of text."""
         raise Exception('`range` has been removed')

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -205,24 +205,6 @@ class Highlight:
 
         self.lines[error_type][line] = style
 
-    def update(self, other):
-        """
-        Update this object with another Highlight.
-
-        It is assumed that other.code == self.code.
-
-        other's marks and error positions are merged, and this
-        object takes the newlines array from other.
-
-        """
-        for error_type in WARN_ERR:
-            self.marks[error_type].update(other.marks[error_type])
-
-            for line, style in other.lines[error_type].items():
-                self.overwrite_line(line, error_type, style)
-
-        self.newlines = other.newlines
-
     def draw(self, view):
         """
         Draw code and gutter marks in the given view.

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import re
 import sublime
 
 from . import persist
@@ -18,9 +17,6 @@ MARK_STYLES = {
     'stippled_underline': sublime.DRAW_STIPPLED_UNDERLINE | UNDERLINE_FLAGS,
     'none': sublime.HIDDEN
 }
-
-WORD_RE = re.compile(r'^([-\w]+)')
-NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'
 
 
 # Dict[view_id, region_keys]

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -227,48 +227,6 @@ class Highlight:
         self.marks[error_type].setdefault(style, []).append(region)
         return length
 
-    def regex(self, line, regex, error_type=ERROR,
-              line_match=None, word_match=None, word_re=None):
-        """
-        Mark a range of text that matches a regex.
-
-        line, error_type and word_re are the same as in range().
-
-        line_match may be a string pattern or a compiled regex.
-        If provided, it must have a named group called 'match' that
-        determines which part of the source line will be considered
-        for marking.
-
-        word_match may be a string pattern or a compiled regex.
-        If provided, it must have a named group called 'mark' that
-        determines which part of the source line will actually be marked.
-        Multiple portions of the source line may match.
-        """
-        offset = 0
-
-        start, end = self.full_line(line)
-        line_text = self.code[start:end]
-
-        if line_match:
-            match = re.match(line_match, line_text)
-
-            if match:
-                line_text = match.group('match')
-                offset = match.start('match')
-            else:
-                return
-
-        it = re.finditer(regex, line_text)
-        results = [
-            result.span('mark')
-            for result in it
-            if word_match is None or result.group('mark') == word_match
-        ]
-
-        for start, end in results:
-            self.range(line, start + offset, end -
-                       start, error_type=error_type)
-
     def near(self, line, near, error_type=ERROR, word_re=None, style=None):
         """
         Mark a range of text near a given word.

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 import re
 import sublime
 
-from . import persist, util
+from . import persist
 from .style import HighlightStyleStore
 from .const import PROTECTED_REGIONS_KEY, WARNING, ERROR, WARN_ERR, INBUILT_ICONS
 
@@ -89,13 +89,14 @@ class Highlight:
 
     def __init__(self, code=''):
         self.code = code
-        self.marks = util.get_new_dict()
-        self.mark_style = 'outline'
+        # Dict[error_type, Dict[style, List[region]]]
+        self.marks = defaultdict(lambda: defaultdict(list))
         self.style_store = HighlightStyleStore()
 
         # Every line that has a mark is kept in this dict, so we know which
         # lines to mark in the gutter.
-        self.lines = util.get_new_dict()
+        # Dict[error_type, Dict[lineno, style]]
+        self.lines = defaultdict(dict)
 
         # These are used when highlighting embedded code
         # The embedded code is linted as if it begins
@@ -232,7 +233,7 @@ class Highlight:
                         self.marks[other_type][scope].pop(i - i_offset)
                         i_offset += 1
 
-        self.marks[error_type].setdefault(style, []).append(region)
+        self.marks[error_type][style].append(region)
 
     def near(self, line, near, error_type=ERROR, word_re=None, style=None):
         """

--- a/lint/highlight.py
+++ b/lint/highlight.py
@@ -294,15 +294,3 @@ class Highlight:
 
         # persisting region keys for later clearance
         remember_drawn_regions(view, drawn_regions)
-
-    def move_to(self, line, char_offset):
-        """
-        Move the highlight to the given line and character offset.
-
-        The character offset is relative to the start of the line.
-        This method is used to create virtual line numbers
-        and character positions when linting embedded code.
-
-        """
-        self.line_offset = line
-        self.char_offset = char_offset

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1200,7 +1200,7 @@ class Linter(metaclass=LinterMeta):
             "end": end,
             "linter": self.name,
             "error_type": error_type,
-            "code": m.warning or m.error or '',
+            "code": m.error or m.warning or '',
             "msg": m.message,
             "style": style
         }

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -707,7 +707,7 @@ class Linter(metaclass=LinterMeta):
             return
 
         disabled = set()
-        syntax = util.get_syntax(persist.views[vid])
+        syntax = util.get_syntax(view)
 
         all_errors = []
         for linter in linters:

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1184,7 +1184,11 @@ class Linter(metaclass=LinterMeta):
         if not match:
             persist.debug('No match for regex: {}'.format(self.regex.pattern))
         else:
-            match_dict.update(match.groupdict())
+            match_dict.update({
+                k: v
+                for k, v in match.groupdict().items()
+                if k in match_dict
+            })
             match_dict["match"] = match
 
             # normalize line and col if necessary

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -789,7 +789,7 @@ class Linter(metaclass=LinterMeta):
             )
 
         # Merge our result back to the main thread
-        callback(cls.get_view(vid), (all_errors, highlights), hit_time)
+        callback(view, (all_errors, highlights), hit_time)
 
     @classmethod
     def which(cls, cmd):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -783,12 +783,8 @@ class Linter(metaclass=LinterMeta):
 
                 all_errors.extend(errors)
 
-        highlights = highlight.Highlight(view)
-        for error in all_errors:
-            highlights.add_error(**error)
-
         # Merge our result back to the main thread
-        callback(view, (all_errors, highlights), hit_time)
+        callback(view, all_errors, hit_time)
 
     @classmethod
     def which(cls, cmd):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -11,7 +11,6 @@ import sublime
 
 from . import highlight, persist, util
 from .const import STATUS_KEY, WARNING, ERROR
-from .style import LinterStyleStore
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 BASE_CLASSES = ('PythonLinter',)
@@ -367,7 +366,6 @@ class Linter(metaclass=LinterMeta):
     def __init__(self, view, syntax):  # noqa: D107
         self.view = view
         self.syntax = syntax
-        self.style_store = LinterStyleStore(self.name)
 
     @property
     def filename(self):
@@ -1166,9 +1164,6 @@ class Linter(metaclass=LinterMeta):
 
     def process_match(self, m, vv):
         error_type = self.get_error_type(m.error, m.warning)
-        style = self.style_store.get_style(m.error or m.warning, error_type)
-
-        assert style
 
         col = m.col
 
@@ -1200,7 +1195,6 @@ class Linter(metaclass=LinterMeta):
             "error_type": error_type,
             "code": m.error or m.warning or '',
             "msg": m.message,
-            "style": style
         }
 
     def find_good_columns_for_match(self, m, vv):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -676,7 +676,7 @@ class Linter(metaclass=LinterMeta):
         return selectors
 
     @classmethod
-    def lint_view(cls, view, filename, code, hit_time, callback):
+    def lint_view(cls, view, hit_time, callback):
         """
         Lint the given view.
 
@@ -697,8 +697,13 @@ class Linter(metaclass=LinterMeta):
 
         A list of the linters that ran is returned.
         """
+        code = Linter.text(view)
         if not code:
             return
+
+        filename = view.file_name()
+        if filename:
+            filename = os.path.realpath(filename)
 
         vid = view.id()
         linters = persist.view_linters.get(vid)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -757,7 +757,6 @@ class Linter(metaclass=LinterMeta):
             if linter in disabled:
                 continue
 
-            linters.add(linter)
             regions = []
 
             for region in view.find_by_selector(selector):
@@ -794,11 +793,8 @@ class Linter(metaclass=LinterMeta):
                 error['style']
             )
 
-        # Remove disabled linters
-        linters = list(linters - disabled)
-
         # Merge our result back to the main thread
-        callback(cls.get_view(vid), linters, (all_errors, highlights), hit_time)
+        callback(cls.get_view(vid), (all_errors, highlights), hit_time)
 
     def reset(self, code):
         """Reset a linter to work on the given code and filename."""

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -13,6 +13,8 @@ from . import highlight, persist, util
 from .const import STATUS_KEY, WARNING, ERROR
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
+NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'
+WORD_RE = re.compile(r'^([-\w]+)')
 BASE_CLASSES = ('PythonLinter',)
 
 MATCH_DICT = OrderedDict(
@@ -1261,7 +1263,7 @@ class Linter(metaclass=LinterMeta):
                     if near[pos].isalnum() or near[pos] == '_':
                         fence[i] = r'\b'
 
-                pattern = highlight.NEAR_RE_TEMPLATE.format(fence[0], re.escape(near), fence[1])
+                pattern = NEAR_RE_TEMPLATE.format(fence[0], re.escape(near), fence[1])
                 match = re.search(pattern, text)
 
                 if match:
@@ -1287,7 +1289,7 @@ class Linter(metaclass=LinterMeta):
                 return line, col, col + length
             else:
                 text = vv.select_line(m.line)[col:]
-                match = (self.word_re or highlight.WORD_RE).search(text)
+                match = (self.word_re or WORD_RE).search(text)
 
                 length = len(match.group()) if match else 1
                 return line, col, col + length

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1292,7 +1292,7 @@ class Linter(metaclass=LinterMeta):
                 return line, col, col + length
             else:
                 text = vv.select_line(m.line)[col:]
-                match = self.word_re.search(text)
+                match = self.word_re.search(text) if self.word_re else None
 
                 length = len(match.group()) if match else 1
                 return line, col, col + length

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1225,7 +1225,7 @@ class Linter(metaclass=LinterMeta):
         if col is None:
             if m.near:
                 text = vv.select_line(m.line)
-                near = highlight.Highlight.strip_quotes(m.near)
+                near = self.strip_quotes(m.near)
 
                 # Add \b fences around the text if it begins/ends with a word character
                 fence = ['', '']
@@ -1255,7 +1255,7 @@ class Linter(metaclass=LinterMeta):
 
         else:
             if m.near:
-                near = highlight.Highlight.strip_quotes(m.mear)
+                near = self.strip_quotes(m.mear)
                 length = len(near)
                 return col, col + length
             else:
@@ -1264,6 +1264,16 @@ class Linter(metaclass=LinterMeta):
 
                 length = len(match.group()) if match else 1
                 return col, col + length
+
+    @staticmethod
+    def strip_quotes(text):
+        """Return text stripped of enclosing single/double quotes."""
+        first = text[0]
+
+        if first in ('\'', '"') and text[-1] == first:
+            text = text[1:-1]
+
+        return text
 
     def error(self, line, col, message, error_type, style=None, code="", length=None):
         """Add a reference to an error/warning on the given line and column."""

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1203,47 +1203,20 @@ class Linter(metaclass=LinterMeta):
             # Pin the column to the start/end line offsets
             col = max(min(col, (end - start) - 1), 0)
 
-        length = None
-        if col is not None:
-            length = self.highlight.range(
-                m.line,
-                col,
-                near=m.near,
-                error_type=error_type,
-                word_re=self.word_re,
-                style=style
-            )
-        elif m.near:
-            col, length = self.highlight.near(
-                m.line,
-                m.near,
-                error_type=error_type,
-                word_re=self.word_re,
-                style=style
-            )
-        else:
-            if (
-                persist.settings.get('no_column_highlights_line') or
-                not persist.settings.has('gutter_theme')
-            ):
-                pos = -1
-            else:
-                pos = 0
-
-            length = self.highlight.range(
-                m.line,
-                pos,
-                length=0,
-                error_type=error_type,
-                word_re=self.word_re,
-                style=style
-            )
-
-        print('===')
-        print('old: ', m.line, m.col, (m.col or 0) + length)
+        # print('===')
+        # print('old: ', m.line, m.col, (m.col or 0) + length)
         start, end = self.find_good_columns_for_match(m)
-        print('new: ', m.line, start, end)
-        return self.error(m.line, col, m.message, error_type, style=style, code=m.warning or m.error, length=length)
+        # print('new: ', m.line, start, end)
+        self.highlight.add_error(m.line, start, end, error_type, style)
+        return {
+            "line": m.line,
+            "start": start,
+            "end": end,
+            "linter": self.name,
+            "error_type": error_type,
+            "code": m.warning or m.error or '',
+            "msg": m.message
+        }
 
     def find_good_columns_for_match(self, m):
         col = m.col
@@ -1295,18 +1268,7 @@ class Linter(metaclass=LinterMeta):
 
     def error(self, line, col, message, error_type, style=None, code="", length=None):
         """Add a reference to an error/warning on the given line and column."""
-        self.highlight.line(line, error_type, style=style)
-
-        col = col or 0
-        return {
-            "line": line,
-            "start": col,
-            "end": col + (length or 0),
-            "linter": self.name,
-            "error_type": error_type,
-            "code": code,
-            "msg": message
-        }
+        raise Exception('`error` has been removed')
 
     @staticmethod
     def clear_view(view):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -14,7 +14,6 @@ from .const import STATUS_KEY, WARNING, ERROR
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'
-WORD_RE = re.compile(r'^([-\w]+)')
 BASE_CLASSES = ('PythonLinter',)
 
 MATCH_DICT = OrderedDict(
@@ -349,7 +348,7 @@ class Linter(metaclass=LinterMeta):
     # If a linter reports a column position, SublimeLinter highlights the nearest
     # word at that point. You can customize the regex used to highlight words
     # by setting this to a pattern string or a compiled regex.
-    word_re = None
+    word_re = re.compile(r'^([-\w]+)')
 
     # If you want to provide default settings for the linter, set this attribute.
     # If a setting will be passed as an argument to the linter executable,
@@ -1289,7 +1288,7 @@ class Linter(metaclass=LinterMeta):
                 return line, col, col + length
             else:
                 text = vv.select_line(m.line)[col:]
-                match = (self.word_re or WORD_RE).search(text)
+                match = self.word_re.search(text)
 
                 length = len(match.group()) if match else 1
                 return line, col, col + length

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -783,7 +783,7 @@ class Linter(metaclass=LinterMeta):
 
                 all_errors.extend(errors)
 
-        highlights = highlight.Highlight(code)
+        highlights = highlight.Highlight(view)
         for error in all_errors:
             highlights.add_error(**error)
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -743,7 +743,6 @@ class Linter(metaclass=LinterMeta):
                         continue
 
             if syntax not in linter.selectors and '*' not in linter.selectors:
-                linter.reset(code)
                 errors = linter.lint(code, hit_time)
                 if errors is None:
                     return  # ABORT
@@ -760,8 +759,6 @@ class Linter(metaclass=LinterMeta):
 
             for region in view.find_by_selector(selector):
                 regions.append(region)
-
-            linter.reset(code)
 
             for region in regions:
                 line_offset, col_offset = view.rowcol(region.begin())
@@ -793,9 +790,6 @@ class Linter(metaclass=LinterMeta):
 
         # Merge our result back to the main thread
         callback(cls.get_view(vid), (all_errors, highlights), hit_time)
-
-    def reset(self, code):
-        """Reset a linter to work on the given code and filename."""
 
     @classmethod
     def which(cls, cmd):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -785,13 +785,7 @@ class Linter(metaclass=LinterMeta):
 
         highlights = highlight.Highlight(code)
         for error in all_errors:
-            highlights.add_error(
-                error['line'],
-                error['start'],
-                error['end'],
-                error['error_type'],
-                error['style']
-            )
+            highlights.add_error(**error)
 
         # Merge our result back to the main thread
         callback(view, (all_errors, highlights), hit_time)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -337,8 +337,6 @@ class Linter(metaclass=LinterMeta):
     #
     # Internal class storage, do not set
     #
-    errors = None
-    highlight = None
     lint_settings = None
     env = None
     disabled = False

--- a/lint/style.py
+++ b/lint/style.py
@@ -8,6 +8,17 @@ import os
 GUTTER_ICONS = {}
 
 
+linter_style_stores = {}
+
+
+def get_linter_style_store(name):
+    try:
+        return linter_style_stores[name]
+    except KeyError:
+        linter_style_stores[name] = store = LinterStyleStore(name)
+        return store
+
+
 class StyleBaseStore(metaclass=ABCMeta):
     @abstractmethod
     def update(cls):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -202,7 +202,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         util.apply_to_all_views(apply)
 
-    def lint(self, view_id, hit_time=None, callback=None):
+    def lint(self, view_id, hit_time=None):
         """Lint the view with the given id.
 
         This method is called asynchronously by queue.Daemon when a lint
@@ -212,9 +212,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         to the queue. It is used to determine if the view has been modified
         since the lint request was queued. If so, the lint is aborted, since
         another lint request is already in the queue.
-
-        callback is the method to call when the lint is finished. If not
-        provided, it defaults to highlight().
         """
         # If this is not the latest 'hit' we're processing abort early.
         if hit_time and persist.last_hit_times.get(view_id, 0) > hit_time:
@@ -227,10 +224,9 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         filename = view.file_name()
         code = Linter.text(view)
-        callback = callback or self.highlight
 
         events.broadcast(events.BEGIN_LINTING, {'buffer_id': view.buffer_id()})
-        Linter.lint_view(view, filename, code, hit_time, callback)
+        Linter.lint_view(view, filename, code, hit_time, self.highlight)
 
     def highlight(self, view, linters, hit_time):
         """

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -222,11 +222,8 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         if not view:
             return
 
-        filename = view.file_name()
-        code = Linter.text(view)
-
         events.broadcast(events.BEGIN_LINTING, {'buffer_id': view.buffer_id()})
-        Linter.lint_view(view, filename, code, hit_time, self.highlight)
+        Linter.lint_view(view, hit_time, self.highlight)
 
     def highlight(self, view, result, hit_time):
         """

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -225,7 +225,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         events.broadcast(events.BEGIN_LINTING, {'buffer_id': view.buffer_id()})
         Linter.lint_view(view, hit_time, self.highlight)
 
-    def highlight(self, view, result, hit_time):
+    def highlight(self, view, errors, hit_time):
         """
         Highlight any errors found during a lint of the given view.
 
@@ -241,8 +241,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         if hit_time and persist.last_hit_times.get(vid, 0) > hit_time:
             return
 
-        errors, highlights = result
-
         errors_by_line = defaultdict(lambda: defaultdict(list))
         for error in errors:
             line = error['line']
@@ -254,6 +252,10 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
             persist.errors[vid] = errors_by_line
 
         events.broadcast(events.FINISHED_LINTING, {'buffer_id': view.buffer_id()})
+
+        highlights = highlight.Highlight(view)
+        for error in errors:
+            highlights.add_error(**error)
 
         for view in all_views_into_buffer(view):
             highlight.clear_view(view)

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -228,18 +228,11 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         events.broadcast(events.BEGIN_LINTING, {'buffer_id': view.buffer_id()})
         Linter.lint_view(view, filename, code, hit_time, self.highlight)
 
-    def highlight(self, view, linters, result, hit_time):
+    def highlight(self, view, result, hit_time):
         """
         Highlight any errors found during a lint of the given view.
 
         This method is called by Linter.lint_view after linting is finished.
-
-        linters is a list of the linters that ran. hit_time has the same meaning
-        as in lint(), and if the view was modified since the lint request was
-        made, this method aborts drawing marks.
-
-        If the view has not been modified since hit_time, all of the marks and
-        errors from the list of linters are aggregated and drawn, and the status is updated.
         """
         if not view:
             return


### PR DESCRIPTION
This is basically a refactor to make our main `Linter.lint_view` idempotent and reduce the mutable data structure. After this it should be basically okay, to run `lint_view` concurrently with the same view. (So the `queue.running` locks could go away.)

- Removed `self.code`, `self.highlight`, and `self.errors`
- Really simplify Highlight
- Bc we use a flat data structure, merging the results, is a simple list.extend

TODO/MAYBES

- [x] Name bike-shedding and comments
- [x] Move highlights creation up out of Linter.lint_view
- [x] Change type `highlight.Highlight(code)` ->`Highlight(view)` - As long as we don't plan to somehow keep a *virtual view* up-to-date in the sense that we update/invalidate error lines and columns while the user is typing, we can just use a real view to compute region boundaries
- [x] Remove `LinterStyleStore` from linter bc it belongs to highlight. Do we use the *style* somewhere else? 
- [x] ~~Maybe simplify `lint_view` if we find it's too long and unreadable~~ Implemented, but goes into another PR
- [x] ~~Use the new raw errors list, linting now produces. For compatibility, I convert the flat list to a struct grouped by line and error_type. But it is really trivial to get e.g. the `we_count` from the flat list.~~ Out of scope. But I used it for the goto commands, yet to PR
- [x] ~~Concurrently run the linters inside `lint_view`. E.g. run `flake8`and `mypy` in parallel~~ Implemented but becomes a new PR
- [x] ~~Use one instance per linter, not one per view~~ Out of scope, we have a `self.view`, which is used by `get_view_settings()` which is used in user-land
  
  
  