### PR TITLE
Remove newline characters in panel view

### DIFF
--- a/panel/panel.py
+++ b/panel/panel.py
@@ -112,8 +112,10 @@ def format_header(f_path):
 def format_row(lineno, error_type, dic):
     lineno = int(lineno) + 1
     start = dic['start'] + 1
-    tmpl = " {LINENO:>5}:{START:<4} {ERR_TYPE:7} {linter:>12}: {code:12} {msg}"
-    return tmpl.format(LINENO=lineno, START=start, ERR_TYPE=error_type, **dic)
+    msg = dic['msg'].rstrip()
+    tmpl = " {LINENO:>5}:{START:<4} {ERR_TYPE:7} {linter:>12}: {code:12} {MSG}"
+    return tmpl.format(
+        LINENO=lineno, START=start, ERR_TYPE=error_type, MSG=msg, **dic)
 
 
 def fill_panel(window, types=None, codes=None, linter=None, update=False):


### PR DESCRIPTION
I don't find the issue right now, but it's about 

![image](https://user-images.githubusercontent.com/8558/34797378-7ea7c824-f658-11e7-9a17-ea27bf9fe7d0.png)

After:

![image](https://user-images.githubusercontent.com/8558/34797436-a9946b82-f658-11e7-8f6b-a0096da717dd.png)

This is completely the KISS approach.