### PR TITLE
Blacklist filtering for panel 

### DIFF
--- a/keymaps/Default (Linux).sublime-keymap
+++ b/keymaps/Default (Linux).sublime-keymap
@@ -7,12 +7,15 @@
     { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle" },
     // To display filtered results in the panel add arguments:
     // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
+    // whitelist via:
     //         "types": ["error"],
     //         "codes": [],
-    //         "linter": []
+    //         "linter": [],
+    // blacklist via:
+    //          "exclude_codes": [],
+    //          "exclude_linter": []
     //     }
     // }
-
 
     // You can also trigger the line report with a keybinding:
     // { "keys": ["ctrl+k", "r"], "command": "sublime_linter_line_report" }

--- a/keymaps/Default (Linux).sublime-keymap
+++ b/keymaps/Default (Linux).sublime-keymap
@@ -8,7 +8,7 @@
     // To display filtered results in the panel add arguments:
     // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
     // whitelist via:
-    //         "types": ["error"],
+    //         "types": ["error", "warning"],
     //         "codes": [],
     //         "linter": [],
     // blacklist via:
@@ -16,6 +16,7 @@
     //          "exclude_linter": []
     //     }
     // }
+
 
     // You can also trigger the line report with a keybinding:
     // { "keys": ["ctrl+k", "r"], "command": "sublime_linter_line_report" }

--- a/keymaps/Default (OSX).sublime-keymap
+++ b/keymaps/Default (OSX).sublime-keymap
@@ -6,14 +6,9 @@
     // Show all errors
     { "keys": ["ctrl+super+a"], "command": "sublime_linter_panel_toggle" },
     // To display filtered results in the panel add arguments:
-<<<<<<< HEAD
-    // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
-    // whitelist via:
-    //         "types": ["error"],
-=======
     // { "keys": ["ctrl+super+a"], "command": "sublime_linter_panel_toggle", "args": {
+    // whitelist via:
     //         "types": ["error", "warning"],
->>>>>>> panel_select
     //         "codes": [],
     //         "linter": [],
     // blacklist via:

--- a/keymaps/Default (OSX).sublime-keymap
+++ b/keymaps/Default (OSX).sublime-keymap
@@ -6,10 +6,19 @@
     // Show all errors
     { "keys": ["ctrl+super+a"], "command": "sublime_linter_panel_toggle" },
     // To display filtered results in the panel add arguments:
+<<<<<<< HEAD
+    // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
+    // whitelist via:
+    //         "types": ["error"],
+=======
     // { "keys": ["ctrl+super+a"], "command": "sublime_linter_panel_toggle", "args": {
     //         "types": ["error", "warning"],
+>>>>>>> panel_select
     //         "codes": [],
-    //         "linter": []
+    //         "linter": [],
+    // blacklist via:
+    //          "exclude_codes": [],
+    //          "exclude_linter": []
     //     }
     // }
 

--- a/keymaps/Default (Windows).sublime-keymap
+++ b/keymaps/Default (Windows).sublime-keymap
@@ -7,9 +7,13 @@
     { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle" },
     // To display filtered results in the panel add arguments:
     // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
+    // whitelist via:
     //         "types": ["error"],
     //         "codes": [],
-    //         "linter": []
+    //         "linter": [],
+    // blacklist via:
+    //          "exclude_codes": [],
+    //          "exclude_linter": []
     //     }
     // }
 

--- a/keymaps/Default (Windows).sublime-keymap
+++ b/keymaps/Default (Windows).sublime-keymap
@@ -8,7 +8,7 @@
     // To display filtered results in the panel add arguments:
     // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
     // whitelist via:
-    //         "types": ["error"],
+    //         "types": ["error", "warning"],
     //         "codes": [],
     //         "linter": [],
     // blacklist via:


### PR DESCRIPTION
This PR replaces #754.
It extends the options for filtering panel output with blacklisting of `codes` and `linters`.

Instruction to make custom command with provided args for filtering:
```
    // Show all errors
    { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle" },
    // To display filtered results in the panel add arguments:
    // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
    // whitelist via:
    //         "types": ["error"],
    //         "codes": [],
    //         "linter": [],
    // blacklist via:
    //          "exclude_codes": [],
    //          "exclude_linter": []
    //     }
    // }
```