### PR TITLE
Scope based syntax detection

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -118,17 +118,5 @@
                 "error"
             ]
         }
-    ],
-
-    // Maps variant syntaxes to the syntax that you have a linter for.
-    "syntax_map": {
-        "html (django)": "html",
-        "html (rails)": "html",
-        "html 5": "html",
-        "javascript (babel)": "javascript",
-        "magicpython": "python",
-        "php": "html",
-        "python django": "python",
-        "pythonimproved": "python"
-    }
+    ]
 }

--- a/resources/syntax_map.json
+++ b/resources/syntax_map.json
@@ -1,0 +1,7 @@
+{
+    "coffeescript": ["source.coffee"],
+    "javascript": ["source.js"],
+    "markdown": [],
+    "pug": ["text.jade", "source.pyjade"],
+    "typescript": ["source.ts"]
+}


### PR DESCRIPTION
### Objective
As of now SL, uses the name of a syntax file for detecting a syntax.
That method lacks flexibility and also necessitates long syntax maps.
See: #740 #691 

This PR implements a new syntax selection using the base scope of a view instead. (Replaces #753)
The regarding steps are:

### Algorithm
0. A syntax map to reference internally usable aliases to a scope selectors.
Like ```"javascript": ["source.js"]```
1. The main scope of a view is retrieved. Examples:
  **a)** `source.python`
  **b)** `source.json.sublime-xxx`
  **c)** `text.html.markdown`
2. The base scope is iteratively split on `.` from right to left. If a resulting tail fragment is identicaly to an alias in the syntax map it is returned. (Like `markdown` from **c)**)
3. If 2. has not been successful in returning a syntax, now a function build around [score_selector](https://www.sublimetext.com/docs/3/api_reference.html) is employed, which tries to find the syntax alias owning the highest scoring scope selector.
4. As a final resort the last tail determined in 2) is returned. Like `python` from `source.python`.

Main parts of the code are derived from https://github.com/Snazzah/SublimeDiscordRP/pull/15

#### Limitations
*I like however to stress that the PR at hand represents my own interpretation of that linked code.
My understanding of Sublime's syntax system is limited at this point. Hence, I invite constructive reviews and critique.*

For example my hypothesis is that most base scopes look like `source.usable_alias` like **a)**. Hence
step 4) will give us `usable_alias` as the syntax.  Thereby we do not need to explicitly put `python` into our syntax map. *That can make the map shorter as we only need to put in entries for required cases.*
I could be wrong about this though. Maybe we need a much larger syntax map.

### TODO:
- test and review
- extension of the syntax map if required