### PR TITLE
Refactor view settings

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -477,9 +477,8 @@ class Linter(metaclass=LinterMeta):
                 return value
 
         window = self.view.window()
-        variables = os.environ.copy()
-        if window:
-            variables.update(window.extract_variables())
+        variables = ChainMap(
+            {}, window.extract_variables() if window else {}, os.environ)
 
         filename = self.view.file_name()
         project_folder = self._guess_project_path(window, filename)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -476,11 +476,13 @@ class Linter(metaclass=LinterMeta):
 
 
         """
-        def recursive_replace_value(expressions, value):
+        def recursive_replace(expressions, value):
             if isinstance(value, dict):
-                value = recursive_replace(expressions, value, nested=True)
+                value = {key: recursive_replace(expressions, val)
+                         for key, val in value.items()}
             elif isinstance(value, list):
-                value = [recursive_replace_value(expressions, item) for item in value]
+                value = [recursive_replace(expressions, item)
+                         for item in value]
             elif isinstance(value, str):
                 for exp in expressions:
                     if isinstance(exp['value'], str):
@@ -489,12 +491,6 @@ class Linter(metaclass=LinterMeta):
                         value = exp['token'].sub(exp['value'], value)
 
             return value
-
-        def recursive_replace(expressions, mutable_input, nested=False):
-            for key, value in mutable_input.items():
-                mutable_input[key] = recursive_replace_value(expressions, value)
-            if nested:
-                return mutable_input
 
         # Expressions are evaluated in list order.
         expressions = []

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -459,29 +459,29 @@ class Linter(metaclass=LinterMeta):
         See https://docs.python.org/3/library/os.path.html#os.path.expandvars
 
         """
-        def recursive_replace(vars, value):
+        def recursive_replace(variables, value):
             if isinstance(value, Mapping):
-                return {key: recursive_replace(vars, val)
+                return {key: recursive_replace(variables, val)
                         for key, val in value.items()}
             elif isinstance(value, list):
-                return [recursive_replace(vars, item)
+                return [recursive_replace(variables, item)
                         for item in value]
             elif isinstance(value, str):
                 value = os.path.expanduser(value)
                 value = os.path.expandvars(value)
-                value = sublime.expand_variables(value, vars)
+                value = sublime.expand_variables(value, variables)
                 return value
 
         window = self.view.window()
-        vars = window.extract_variables() if window else {}
+        variables = window.extract_variables() if window else {}
 
         filename = self.view.file_name()
         project_folder = self._guess_project_path(window, filename)
         if project_folder:
-            vars['folder'] = project_folder
+            variables['folder'] = project_folder
 
-        persist.debug('Available variables: {}'.format(vars))
-        return recursive_replace(vars, settings)
+        persist.debug('Available variables: {}'.format(variables))
+        return recursive_replace(variables, settings)
 
     @staticmethod
     def _guess_project_path(window, filename):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -550,19 +550,9 @@ class Linter(metaclass=LinterMeta):
 
     @staticmethod
     def _guess_project_path(window, filename):
-        data = window.project_data()
-        if not data:
-            return
-
-        folders = data.get('folders')
+        folders = window.folders()
         if not folders:
             return
-
-        folders = [folder['path'] for folder in folders]
-
-        if folders[0] == '.':
-            window_vars = window.extract_variables()
-            folders[0] = window_vars['folder']
 
         if not filename:
             return folders[0]

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1,4 +1,4 @@
-from collections import namedtuple, OrderedDict, ChainMap, Mapping
+from collections import namedtuple, OrderedDict, ChainMap, Mapping, Sequence
 from distutils.versionpredicate import VersionPredicate
 from functools import lru_cache
 from numbers import Number
@@ -462,21 +462,19 @@ class Linter(metaclass=LinterMeta):
 
         Additionally, we expand the `~` home prefix using `os.path.expanduser`.
         See: https://docs.python.org/3/library/os.path.html#os.path.expanduser
-
-        And environment variables using `os.path.expandvars`.
-        See https://docs.python.org/3/library/os.path.html#os.path.expandvars
-
         """
         def recursive_replace(variables, value):
             if isinstance(value, Mapping):
                 return {key: recursive_replace(variables, val)
                         for key, val in value.items()}
-            elif isinstance(value, list):
+            elif isinstance(value, Sequence):
                 return [recursive_replace(variables, item)
                         for item in value]
             elif isinstance(value, str):
                 value = sublime.expand_variables(value, variables)
                 value = os.path.expanduser(value)
+                return value
+            else:
                 return value
 
         window = self.view.window()

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -503,11 +503,11 @@ class Linter(metaclass=LinterMeta):
                 'value': filename.replace('\\', '/')
             })
 
-        directory = os.path.dirname(filename) if filename else None
-        if directory:
+        file_path = os.path.dirname(filename) if filename else None
+        if file_path:
             expressions.append({
-                'token': '${directory}',
-                'value': directory.replace('\\', '/')
+                'token': '${file_path}',
+                'value': file_path.replace('\\', '/')
             })
 
         if window:
@@ -519,7 +519,7 @@ class Linter(metaclass=LinterMeta):
                 })
 
             window_vars = window.extract_variables()
-            root = window_vars.get('folder', None) or directory
+            root = window_vars.get('folder', None) or file_path
             if root:
                 expressions.append({
                     'token': '${root}',

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -464,16 +464,15 @@ class Linter(metaclass=LinterMeta):
         See: https://docs.python.org/3/library/os.path.html#os.path.expanduser
         """
         def recursive_replace(variables, value):
-            if isinstance(value, Mapping):
+            if isinstance(value, str):
+                value = sublime.expand_variables(value, variables)
+                return os.path.expanduser(value)
+            elif isinstance(value, Mapping):
                 return {key: recursive_replace(variables, val)
                         for key, val in value.items()}
             elif isinstance(value, Sequence):
                 return [recursive_replace(variables, item)
                         for item in value]
-            elif isinstance(value, str):
-                value = sublime.expand_variables(value, variables)
-                value = os.path.expanduser(value)
-                return value
             else:
                 return value
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -520,6 +520,13 @@ class Linter(metaclass=LinterMeta):
                 'value': window_vars.get('folder', None) or directory
             })
 
+            project_base_name = window_vars.get('project_base_name', None)
+            if project_base_name:
+                expressions.append({
+                    'token': '${project_name}',
+                    'value': project_base_name
+                })
+
         expressions.append({
             'token': '${home}',
             'value': os.path.expanduser('~').rstrip(os.sep).rstrip(os.altsep).replace('\\', '/') or 'HOME NOT SET'

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -485,8 +485,15 @@ class Linter(metaclass=LinterMeta):
         if project_folder:
             variables['folder'] = project_folder
 
-        persist.debug('Available variables: {}'.format(variables))
+        if persist.debug_mode():
+            import pprint
+            self._debug_print_available_variables(pprint.pformat(dict(variables), indent=2))
         return recursive_replace(variables, settings)
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _debug_print_available_variables(variables):
+        persist.debug('Available variables: {}'.format(variables))
 
     @staticmethod
     def _guess_project_path(window, filename):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -519,13 +519,6 @@ class Linter(metaclass=LinterMeta):
                 })
 
             window_vars = window.extract_variables()
-            root = window_vars.get('folder', None) or file_path
-            if root:
-                expressions.append({
-                    'token': '${root}',
-                    'value': root.replace('\\', '/')
-                })
-
             project_base_name = window_vars.get('project_base_name', None)
             if project_base_name:
                 expressions.append({

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -495,9 +495,22 @@ class Linter(metaclass=LinterMeta):
         # Expressions are evaluated in list order.
         expressions = []
         window = self.view.window()
-        if window:
-            filename = self.view.file_name()
+        filename = self.view.file_name()
 
+        if filename:
+            expressions.append({
+                'token': '${file}',
+                'value': filename.replace('\\', '/')
+            })
+
+        directory = os.path.dirname(filename) if filename else None
+        if directory:
+            expressions.append({
+                'token': '${directory}',
+                'value': directory.replace('\\', '/')
+            })
+
+        if window:
             project = self._guess_project_path(window, filename)
             if project:
                 expressions.append({
@@ -505,20 +518,13 @@ class Linter(metaclass=LinterMeta):
                     'value': project.replace('\\', '/')
                 })
 
-            directory = (
-                os.path.dirname(filename).replace('\\', '/') if
-                filename else "FILE NOT ON DISK")
-
-            expressions.append({
-                'token': '${directory}',
-                'value': directory
-            })
-
             window_vars = window.extract_variables()
-            expressions.append({
-                'token': '${root}',
-                'value': window_vars.get('folder', None) or directory
-            })
+            root = window_vars.get('folder', None) or directory
+            if root:
+                expressions.append({
+                    'token': '${root}',
+                    'value': root.replace('\\', '/')
+                })
 
             project_base_name = window_vars.get('project_base_name', None)
             if project_base_name:
@@ -527,10 +533,12 @@ class Linter(metaclass=LinterMeta):
                     'value': project_base_name
                 })
 
-        expressions.append({
-            'token': '${home}',
-            'value': os.path.expanduser('~').rstrip(os.sep).rstrip(os.altsep).replace('\\', '/') or 'HOME NOT SET'
-        })
+        home = os.path.expanduser('~').rstrip(os.sep).rstrip(os.altsep)
+        if home:
+            expressions.append({
+                'token': '${home}',
+                'value': home.replace('\\', '/')
+            })
 
         expressions.append({
             'token': '${sublime}',


### PR DESCRIPTION
Confirm to the standards.

**** BREAKING ****

We start with all Sublime variables, but enhance the ${folder} with a better
guess. We use standard python to expand '~'. We also expand all environment 
variables.

- ${folder} instead of ${project}
- ~ instead of ${home}
- ${GEM_HOME} instead of ${env:GEM_HOME}

We use `sublime.expand_variables` under the hood, so we get 'OR' functionality
for free. E.g. `${XDG_CONFIG_HOME:~.config}/blub` will just work. 

Note that our current wanted default working directory (specced in #818) can be expressed just 
like `${folder:$file_path}`. T.i. try the *folder*, fallback to `os.path.dirname(filename)`.

Fixes #824 

Notable: Removed `cls.lint_settings`