### PR TITLE
Use tempdir as working dir fallback

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -7,6 +7,7 @@ import os
 import re
 import shlex
 import sublime
+import tempfile
 
 from . import highlight, persist, util
 from .const import STATUS_KEY, WARNING, ERROR
@@ -955,11 +956,10 @@ class Linter(metaclass=LinterMeta):
         if chdir and os.path.isdir(chdir):
             persist.debug('chdir has been set to: {0}'.format(chdir))
             return chdir
+        elif self.filename:
+            return os.path.dirname(self.filename)
         else:
-            if self.filename:
-                return os.path.dirname(self.filename)
-            else:
-                return os.path.realpath('.')
+            return tempfile.gettempdir()
 
     def get_error_type(self, error, warning):  # noqa:D102
         if error:


### PR DESCRIPTION
Just expanding the "current dir" is a) unnecessary, since it would just be the current directory anyway, and b) unpredictable. If the working dir cannot be specified in any other way, i.e. for unsaved views, we fall back to the tempdir instead.

This is just the "ultimate fallback" version. Ideally, the project folder should be attempted first, but my proposal in #818 would require #825 to be merged first.