### PR TITLE
Remove now redundant setting expansions in PythonLinter

### DIFF
--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -59,15 +59,8 @@ class PythonLinter(linter.Linter):
         settings = self.get_view_settings()
 
         # If the user explicitly set an executable, it takes precedence.
-        # We expand environment variables. E.g. a user could have a project
-        # structure where a virtual environment is always located within
-        # the project structure. She could then simply specify
-        # `${project_path}/venv/bin/flake8`. Note that setting `python`
-        # to a path will have a similar effect.
         executable = settings.get('executable', '')
         if executable:
-            executable = expand_variables(executable)
-
             persist.debug(
                 "{}: wanted executable is '{}'".format(self.name, executable)
             )
@@ -84,15 +77,7 @@ class PythonLinter(linter.Linter):
 
         # `python` can be number or a string. If it is a string it should
         # point to a python environment, NOT a python binary.
-        # We expand environment variables. E.g. a user could have a project
-        # structure where virtual envs are located always like such
-        # `some/where/venvs/${project_base_name}` or she has the venv
-        # contained in the project dir `${project_path}/venv`. She then
-        # could edit the global settings once and can be sure that always the
-        # right linter installed in the virtual environment gets executed.
         python = settings.get('python', None)
-        if isinstance(python, str):
-            python = expand_variables(python)
 
         persist.debug(
             "{}: wanted python is '{}'".format(self.name, python)
@@ -204,27 +189,6 @@ def find_script_by_python_env(python_env_path, script):
         return full_path
 
     return None
-
-
-def expand_variables(string):
-    """Expand environment, user, and sublime text variables in the given string.
-
-    User variables:
-    https://docs.python.org/3/library/os.path.html#os.path.expanduser
-
-    Environment variables:
-    See https://docs.python.org/3/library/os.path.html#os.path.expandvars
-
-    Sublime Text variables:
-    e.g. "packages", "platform", "file", "file_path", file_name",
-    "file_base_name", "file_extension, "folder", "project", project_path",
-    "project_name", "project_base_name, "project_extension".
-    """
-    string = os.path.expanduser(string)
-    string = os.path.expandvars(string)
-    window = sublime.active_window()
-    env = window.extract_variables()
-    return sublime.expand_variables(string, env)
 
 
 def get_project_path():


### PR DESCRIPTION
Since #825 this functionality moved to core.

Fixes #750 