### PR TITLE
Fix: Abort lint if no executable can be found.

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -874,16 +874,14 @@ class Linter(metaclass=LinterMeta):
             return self.default_type
 
     def lint(self, code, hit_time):
-        """
-        Perform the lint, retrieve the results, and add marks to the view.
+        """Perform the lint, retrieve the results, and add marks to the view.
 
         The flow of control is as follows:
 
-        - Get the command line. If it is an empty string, bail.
+        - Get the command line.
         - Run the linter.
         - If the view has been modified since the original hit_time, stop.
         - Parse the linter output with the regex.
-        - Highlight warnings and errors.
         """
         if self.disabled:
             return []

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -603,7 +603,7 @@ class Linter(metaclass=LinterMeta):
         override this method.
 
         Note that this method will be called statically as well as per
-        instance. So you can rely on `get_view_settings` to be available.
+        instance. So you *can't* rely on `get_view_settings` to be available.
 
         `context_sensitive_executable_path` is guaranteed to be called per
         instance and might be the better override point.


### PR DESCRIPTION
Fixes #836

Fixed two comments. 