### PR TITLE
[docs] Change chdir example value to the default

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -39,18 +39,21 @@ The value must be a string, corresponding to a valid directory path.
 .. code-block:: json
 
     {
-        "chdir": "${project}"
+        "chdir": "${folder:$file_path}"
     }
 
-With the above example, the linter will get invoked from the ``${project}`` directory (see :ref:`Settings Expansion <settings-expansion>` for more info on using variables).
+With the above example,
+the linter will get invoked from the ``${folder}`` directory
+or the file's directory if it is not contained within a project folder
+(see :ref:`Settings Expansion <settings-expansion>` for more info on using variables).
 
 .. note::
 
      If the value of ``chdir`` is unspecified (or inaccessible), then:
 
-     - If linting an unsaved file, the directory is unchanged
-
      - If linting a saved file, the directory is set to that of the linted file
+
+     - If linting an unsaved file, the directory is unchanged
 
 
 excludes


### PR DESCRIPTION
`${project}` is most likely not what users want, so we better not suggest to use that.