### PR TITLE
Implement `executable` setting in core Linter

### DIFF
--- a/lint/base_linter/composer_linter.py
+++ b/lint/base_linter/composer_linter.py
@@ -43,6 +43,12 @@ class ComposerLinter(linter.Linter):
 
         Return a tuple of (have_path, path).
         """
+        # The default implementation will look for a user defined `executable`
+        # setting.
+        success, executable = super().context_sensitive_executable_path(cmd)
+        if success:
+            return success, executable
+
         local_cmd = None
         global_cmd = util.which(cmd[0])
 

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -88,6 +88,12 @@ class NodeLinter(linter.Linter):
         looking in the global system node_modules folder. return
         a tuple of (have_path, path).
         """
+        # The default implementation will look for a user defined `executable`
+        # setting.
+        success, executable = super().context_sensitive_executable_path(cmd)
+        if success:
+            return success, executable
+
         local_cmd = None
         global_cmd = util.which(cmd[0])
 

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -56,24 +56,13 @@ class PythonLinter(linter.Linter):
 
     def context_sensitive_executable_path(self, cmd):
         """Try to find an executable for a given cmd."""
+        # The default implementation will look for a user defined `executable`
+        # setting.
+        success, executable = super().context_sensitive_executable_path(cmd)
+        if success:
+            return success, executable
+
         settings = self.get_view_settings()
-
-        # If the user explicitly set an executable, it takes precedence.
-        executable = settings.get('executable', '')
-        if executable:
-            persist.debug(
-                "{}: wanted executable is '{}'".format(self.name, executable)
-            )
-
-            if util.can_exec(executable):
-                return True, executable
-
-            persist.printf(
-                "ERROR: {} deactivated, cannot locate '{}' "
-                .format(self.name, executable)
-            )
-            # no fallback, the user specified something, so we err
-            return True, None
 
         # `python` can be number or a string. If it is a string it should
         # point to a python environment, NOT a python binary.

--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -61,6 +61,12 @@ class RubyLinter(linter.Linter):
 
         Otherwise [ruby] or [gem] will be returned.
         """
+        # The default implementation will look for a user defined `executable`
+        # setting.
+        success, executable = super().context_sensitive_executable_path(cmd)
+        if success:
+            return success, executable
+
         ruby = None
         rbenv = util.which('rbenv')
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -678,17 +678,38 @@ class Linter(metaclass=LinterMeta):
         return self.insert_args(cmd)
 
     def context_sensitive_executable_path(self, cmd):
-        """
-        Calculate the context-sensitive executable path, return a tuple of (have_path, path).
+        """Calculate the context-sensitive executable path.
 
-        Subclasses may override this to return a special path.
+        Subclasses may override this to return a special path. The default
+        implementation looks for a setting `executable` and if set will use
+        that.
 
         Return (True, '<path>') if you can resolve the executable given at cmd[0]
         Return (True, None) if you want to skip the linter
         Return (False, None) if you want to kick in the default implementation
             of SublimeLinter
 
+        Notable: `<path>` can be a list/tuple or str
+
         """
+        settings = self.get_view_settings()
+        executable = settings.get('executable', None)
+        if executable:
+            persist.debug(
+                "{}: wanted executable is '{}'".format(self.name, executable)
+            )
+
+            # If `executable` is an iterable, we can only assume it will work.
+            if isinstance(executable, str) and not util.can_exec(executable):
+                persist.printf(
+                    "ERROR: {} deactivated, cannot locate '{}' "
+                    .format(self.name, executable)
+                )
+                # no fallback, the user specified something, so we err
+                return True, None
+
+            return True, executable
+
         return False, None
 
     def insert_args(self, cmd):


### PR DESCRIPTION
The executable setting will be recognized by *all* linters. It is implemented in `context_sensitive_executable_path` so the behavior is pluggable. However, it also means that plugins which override that method must be patched to see the new functionality.
    
Fixes #781