### PR TITLE
Hotfix: `util.tmpdir` should not use `os.chdir` on its own

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -475,8 +475,7 @@ def tmpdir(cmd, files, filename, code, output_stream=STREAM_STDOUT, env=None):
             else:
                 shutil.copyfile(f, target)
 
-        os.chdir(d)
-        out = communicate(cmd, output_stream=output_stream, env=env)
+        out = communicate(cmd, output_stream=output_stream, env=env, cwd=d)
 
         if out:
             # filter results from build to just this filename


### PR DESCRIPTION
Funfact: it didn't even try to switch back to the original dir. 