### PR TITLE
Rename setting `chdir` to `working_dir`

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -34,8 +34,7 @@ working_dir
 -----
 This setting specifies the linter working directory.
 
-The value must be a string, corresponding to a valid directory path. Variable
-substitutions are supported.
+The value must be a string, corresponding to a valid directory path.
 
 .. code-block:: json
 

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -30,16 +30,17 @@ The value may be a string or an array. If it is a string, it will be parsed as i
 The default value is an empty array.
 
 
-chdir
+working_dir
 -----
 This setting specifies the linter working directory.
 
-The value must be a string, corresponding to a valid directory path.
+The value must be a string, corresponding to a valid directory path. Variable
+substitutions are supported.
 
 .. code-block:: json
 
     {
-        "chdir": "${folder:$file_path}"
+        "working_dir": "${folder:$file_path}"
     }
 
 With the above example,
@@ -49,11 +50,7 @@ or the file's directory if it is not contained within a project folder
 
 .. note::
 
-     If the value of ``chdir`` is unspecified (or inaccessible), then:
-
-     - If linting a saved file, the directory is set to that of the linted file
-
-     - If linting an unsaved file, the directory is unchanged
+     The above example is the default.
 
 
 excludes

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -111,7 +111,7 @@ class PythonLinter(linter.Linter):
 
         # If we're here the user didn't specify anything. This is the default
         # experience. So we kick in some 'magic'
-        chdir = self.get_chdir(settings)
+        chdir = self.get_working_dir(settings)
         executable = ask_pipenv(cmd[0], chdir)
         if executable:
             persist.debug(

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -111,8 +111,8 @@ class PythonLinter(linter.Linter):
 
         # If we're here the user didn't specify anything. This is the default
         # experience. So we kick in some 'magic'
-        chdir = self.get_working_dir(settings)
-        executable = ask_pipenv(cmd[0], chdir)
+        cwd = self.get_working_dir(settings)
+        executable = ask_pipenv(cmd[0], cwd)
         if executable:
             persist.debug(
                 "{}: Using {} according to 'pipenv'"
@@ -192,7 +192,7 @@ def get_project_path():
         return folders[0]['path']  # ?
 
 
-def ask_pipenv(linter_name, chdir):
+def ask_pipenv(linter_name, cwd):
     """Ask pipenv for a virtual environment and maybe resolve the linter."""
     # Some pre-checks bc `pipenv` is super slow
     project_path = get_project_path()
@@ -206,13 +206,13 @@ def ask_pipenv(linter_name, chdir):
     # Defer the real work to another function we can cache.
     # ATTENTION: If the user has a Pipfile, but did not (yet) installed the
     # environment, we will cache a wrong result here.
-    return _ask_pipenv(linter_name, chdir)
+    return _ask_pipenv(linter_name, cwd)
 
 
 @lru_cache(maxsize=None)
-def _ask_pipenv(linter_name, chdir):
+def _ask_pipenv(linter_name, cwd):
     cmd = ['pipenv', '--venv']
-    venv = _communicate(cmd, cwd=chdir).strip().split('\n')[-1]
+    venv = _communicate(cmd, cwd=cwd).strip().split('\n')[-1]
 
     if not venv:
         return

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -876,15 +876,15 @@ class Linter(metaclass=LinterMeta):
 
     def get_working_dir(self, settings):
         """Return the working dir for this lint."""
-        chdir = settings.get('chdir', None)
+        cwd = settings.get('working_dir', None)
 
-        if chdir:
-            if os.path.isdir(chdir):
-                return chdir
+        if cwd:
+            if os.path.isdir(cwd):
+                return cwd
             else:
                 persist.printf(
                     "{}: WARNING: wanted working_dir '{}' is not a dir"
-                    "".format(self.name, chdir)
+                    "".format(self.name, cwd)
                 )
                 return None
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -874,7 +874,7 @@ class Linter(metaclass=LinterMeta):
 
                     options[name] = value
 
-    def get_chdir(self, settings):
+    def get_working_dir(self, settings):
         """Return the working dir for this lint."""
         chdir = settings.get('chdir', None)
 
@@ -1310,7 +1310,7 @@ class Linter(metaclass=LinterMeta):
             cmd.append(self.filename)
 
         settings = self.get_view_settings()
-        cwd = self.get_chdir(settings)
+        cwd = self.get_working_dir(settings)
 
         if persist.debug_mode():
             util.printf('{}: {} {}'.format(
@@ -1331,7 +1331,7 @@ class Linter(metaclass=LinterMeta):
     def tmpfile(self, cmd, code, suffix=''):
         """Run an external executable using a temp file to pass code and return its output."""
         settings = self.get_view_settings()
-        cwd = self.get_chdir(settings)
+        cwd = self.get_working_dir(settings)
 
         if persist.debug_mode():
             util.printf('{}: {} {}'.format(

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -883,7 +883,7 @@ class Linter(metaclass=LinterMeta):
                 return cwd
             else:
                 persist.printf(
-                    "{}: WARNING: wanted working_dir '{}' is not a dir"
+                    "{}: WARNING: wanted working_dir '{}' is not a directory"
                     "".format(self.name, cwd)
                 )
                 return None


### PR DESCRIPTION
Follow up to #845 

** BREAKING **

**This needs a banner on install.** 

```
Renamed setting `chdir` to `working_dir`. The new default is `${folder:$file_path}`, which means it chooses the project root if available, and falls back to use the directory of the file you're currently editing.  
``` 