### PR TITLE
Prepare complete runtime environment within `linter.get_environment`

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -15,6 +15,20 @@ ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:]
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'
 BASE_CLASSES = ('PythonLinter',)
 
+# Many linters use stdin, and we convert text to utf-8
+# before sending to stdin, so we have to make sure stdin
+# in the target executable is looking for utf-8. Some
+# linters (like ruby) need to have LANG and/or LC_CTYPE
+# set as well.
+UTF8_ENV_VARS = {
+    'PYTHONIOENCODING': 'utf8',
+    'LANG': 'en_US.UTF-8',
+    'LC_CTYPE': 'en_US.UTF-8',
+}
+
+BASE_LINT_ENVIRONMENT = ChainMap(UTF8_ENV_VARS, os.environ)
+
+
 MATCH_DICT = OrderedDict(
     (
         ("match", None),
@@ -895,7 +909,7 @@ class Linter(metaclass=LinterMeta):
 
     def get_environment(self, settings):
         """Return runtime environment for this lint."""
-        return ChainMap({}, settings.get('env', {}), self.env)
+        return ChainMap({}, settings.get('env', {}), self.env, BASE_LINT_ENVIRONMENT)
 
     def get_error_type(self, error, warning):  # noqa:D102
         if error:

--- a/lint/util.py
+++ b/lint/util.py
@@ -222,15 +222,6 @@ def create_environment():
     if persist.debug_mode() and env['PATH']:
         debug_print_env(env['PATH'])
 
-    # Many linters use stdin, and we convert text to utf-8
-    # before sending to stdin, so we have to make sure stdin
-    # in the target executable is looking for utf-8. Some
-    # linters (like ruby) need to have LANG and/or LC_CTYPE
-    # set as well.
-    env['PYTHONIOENCODING'] = 'utf8'
-    env['LANG'] = 'en_US.UTF-8'
-    env['LC_CTYPE'] = 'en_US.UTF-8'
-
     return env
 
 
@@ -301,7 +292,7 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None)
 
     The result is a string which comes from stdout, stderr or the
     combining of the two, depending on the value of output_stream.
-    If env is not None, it is merged with the result of create_environment.
+    If env is None, the result of create_environment is used.
 
     """
     # On Windows, using subprocess.PIPE with Popen() is broken when not
@@ -320,7 +311,7 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None)
         stdout = stderr = None
 
     out = popen(cmd, stdout=stdout, stderr=stderr,
-                output_stream=output_stream, extra_env=env, cwd=cwd)
+                output_stream=output_stream, env=env, cwd=cwd)
 
     if out is not None:
         if code is not None:
@@ -383,7 +374,7 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
     which is a filename to process.
 
     The result is a string combination of stdout and stderr.
-    If env is not None, it is merged with the result of create_environment.
+    If env is None, the result of create_environment is used.
     """
     if not filename:
         filename = "untitled"
@@ -423,7 +414,7 @@ def tmpdir(cmd, files, filename, code, output_stream=STREAM_STDOUT, env=None):
     which is a filename to process.
 
     Returns a string combination of stdout and stderr.
-    If env is not None, it is merged with the result of create_environment.
+    If env is None, the result of create_environment is used.
     """
     filename = os.path.basename(filename) if filename else ''
     out = None
@@ -462,7 +453,7 @@ def tmpdir(cmd, files, filename, code, output_stream=STREAM_STDOUT, env=None):
     return out or ''
 
 
-def popen(cmd, stdout=None, stderr=None, output_stream=STREAM_BOTH, env=None, extra_env=None, cwd=None):
+def popen(cmd, stdout=None, stderr=None, output_stream=STREAM_BOTH, env=None, cwd=None):
     """Open a pipe to an external process and return a Popen object."""
     info = None
 
@@ -483,9 +474,6 @@ def popen(cmd, stdout=None, stderr=None, output_stream=STREAM_BOTH, env=None, ex
 
     if env is None:
         env = create_environment()
-
-    if extra_env is not None:
-        env.update(extra_env)
 
     try:
         return subprocess.Popen(


### PR DESCRIPTION
Note that `util.create_environment()` has our enhanced PATH and this
augmented environment is not used for lint execution anymore.

The augmented PATH is only used for `which` calls.