### PR TITLE
Fix temporary files, remove temporary folders

### DIFF
--- a/docs/linter_methods.rst
+++ b/docs/linter_methods.rst
@@ -69,7 +69,7 @@ This method does the actual linting. *cmd* is a tuple/list of the command to be 
 
 If a linter plugin always uses built-in code (as opposed to a subclass of :doc:`PythonLinter <python_linter>` that may use a :ref:`module <module>`), it should override this method and return a string as the output. Subclasses of ``PythonLinter`` that specify a ``module`` attribute should **not** override this method, but the :ref:`check <check-method>` method instead.
 
-If a linter plugin needs to do complicated setup or will use the :ref:`tmpdir` method, it will need to override this method.
+If a linter plugin needs to do complicated setup it will need to override this method.
 
 
 split_match
@@ -81,17 +81,6 @@ split_match
 This method extracts the named capture groups from the :ref:`regex` and return a tuple of *match*, *line*, *col*, *error*, *warning*, *message*, *near*.
 
 If subclasses need to modify the values returned by the regex, they should override this method, call ``super().split_match(match)``, then modify the values and return them.
-
-
-tmpdir
-------
-.. code-block:: python
-
-   tmpdir(self, cmd, files, code)
-
-This method creates a temp directory, copies the files in the sequence *files* to the directory, appends the temp directory name to the sequence *cmd*, runs the external executable (with arguments) specified by *cmd*, and returns its output.
-
-Normally there is no need to call this method, but if you override the :ref:`run` method you can use this method to execute an external linter that requires a group of files in a specific directory structure.
 
 
 tmpfile

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1373,16 +1373,3 @@ class Linter(metaclass=LinterMeta):
             output_stream=self.error_stream,
             env=env,
             cwd=cwd)
-
-    def tmpdir(self, cmd, files, code):
-        """Run an external executable using a temp dir filled with files and return its output."""
-        settings = self.get_view_settings()
-        env = self.get_environment(settings)
-
-        return util.tmpdir(
-            cmd,
-            files,
-            self.filename,
-            code,
-            output_stream=self.error_stream,
-            env=env)

--- a/lint/util.py
+++ b/lint/util.py
@@ -335,11 +335,12 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
     if suffix:
         filename = os.path.splitext(filename)[0] + suffix
 
+    file = tempfile.NamedTemporaryFile(delete=False)
+    path = file.name
+
     try:
-        f = tempfile.NamedTemporaryFile(delete=False)
-        f.write(bytes(code, 'UTF-8'))
-        f.close()
-        path = f.name
+        file.write(bytes(code, 'UTF-8'))
+        file.close()
 
         cmd = list(cmd)
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -383,15 +383,11 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
     if suffix:
         filename = os.path.splitext(filename)[0] + suffix
 
-    path = os.path.join(tempdir, filename)
-
     try:
-        with open(path, mode='wb') as f:
-            if isinstance(code, str):
-                code = code.encode('utf-8')
-
-            f.write(code)
-            f.flush()
+        f = tempfile.NamedTemporaryFile(delete=False)
+        f.write(bytes(code, 'UTF-8'))
+        f.close()
+        path = f.name
 
         cmd = list(cmd)
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -4,34 +4,20 @@ from functools import lru_cache
 import locale
 from numbers import Number
 import os
-import getpass
 import re
-import shutil
-import stat
 import sublime
 import subprocess
 import tempfile
 
-
 from copy import deepcopy
 
 from .const import WARNING, ERROR
-
-if sublime.platform() != 'windows':
-    import pwd
-
 
 STREAM_STDOUT = 1
 STREAM_STDERR = 2
 STREAM_BOTH = STREAM_STDOUT + STREAM_STDERR
 
 ANSI_COLOR_RE = re.compile(r'\033\[[0-9;]*m')
-
-# Temp directory used to store temp files for linting
-tempdir = os.path.join(
-    tempfile.gettempdir(),
-    "SublimeLinter3-" + getpass.getuser()
-)
 
 
 def printf(*args):
@@ -331,40 +317,6 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None)
         return ''
 
 
-def create_tempdir():
-    """Create a directory within the system temp directory used to create temp files."""
-    try:
-        if os.path.isdir(tempdir):
-            shutil.rmtree(tempdir)
-
-        os.mkdir(tempdir)
-
-        # Make sure the directory can be removed by anyone in case the user
-        # runs ST later as another user.
-        os.chmod(tempdir, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
-
-    except PermissionError:
-        if sublime.platform() != 'windows':
-            current_user = pwd.getpwuid(os.geteuid())[0]
-            temp_uid = os.stat(tempdir).st_uid
-            temp_user = pwd.getpwuid(temp_uid)[0]
-            message = (
-                'The SublimeLinter temp directory:\n\n{0}\n\ncould not be cleared '
-                'because it is owned by \'{1}\' and you are logged in as \'{2}\'. '
-                'Please use sudo to remove the temp directory from a terminal.'
-            ).format(tempdir, temp_user, current_user)
-        else:
-            message = (
-                'The SublimeLinter temp directory ({}) could not be reset '
-                'because it belongs to a different user.'
-            ).format(tempdir)
-
-        sublime.error_message(message)
-
-    from . import persist
-    persist.debug('temp directory:', tempdir)
-
-
 def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=None, cwd=None):
     """
     Return the result of running an executable against a temporary file containing code.
@@ -399,53 +351,6 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
         return communicate(cmd, output_stream=output_stream, env=env, cwd=cwd)
     finally:
         os.remove(path)
-
-
-def tmpdir(cmd, files, filename, code, output_stream=STREAM_STDOUT, env=None):
-    """
-    Run an executable against a temporary file containing code.
-
-    It is assumed that the executable launched by cmd can take one more argument
-    which is a filename to process.
-
-    Returns a string combination of stdout and stderr.
-    If env is None, the result of create_environment is used.
-    """
-    filename = os.path.basename(filename) if filename else ''
-    out = None
-
-    with tempfile.TemporaryDirectory(dir=tempdir) as d:
-        for f in files:
-            try:
-                os.makedirs(os.path.join(d, os.path.dirname(f)))
-            except OSError:
-                pass
-
-            target = os.path.join(d, f)
-
-            if os.path.basename(target) == filename:
-                # source file hasn't been saved since change, so update it from our live buffer
-                f = open(target, 'wb')
-
-                if isinstance(code, str):
-                    code = code.encode('utf8')
-
-                f.write(code)
-                f.close()
-            else:
-                shutil.copyfile(f, target)
-
-        out = communicate(cmd, output_stream=output_stream, env=env, cwd=d)
-
-        if out:
-            # filter results from build to just this filename
-            # no guarantee all syntaxes are as nice about this as Go
-            # may need to improve later or just defer to communicate()
-            out = '\n'.join([
-                line for line in out.split('\n') if filename in line.split(':', 1)[0]
-            ])
-
-    return out or ''
 
 
 def popen(cmd, stdout=None, stderr=None, output_stream=STREAM_BOTH, env=None, cwd=None):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -49,8 +49,6 @@ def plugin_loaded():
 
     style.StyleParser()()
 
-    util.create_tempdir()
-
     persist.errors = ErrorStore()
 
     for linter in persist.linter_classes.values():


### PR DESCRIPTION
Fixes #864 by creating a random temp file using `tempfile.NamedTemporaryFile`, so that every linter gets his own file to work on an delete when done. 

The same problem could occur in `tmpdir` if multiple linters create and then remove the same temporary directory. The only linter to use this feature is SublimeLinter-contrib-gometalinter, but only for go < 1.5 (it apparently doesn't even try to support background linting mode for newer versions). Leaving it in a broken state is not an option IMO. I therefore propose to drop the feature altogether instead trying to fix it.