### PR TITLE
provide version info via package metadata

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -450,3 +450,11 @@ def load_json(*segments, from_sl_dir=False):
     base_path = "Packages/SublimeLinter/" if from_sl_dir else ""
     full_path = base_path + "/".join(segments)
     return sublime.decode_value(sublime.load_resource(full_path))
+
+
+def get_sl_version():
+    try:
+        metadata = load_json("package-metadata.json", from_sl_dir=True)
+        return metadata.get("version")
+    except Exception:
+        return "version unknown"

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -46,7 +46,7 @@ def plugin_loaded():
     persist.plugin_is_loaded = True
     persist.settings.load()
     persist.debug("debug mode: on")
-
+    persist.debug(util.get_sl_version())
     style.load_gutter_icons()
     style.StyleParser()()
 


### PR DESCRIPTION
Fixes #855 by creating `util.get_sl_version()`. Version number, if known, is printed in debug mode. I guess this also makes the version available to plugins, but unlike the ST build number it isn't a number and cannot be converted to one so you can't really target e.g. > 4.0.0 without shenanigans.