### PR TITLE
Prototype/idea: Implement `toast` messages

### DIFF
--- a/goto_commands.py
+++ b/goto_commands.py
@@ -2,7 +2,7 @@ import sublime
 import sublime_plugin
 
 from itertools import dropwhile, takewhile
-from .lint import persist
+from .lint import persist, events
 
 
 """
@@ -100,3 +100,5 @@ def get_current_pos(view):
 def flash(view, msg):
     window = view.window() or sublime.active_window()
     window.status_message(msg)
+
+    events.broadcast(events.TOAST, {'message': msg})

--- a/lint/events.py
+++ b/lint/events.py
@@ -4,6 +4,7 @@ import traceback
 
 BEGIN_LINTING = 'BEGIN_LINTING'
 FINISHED_LINTING = 'FINISHED_LINTING'
+TOAST = 'SHOW_TOAST'
 
 
 listeners = defaultdict(set)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -678,6 +678,14 @@ class Linter(metaclass=LinterMeta):
             util.printf('WARNING: {} cannot locate \'{}\''.format(self.name, which))
             return None
 
+        # TOAST error example
+        from . import events
+        import random
+        if random.randrange(0, 3, 1) == 0:
+            msg = 'WARNING: {} cannot locate \'{}\''.format(self.name, path)
+            events.broadcast(
+                events.TOAST, {'message': msg, 'type': 'error', 'timeout': 5000})
+
         cmd[0:1] = util.convert_type(path, [])
         return self.insert_args(cmd)
 

--- a/toasts_view.py
+++ b/toasts_view.py
@@ -1,0 +1,71 @@
+import sublime
+
+import math
+
+from .lint import events
+
+
+DEFAULT_TIMEOUT = 2500  # [ms]
+INFO = 'info'
+ERROR = 'error'
+
+STYLES = {
+    INFO: {
+        'background': 'transparent',
+        'foreground': 'var(--foreground)'
+    },
+    ERROR: {
+        'background': 'var(--redish)',
+        'foreground': '#fff'
+    }
+}
+
+
+def plugin_unloaded():
+    events.off(on_toast)
+
+
+@events.on(events.TOAST)
+def on_toast(message, type=INFO, timeout=DEFAULT_TIMEOUT, **kwargs):
+    active_view = sublime.active_window().active_view()
+    show_toast(active_view, message, timeout=timeout, style=STYLES[type])
+
+
+def show_toast(view, message, timeout=DEFAULT_TIMEOUT, style=STYLES[INFO]):
+    width, _ = view.viewport_extent()
+    max_chars = math.floor(width // view.em_width())
+    content = style_message(center(message, cols=max_chars), style)
+
+    visible_region = view.visible_region()
+    first_row, _ = view.rowcol(visible_region.begin())
+    line_start = view.text_point(first_row, 0)
+
+    flags = (
+        sublime.COOPERATE_WITH_AUTO_COMPLETE |
+        sublime.HIDE_ON_MOUSE_MOVE_AWAY
+    )
+    view.show_popup(content, flags,
+                    max_width=width, location=line_start)
+
+    sublime.set_timeout_async(lambda: hide_popup(view), timeout)
+
+
+def hide_popup(view):
+    if view.is_popup_visible():
+        view.hide_popup()
+
+
+def center(text, cols=80, char='&nbsp;'):
+    fill_len = (cols - len(text)) // 2 - 1
+    fill = fill_len * char
+    return fill + text + fill
+
+
+def style_message(message, style):
+    return """
+        <div
+            style="padding: 1em 0;
+                   background-color: {background};
+                   color: {foreground}"
+        >{message}</div>
+    """.format(message=message, **style)


### PR DESCRIPTION
🌶 

This PR implements toast messages. For demo purposes, the Goto commands `ctrl-k, n` flashes toast messages, if there are no more problems to jump to etc. Also, here and then, we simulate a big red config error.

Implementation details are not important. I did this somewhen, and just rebased it now, to show it. 😄 