### PR TITLE
A version number for plugins

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+"""Provides an API version for plugins."""
+VERSION = 1

--- a/lint/const.py
+++ b/lint/const.py
@@ -1,5 +1,3 @@
-VERSION = "4.0.0"
-
 PROTECTED_REGIONS_KEY = "sublime_linter.protected_regions"
 STATUS_KEY = "sublime_linter_status"
 STATUS_BUSY_KEY = "sublime_linter_status_busy"

--- a/lint/const.py
+++ b/lint/const.py
@@ -1,3 +1,5 @@
+VERSION = "4.0.0"
+
 PROTECTED_REGIONS_KEY = "sublime_linter.protected_regions"
 STATUS_KEY = "sublime_linter_status"
 STATUS_BUSY_KEY = "sublime_linter_status_busy"

--- a/lint/util.py
+++ b/lint/util.py
@@ -454,8 +454,10 @@ def load_json(*segments, from_sl_dir=False):
 
 
 def get_sl_version():
+    import SublimeLinter
+    version = str(getattr(SublimeLinter, 'VERSION'))
     try:
         metadata = load_json("package-metadata.json", from_sl_dir=True)
-        return metadata.get("version")
+        return version + ", " + metadata.get("version")
     except Exception:
-        return "unknown"
+        return version + ", dev"

--- a/lint/util.py
+++ b/lint/util.py
@@ -11,7 +11,7 @@ import tempfile
 
 from copy import deepcopy
 
-from .const import WARNING, ERROR
+from .const import WARNING, ERROR, VERSION
 
 STREAM_STDOUT = 1
 STREAM_STDERR = 2
@@ -458,4 +458,4 @@ def get_sl_version():
         metadata = load_json("package-metadata.json", from_sl_dir=True)
         return metadata.get("version")
     except Exception:
-        return "unknown"
+        return VERSION

--- a/lint/util.py
+++ b/lint/util.py
@@ -11,7 +11,7 @@ import tempfile
 
 from copy import deepcopy
 
-from .const import WARNING, ERROR, VERSION
+from .const import WARNING, ERROR
 
 STREAM_STDOUT = 1
 STREAM_STDERR = 2
@@ -458,4 +458,4 @@ def get_sl_version():
         metadata = load_json("package-metadata.json", from_sl_dir=True)
         return metadata.get("version")
     except Exception:
-        return VERSION
+        return "unknown"


### PR DESCRIPTION
addresses #897 

This is not really the most excellent way to go about this, but perhaps gets the ball rolling. With this, a plugin can do

```py
from SublimeLinter.lint import PythonLinter, util

try:
    v = util.get_sl_version().split(".")
    api_version = v[0]
except Exception:
    # SL3 doesn't have this feature
    api_version = 3
```

I really don't want to introduce different versions for plugins vs. end users, that needlessly complicates matters. New releases with niceties for end users: bump the patch number. New feature in the api: bump the minor number. Removal of features from the api: bump the major number. We can let the hardcoded patch number at 0 as long as we remember to bump it for the api changes, which shouldn't happen that often either. 

I don't think we should have all sorts of different versions out there, it's not the goal to have multiple implementations in every linter. It's also not a goal to create a very formal contract with each plugin about the API features they can expect. End of the day it's all just a single environment full of python code anyway. We're just looking for a, mostly temporary, hook to not have flake8 break on everybody right now, and to enable api breakage down the road.

This PR exposes the version we want to communicate with end users. When deployed via package control `get_sl_version` returns the exact same semver string as we tagged the repo with. The hardcoded version is a fallback for development usage. Because older version of SL cannot report their version plugins cannot be sure that `get_sl_version` exists, but can reasonably assume that if it doesn't it's probably SL3.

Opinions very welcome @FichteFoll @kaste @pykong 