### PR TITLE
Refactor logging

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -124,10 +124,7 @@ def get_linters(view):
 
                 for pattern in excludes:
                     if fnmatch(filename, pattern):
-                        persist.debug(
-                            '{} skipped \'{}\', excluded by \'{}\''
-                            .format(linter.name, filename, pattern)
-                        )
+                        linter.logger.debug('skipping; excluded by \'{}\'', pattern)
                         matched = True
                         break
 

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -124,7 +124,7 @@ def get_linters(view):
 
                 for pattern in excludes:
                     if fnmatch(filename, pattern):
-                        linter.logger.debug('skipping; excluded by \'{}\'', pattern)
+                        linter.logger.debug('skipping; excluded by %r', pattern)
                         matched = True
                         break
 

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -68,7 +68,7 @@ class PythonLinter(linter.Linter):
         # point to a python environment, NOT a python binary.
         python = settings.get('python', None)
 
-        self.logger.debug("wanted python is '{}'", python)
+        self.logger.debug("wanted python is '%s'", python)
 
         cmd_name = cmd[0] if isinstance(cmd, (list, tuple)) else cmd
 
@@ -78,9 +78,9 @@ class PythonLinter(linter.Linter):
                     python, cmd_name
                 )
                 if not executable:
-                    self.logger.print(
-                        "WARNING: deactivated; cannot locate '{}' "
-                        "for given python '{}'",
+                    self.logger.warning(
+                        "WARNING: deactivated; cannot locate %r "
+                        "for given python %r",
                         cmd_name, python
                     )
                     # Do not fallback, user specified something we didn't find
@@ -94,14 +94,14 @@ class PythonLinter(linter.Linter):
                 )
 
                 if executable is None:
-                    self.logger.print(
-                        "WARNING: {} deactivated; cannot locate '{}' "
-                        "for given python '{}'",
+                    self.logger.warning(
+                        "WARNING: deactivated; cannot locate %r "
+                        "for given python %r",
                         cmd_name, python
                     )
                     return True, None
 
-                self.logger.debug("Using '{}' for given python '{}'", executable, python)
+                self.logger.debug("Using '%s' for given python %r", executable, python)
                 return True, executable
 
         # If we're here the user didn't specify anything. This is the default
@@ -109,18 +109,18 @@ class PythonLinter(linter.Linter):
         cwd = self.get_working_dir(settings)
         executable = ask_pipenv(cmd[0], cwd)
         if executable:
-            self.logger.debug("Using '{}' according to pipenv", executable)
+            self.logger.debug("Using '%s' according to pipenv", executable)
             return True, executable
 
         # Should we try a `pyenv which` as well? Problem: I don't have it,
         # it's MacOS only.
 
-        self.logger.debug("trying to use globally installed {}", cmd_name)
+        self.logger.debug("trying to use globally installed %r", cmd_name)
         # fallback, similiar to a which(cmd)
         executable = util.which(cmd_name)
         if executable is None:
-            self.logger.print("WARNING: cannot locate excecutable."
-                              " Fill in the 'python' or 'executable' setting.")
+            self.logger.warning("WARNING: cannot locate excecutable."
+                                " Fill in the 'python' or 'executable' setting.")
         return True, executable
 
 
@@ -159,7 +159,7 @@ def find_script_by_python_env(python_env_path, script):
     else:
         full_path = os.path.join(python_env_path, 'Scripts', script + '.exe')
 
-    logging.print("trying {}".format(full_path))
+    logging.info("trying '%s'".format(full_path))
     if os.path.exists(full_path):
         return full_path
 
@@ -222,7 +222,7 @@ def _communicate(cmd, cwd):
             cmd, env=env, startupinfo=info, universal_newlines=True, cwd=cwd
         )
     except Exception as err:
-        logging.debug("executing {} failed. reason: {!s}", str(err))
+        logging.debug("executing %s failed. reason: %s", cmd, err)
         return ''
 
 
@@ -239,9 +239,9 @@ def get_python_version(path):
         # 'python -V' returns 'Python <version>', extract the version number
         return extract_major_minor_version(output.split(' ')[1])
     except Exception as ex:
-        logging.print(
-            'ERROR: an error occurred retrieving the version for {}:\n{}',
-            path, str(ex)
+        logging.error(
+            'ERROR: an error occurred retrieving the version for %s:\n%s',
+            path, ex
         )
 
         return {'major': None, 'minor': None}

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 
 import sublime
-from .. import linter, persist, util
+from .. import linter, util, logging
 
 
 class PythonLinter(linter.Linter):
@@ -68,9 +68,7 @@ class PythonLinter(linter.Linter):
         # point to a python environment, NOT a python binary.
         python = settings.get('python', None)
 
-        persist.debug(
-            "{}: wanted python is '{}'".format(self.name, python)
-        )
+        self.logger.debug("wanted python is '{}'", python)
 
         cmd_name = cmd[0] if isinstance(cmd, (list, tuple)) else cmd
 
@@ -80,10 +78,10 @@ class PythonLinter(linter.Linter):
                     python, cmd_name
                 )
                 if not executable:
-                    persist.printf(
-                        "WARNING: {} deactivated, cannot locate '{}' "
-                        "for given python '{}'"
-                        .format(self.name, cmd_name, python)
+                    self.logger.print(
+                        "WARNING: deactivated; cannot locate '{}' "
+                        "for given python '{}'",
+                        cmd_name, python
                     )
                     # Do not fallback, user specified something we didn't find
                     return True, None
@@ -96,17 +94,14 @@ class PythonLinter(linter.Linter):
                 )
 
                 if executable is None:
-                    persist.printf(
-                        "WARNING: {} deactivated, cannot locate '{}' "
-                        "for given python '{}'"
-                        .format(self.name, cmd_name, python)
+                    self.logger.print(
+                        "WARNING: {} deactivated; cannot locate '{}' "
+                        "for given python '{}'",
+                        cmd_name, python
                     )
                     return True, None
 
-                persist.debug(
-                    "{}: Using {} for given python '{}'"
-                    .format(self.name, executable, python)
-                )
+                self.logger.debug("Using '{}' for given python '{}'", executable, python)
                 return True, executable
 
         # If we're here the user didn't specify anything. This is the default
@@ -114,27 +109,18 @@ class PythonLinter(linter.Linter):
         cwd = self.get_working_dir(settings)
         executable = ask_pipenv(cmd[0], cwd)
         if executable:
-            persist.debug(
-                "{}: Using {} according to 'pipenv'"
-                .format(self.name, executable)
-            )
+            self.logger.debug("Using '{}' according to pipenv", executable)
             return True, executable
 
         # Should we try a `pyenv which` as well? Problem: I don't have it,
         # it's MacOS only.
 
-        persist.debug(
-            "{}: trying to use globally installed {}"
-            .format(self.name, cmd_name)
-        )
+        self.logger.debug("trying to use globally installed {}", cmd_name)
         # fallback, similiar to a which(cmd)
         executable = util.which(cmd_name)
         if executable is None:
-            persist.printf(
-                "WARNING: cannot locate '{}'. Fill in the 'python' or "
-                "'executable' setting."
-                .format(self.name)
-            )
+            self.logger.print("WARNING: cannot locate excecutable."
+                              " Fill in the 'python' or 'executable' setting.")
         return True, executable
 
 
@@ -173,7 +159,7 @@ def find_script_by_python_env(python_env_path, script):
     else:
         full_path = os.path.join(python_env_path, 'Scripts', script + '.exe')
 
-    persist.printf("trying {}".format(full_path))
+    logging.print("trying {}".format(full_path))
     if os.path.exists(full_path):
         return full_path
 
@@ -236,9 +222,7 @@ def _communicate(cmd, cwd):
             cmd, env=env, startupinfo=info, universal_newlines=True, cwd=cwd
         )
     except Exception as err:
-        persist.debug(
-            "executing {} failed: reason: {}".format(cmd, str(err))
-        )
+        logging.debug("executing {} failed. reason: {!s}", str(err))
         return ''
 
 
@@ -255,9 +239,10 @@ def get_python_version(path):
         # 'python -V' returns 'Python <version>', extract the version number
         return extract_major_minor_version(output.split(' ')[1])
     except Exception as ex:
-        util.printf(
-            'ERROR: an error occurred retrieving the version for {}: {}'
-            .format(path, str(ex)))
+        logging.print(
+            'ERROR: an error occurred retrieving the version for {}:\n{}',
+            path, str(ex)
+        )
 
         return {'major': None, 'minor': None}
 

--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -80,7 +80,7 @@ class RubyLinter(linter.Linter):
             ruby = util.which('jruby')
 
         if not rbenv and not ruby:
-            self.logger.print('WARNING: deactivated; cannot locate ruby, rbenv or rvm-auto-ruby')
+            self.logger.warning('WARNING: deactivated; cannot locate ruby, rbenv or rvm-auto-ruby')
             return True, None
 
         if isinstance(cmd, str):
@@ -108,7 +108,7 @@ class RubyLinter(linter.Linter):
                 else:
                     ruby_cmd = [ruby, gem_path]
             else:
-                self.logger.print('WARNING: deactivated; cannot locate the gem \'{}\'', gem)
+                self.logger.warning('WARNING: deactivated; cannot locate the gem %r', gem)
                 return True, None
         else:
             ruby_cmd = [ruby]

--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -80,10 +80,7 @@ class RubyLinter(linter.Linter):
             ruby = util.which('jruby')
 
         if not rbenv and not ruby:
-            util.printf(
-                'WARNING: {} deactivated, cannot locate ruby, rbenv or rvm-auto-ruby'
-                .format(self.name, cmd[0])
-            )
+            self.logger.print('WARNING: deactivated; cannot locate ruby, rbenv or rvm-auto-ruby')
             return True, None
 
         if isinstance(cmd, str):
@@ -111,10 +108,7 @@ class RubyLinter(linter.Linter):
                 else:
                     ruby_cmd = [ruby, gem_path]
             else:
-                util.printf(
-                    'WARNING: {} deactivated, cannot locate the gem \'{}\''
-                    .format(self.name, gem)
-                )
+                self.logger.print('WARNING: deactivated; cannot locate the gem \'{}\'', gem)
                 return True, None
         else:
             ruby_cmd = [ruby]

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -494,14 +494,18 @@ class Linter(metaclass=LinterMeta):
             variables['folder'] = project_folder
 
         if persist.debug_mode():
+            # Only print the non-deterministic variables
+            vars_to_print = ('file', 'project', 'folder')
+            filtered_variables = {k: v for k, v in variables.items() if k in vars_to_print}
             import pprint
-            self._debug_print_available_variables(pprint.pformat(dict(variables), indent=4))
+            text = pprint.pformat(dict(filtered_variables), indent=4)
+            self._debug_print_variables(text)
         return recursive_replace(variables, settings)
 
     @staticmethod
     @lru_cache(maxsize=1)
-    def _debug_print_available_variables(variables):
-        persist.debug('Available variables:\n{}'.format(variables))
+    def _debug_print_variables(text):
+        persist.debug('Selected variables:\n{}'.format(text))
 
     @staticmethod
     def _guess_project_path(window, filename):

--- a/lint/logging.py
+++ b/lint/logging.py
@@ -38,9 +38,12 @@ class LinterLogger(Logger):
     def __init__(self, linter):
         self.linter = linter
         self.linter_name = linter.name
-        self.file_path = linter.view.file_name() or "<untitled {}>".format(linter.view.buffer_id())
-        self.file_name = os.path.basename(self.file_path)
-        self.print_prefix = "[SublimeLinter] [{}] ({})".format(self.linter_name, self.file_name)
+
+    def print(self, fmt, *args, **kwargs):
+        file_path = self.linter.view.file_name() or "<untitled {}>".format(self.linter.view.buffer_id())
+        file_name = os.path.basename(file_path)
+        self.print_prefix = "[SublimeLinter] [{}] ({})".format(self.linter_name, file_name)
+        super().print(fmt, *args, **kwargs)
 
 
 # Maps thread idents to an active logger

--- a/lint/logging.py
+++ b/lint/logging.py
@@ -1,55 +1,76 @@
 from contextlib import contextmanager
+import logging
 import os
 import threading
 
-import builtins
+
+BASE_PREFIX = "[SublimeLinter] "
+BASE_FORMAT = "%(message)s"
+NAMESPACE = __name__
+
+# Our created loggers.
+# Needed to set the level for each individually.
+_loggers = set()
+# The associated handlers.
+# Needed to remove the previous one in case a logger is "re-created".
+_handlers = {}
 
 
-class Logger:
+def _build_logger(name, fmt, propagate=True):
+    logger = logging.getLogger(name)
+    logger.propagate = propagate
+    _loggers.add(logger)
+    if logger in _handlers:
+        logger.removeHandler(_handlers[logger])
 
-    # Will be prepended to all print messages
-    print_prefix = "[SublimeLinter]"
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt))
+    logger.addHandler(handler)
+    _handlers[logger] = handler
 
-    def debug(self, fmt, *args, **kwargs):
-        """Print a debug message on stdout, if debug mode is enabled.
-
-        Arguments are forwarded to `fmt.format`.
-        """
-        from . import persist
-        if persist.debug_mode():
-            self.print(fmt, *args, **kwargs)
-
-    def print(self, fmt, *args, **kwargs):
-        """Print a message on stdout. Arguments are forwarded to `fmt.format`."""
-        message = fmt.format(*args, **kwargs)
-        builtins.print(self.print_prefix, message)
+    return logger
 
 
-class LinterClsLogger(Logger):
-
-    def __init__(self, linter_cls):
-        self.linter_cls = linter_cls
-        self.linter_name = linter_cls.name
-        self.print_prefix = "[SublimeLinter] [{}]".format(self.linter_name)
+def setLevel(level):
+    """Set the logging level for all created loggers."""
+    for logger in _loggers:
+        logger.setLevel(level)
 
 
-class LinterLogger(Logger):
-
-    def __init__(self, linter):
-        self.linter = linter
-        self.linter_name = linter.name
-
-    def print(self, fmt, *args, **kwargs):
-        file_path = self.linter.view.file_name() or "<untitled {}>".format(self.linter.view.buffer_id())
-        file_name = os.path.basename(file_path)
-        self.print_prefix = "[SublimeLinter] [{}] ({})".format(self.linter_name, file_name)
-        super().print(fmt, *args, **kwargs)
+def set_debug_level(is_debug):
+    """Set the logging level based on a boolean."""
+    level = logging.DEBUG if is_debug else logging.INFO
+    setLevel(level)
 
 
-# Maps thread idents to an active logger
+def getLinterClsLogger(linter_cls):
+    linter_name = linter_cls.name
+
+    name = "{}.{}".format(NAMESPACE, linter_name)
+    fmt = "{}[{}] {}".format(BASE_PREFIX, linter_name, BASE_FORMAT)
+    return _build_logger(name, fmt, propagate=False)
+
+
+def getLinterLogger(linter):
+    linter_name = linter.name
+    file_path = linter.view.file_name() or "<untitled {}>".format(linter.view.buffer_id())
+    file_name = os.path.basename(file_path)
+
+    name = "{}.{}.{}".format(NAMESPACE, linter_name, linter.view.id())
+    fmt = "{}[{}] ({}) {}".format(BASE_PREFIX, linter_name, file_name, BASE_FORMAT)
+    return _build_logger(name, fmt, propagate=False)
+
+
+# Configure base logger for the entire package
+package_name = __package__.split('.')[0]
+base_logger = _build_logger(package_name, BASE_PREFIX + BASE_FORMAT)
+setLevel(logging.INFO)
+
+
+# Map thread idents to an active logger
 _thread_logger_map = {}
 # Used when no linter-specific logger is active
-default_logger = Logger()
+default_logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -64,16 +85,33 @@ def get_current_logger():
     """Find the active logger for the current thread."""
     logger = _thread_logger_map.get(threading.get_ident())
     if not logger:
-        logger = default_logger
+        logger = base_logger
     return logger
 
 
-def debug(*args, **kwargs):
-    # late-import to prevent circular imports
-    from . import persist
-    if persist.debug_mode():
-        get_current_logger().print(*args, **kwargs)
+# def critical(*args, **kwargs):
+#     get_current_logger().critical(*args, **kwargs)
 
 
-def print(*args, **kwargs):
-    get_current_logger().print(*args, **kwargs)
+# def exception(*args, **kwargs):
+#     get_current_logger().exception(*args, **kwargs)
+
+
+# def error(*args, **kwargs):
+#     get_current_logger().exception(*args, **kwargs)
+
+
+# def warning(*args, **kwargs):
+#     get_current_logger().warning(*args, **kwargs)
+
+
+# def info(*args, **kwargs):
+#     get_current_logger().info(*args, **kwargs)
+
+
+# def debug(*args, **kwargs):
+#     get_current_logger().debug(*args, **kwargs)
+
+# Create thread-aware logging functions
+for func_name in ('critical', 'exception', 'error', 'warning', 'info', 'debug'):
+    globals()[func_name] = lambda *a, **kw: getattr(get_current_logger(), func_name)(*a, **kw)

--- a/lint/logging.py
+++ b/lint/logging.py
@@ -1,0 +1,76 @@
+from contextlib import contextmanager
+import os
+import threading
+
+import builtins
+
+
+class Logger:
+
+    # Will be prepended to all print messages
+    print_prefix = "[SublimeLinter]"
+
+    def debug(self, fmt, *args, **kwargs):
+        """Print a debug message on stdout, if debug mode is enabled.
+
+        Arguments are forwarded to `fmt.format`.
+        """
+        from . import persist
+        if persist.debug_mode():
+            self.print(fmt, *args, **kwargs)
+
+    def print(self, fmt, *args, **kwargs):
+        """Print a message on stdout. Arguments are forwarded to `fmt.format`."""
+        message = fmt.format(*args, **kwargs)
+        builtins.print(self.print_prefix, message)
+
+
+class LinterClsLogger(Logger):
+
+    def __init__(self, linter_cls):
+        self.linter_cls = linter_cls
+        self.linter_name = linter_cls.name
+        self.print_prefix = "[SublimeLinter] [{}]".format(self.linter_name)
+
+
+class LinterLogger(Logger):
+
+    def __init__(self, linter):
+        self.linter = linter
+        self.linter_name = linter.name
+        self.file_path = linter.view.file_name() or "<untitled {}>".format(linter.view.buffer_id())
+        self.file_name = os.path.basename(self.file_path)
+        self.print_prefix = "[SublimeLinter] [{}] ({})".format(self.linter_name, self.file_name)
+
+
+# Maps thread idents to an active logger
+_thread_logger_map = {}
+# Used when no linter-specific logger is active
+default_logger = Logger()
+
+
+@contextmanager
+def logger_context(logger):
+    key = threading.get_ident()
+    _thread_logger_map[key] = logger
+    yield
+    del _thread_logger_map[key]
+
+
+def get_current_logger():
+    """Find the active logger for the current thread."""
+    logger = _thread_logger_map.get(threading.get_ident())
+    if not logger:
+        logger = default_logger
+    return logger
+
+
+def debug(*args, **kwargs):
+    # late-import to prevent circular imports
+    from . import persist
+    if persist.debug_mode():
+        get_current_logger().print(*args, **kwargs)
+
+
+def print(*args, **kwargs):
+    get_current_logger().print(*args, **kwargs)

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -1,9 +1,10 @@
 """This module provides persistent global storage for other modules."""
 
 from collections import defaultdict
+import logging
 
 from .settings import Settings
-from . import logging
+from . import logging as sl_logging
 
 
 if 'plugin_is_loaded' not in globals():
@@ -47,10 +48,11 @@ def edit(vid, edit):
         c(edit)
 
 
+# Backwards compatibility
 def debug_mode():
     """Return whether the "debug" setting is True."""
-    return settings.get('debug', False)
+    return sl_logging.base_logger.isEnabledFor(logging.DEBUG)
 
 
 # Backwards compatibility
-debug = logging.default_logger.debug
+debug = sl_logging.debug

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -2,8 +2,8 @@
 
 from collections import defaultdict
 
-from .util import printf
 from .settings import Settings
+from . import logging
 
 
 if 'plugin_is_loaded' not in globals():
@@ -52,7 +52,5 @@ def debug_mode():
     return settings.get('debug', False)
 
 
-def debug(*args):
-    """Print args to the console if the "debug" setting is True."""
-    if debug_mode():
-        printf(*args)
+# Backwards compatibility
+debug = logging.default_logger.debug

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -1,7 +1,10 @@
+import logging
 import sublime
-from . import util, logging
+from . import util
 from jsonschema.validators import validate
 from jsonschema.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
 
 
 class Settings:
@@ -57,6 +60,9 @@ class Settings:
 
         from . import style
         from .linter import Linter
+        from .logging import set_debug_level
+
+        set_debug_level(self.get("debug", False))
 
         # Reparse settings for style rules
         # Linter specific settings can include style rules too
@@ -82,9 +88,9 @@ def get_settings_objects():
         try:
             yield name, util.load_json(name, from_sl_dir=False)
         except IOError as ie:
-            logging.default_logger.print("Settings file not found: {}".format(name))
+            logger.error("Settings file not found: %s", name)
         except ValueError as ve:
-            logging.default_logger.print("Settings file corrupt: {}".format(name))
+            logger.error("Settings file corrupt: %s", name)
 
 
 def validate_settings():
@@ -98,7 +104,7 @@ def validate_settings():
             validate(settings, schema)
         except ValidationError as ve:
             ve_msg = ve.message.split("\n")[0]  # reduce verbosity
-            logging.default_logger.print("Settings in {!r} invalid:\n{}", name, ve_msg)
+            logger.error("Settings in %r invalid:\n%s", name, ve_msg)
             sublime.active_window().status_message(status_msg)
             good = False
 

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -1,5 +1,5 @@
 import sublime
-from . import util
+from . import util, logging
 from jsonschema.validators import validate
 from jsonschema.exceptions import ValidationError
 
@@ -82,9 +82,9 @@ def get_settings_objects():
         try:
             yield name, util.load_json(name, from_sl_dir=False)
         except IOError as ie:
-            util.printf("Settings file not found: {}".format(name))
+            logging.default_logger.print("Settings file not found: {}".format(name))
         except ValueError as ve:
-            util.printf("Settings file corrupt: {}".format(name))
+            logging.default_logger.print("Settings file corrupt: {}".format(name))
 
 
 def validate_settings():
@@ -98,7 +98,7 @@ def validate_settings():
             validate(settings, schema)
         except ValidationError as ve:
             ve_msg = ve.message.split("\n")[0]  # reduce verbosity
-            util.printf("Settings in '{}' invalid:\n{}".format(name, ve_msg))
+            logging.default_logger.print("Settings in {!r} invalid:\n{}", name, ve_msg)
             sublime.active_window().status_message(status_msg)
             good = False
 

--- a/lint/style.py
+++ b/lint/style.py
@@ -1,8 +1,9 @@
 import sublime
-from . import persist, util, logging
+from . import persist, util
 from abc import ABCMeta, abstractmethod
 from .const import INBUILT_ICONS
 
+import logging
 import os
 from glob import glob
 
@@ -11,6 +12,7 @@ GUTTER_ICONS = {}
 
 
 linter_style_stores = {}
+logger = logging.getLogger(__name__)
 
 
 def get_linter_style_store(name):
@@ -85,7 +87,7 @@ class HighlightStyleStore(StyleBaseStore, util.Borg):
             error_type = args[3]
 
             if not res:
-                logging.default_logger.print(
+                logger.error(
                     "Styles are invalid. Please check your settings and restart Sublime Text."
                 )
                 return

--- a/lint/style.py
+++ b/lint/style.py
@@ -1,5 +1,5 @@
 import sublime
-from . import persist, util
+from . import persist, util, logging
 from abc import ABCMeta, abstractmethod
 from .const import INBUILT_ICONS
 
@@ -85,7 +85,9 @@ class HighlightStyleStore(StyleBaseStore, util.Borg):
             error_type = args[3]
 
             if not res:
-                util.printf("Styles are invalid. Please check your settings and restart Sublime Text.")
+                logging.default_logger.print(
+                    "Styles are invalid. Please check your settings and restart Sublime Text."
+                )
                 return
 
             if key != "icon":

--- a/lint/util.py
+++ b/lint/util.py
@@ -12,6 +12,7 @@ import tempfile
 from copy import deepcopy
 
 from .const import WARNING, ERROR
+from . import logging
 
 STREAM_STDOUT = 1
 STREAM_STDERR = 2
@@ -20,12 +21,8 @@ STREAM_BOTH = STREAM_STDOUT + STREAM_STDERR
 ANSI_COLOR_RE = re.compile(r'\033\[[0-9;]*m')
 
 
-def printf(*args):
-    """Print args to the console, prefixed by the plugin name."""
-    print('SublimeLinter: ', end='')
-    for arg in args:
-        print(arg, end=' ')
-    print()
+# Backwards compatibility
+printf = logging.default_logger.print
 
 
 def get_syntax(view):
@@ -179,9 +176,9 @@ def find_file(start_dir, name, parent=False, limit=None, aux_dirs=[]):
 
 
 @lru_cache(maxsize=1)  # print once every time the path changes
-def debug_print_env(path):
+def debug_print_path(path):
     import textwrap
-    printf('PATH:\n{}'.format(textwrap.indent(path.replace(os.pathsep, '\n'), '    ')))
+    logging.print('PATH:\n{}', textwrap.indent(path.replace(os.pathsep, '\n'), '    '))
 
 
 def create_environment():
@@ -207,7 +204,7 @@ def create_environment():
         env['PATH'] = os.pathsep.join(paths) + os.pathsep + env['PATH']
 
     if persist.debug_mode() and env['PATH']:
-        debug_print_env(env['PATH'])
+        debug_print_path(env['PATH'])
 
     return env
 
@@ -388,9 +385,9 @@ def popen(cmd, stdout=None, stderr=None, output_stream=STREAM_BOTH, env=None, cw
             cwd=cwd,
         )
     except Exception as err:
-        printf('ERROR: could not launch', repr(cmd))
-        printf('reason:', str(err))
-        printf('PATH:', env.get('PATH', ''))
+        logging.print('ERROR: could not launch', repr(cmd))
+        logging.print('reason:', str(err))
+        logging.print('PATH:', env.get('PATH', ''))
 
 
 # view utils

--- a/lint/util.py
+++ b/lint/util.py
@@ -2,6 +2,7 @@
 
 from functools import lru_cache
 import locale
+import logging
 from numbers import Number
 import os
 import re
@@ -12,7 +13,7 @@ import tempfile
 from copy import deepcopy
 
 from .const import WARNING, ERROR
-from . import logging
+from . import logging as sl_logging
 
 STREAM_STDOUT = 1
 STREAM_STDERR = 2
@@ -20,9 +21,10 @@ STREAM_BOTH = STREAM_STDOUT + STREAM_STDERR
 
 ANSI_COLOR_RE = re.compile(r'\033\[[0-9;]*m')
 
+logger = logging.getLogger(__name__)
 
 # Backwards compatibility
-printf = logging.default_logger.print
+printf = sl_logging.info
 
 
 def get_syntax(view):
@@ -178,7 +180,7 @@ def find_file(start_dir, name, parent=False, limit=None, aux_dirs=[]):
 @lru_cache(maxsize=1)  # print once every time the path changes
 def debug_print_path(path):
     import textwrap
-    logging.print('PATH:\n{}', textwrap.indent(path.replace(os.pathsep, '\n'), '    '))
+    logger.info('PATH:\n%s', textwrap.indent(path.replace(os.pathsep, '\n'), '    '))
 
 
 def create_environment():
@@ -385,9 +387,8 @@ def popen(cmd, stdout=None, stderr=None, output_stream=STREAM_BOTH, env=None, cw
             cwd=cwd,
         )
     except Exception as err:
-        logging.print('ERROR: could not launch', repr(cmd))
-        logging.print('reason:', str(err))
-        logging.print('PATH:', env.get('PATH', ''))
+        sl_logging.error('ERROR: could not launch %r\nreason: %s\nPATH: %s',
+                         cmd, err, env.get('PATH', ''))
 
 
 # view utils

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -42,8 +42,12 @@ def plugin_loaded():
 
     persist.plugin_is_loaded = True
     persist.settings.load()
-    persist.debug("debug mode: on")
-    persist.debug("version: " + util.get_sl_version())
+    if persist.debug_mode():
+        persist.debug("debug mode: on")
+        persist.debug("version: " + util.get_sl_version())
+        import pprint
+        text = pprint.pformat(dict(os.environ), indent=4)
+        persist.debug('Environment variables:\n{}'.format(text))
     style.load_gutter_icons()
     style.StyleParser()()
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -48,7 +48,7 @@ def plugin_loaded():
         logging.debug("version: " + util.get_sl_version())
         import pprint
         text = pprint.pformat(dict(os.environ), indent=4)
-        logging.debug('Environment variables:\n{}', (text))
+        logging.debug('Environment variables:\n%s', (text))
     style.load_gutter_icons()
     style.StyleParser()()
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -13,6 +13,7 @@ from .lint.queue import queue
 from .lint import persist, util, style
 from .lint.const import WARN_ERR
 from .lint import backend
+from .lint import logging
 
 
 def backup_old_settings():
@@ -43,11 +44,11 @@ def plugin_loaded():
     persist.plugin_is_loaded = True
     persist.settings.load()
     if persist.debug_mode():
-        persist.debug("debug mode: on")
-        persist.debug("version: " + util.get_sl_version())
+        logging.debug("debug mode: on")
+        logging.debug("version: " + util.get_sl_version())
         import pprint
         text = pprint.pformat(dict(os.environ), indent=4)
-        persist.debug('Environment variables:\n{}'.format(text))
+        logging.debug('Environment variables:\n{}', (text))
     style.load_gutter_icons()
     style.StyleParser()()
 


### PR DESCRIPTION
It was really hard to associate some debug prints with a certain linter (not even considering which view it was executed on) if they originated from outside of the `linter.Linter` class, since no context information could be printed.
Furthermore, added context in logging calls were quite redundant as the linter name had to be added to every call within a lint task.

This PR adds a stateful logging module that maintains a per-thread active logger cache that linters can set when they do the bulk of their work and delegate stuff to the other modules, such as process execution or settings expansion.

Example console output:
```
[SublimeLinter] [flake8] (linter.py) Selected variables:
{   'file': '/home/fichte/.config/sublime-text-3/Packages/SublimeLinter/lint/linter.py',
    'folder': '/home/fichte/.config/sublime-text-3/Packages/SublimeLinter',
    'project': '/home/fichte/.config/sublime-text-3/Packages/SublimeLinter/sublime_linter.sublime-project'}
[SublimeLinter] [flake8] (linter.py) cmd: ['/usr/bin/flake8', '--format', 'default', '--max-line-length=99', '--ignore=E201,E221,E222,E241,E722,W191,W291,W292,W293,W503,D1,D211,D413,D', '-']
[SublimeLinter] [flake8] (linter.py) cwd: /home/fichte/.config/sublime-text-3/Packages/SublimeLinter
[SublimeLinter] [flake8] (linter.py) output:
    stdin:14:100: E501 line too long (117 > 99 characters)
    stdin:439:100: E501 line too long (100 > 99 characters)
```

Partially addresses #907. Settings are still expanded way too frequently.