### PR TITLE
Only determine view's settings once per lint

### DIFF
--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -62,11 +62,9 @@ class PythonLinter(linter.Linter):
         if success:
             return success, executable
 
-        settings = self.get_view_settings()
-
         # `python` can be number or a string. If it is a string it should
         # point to a python environment, NOT a python binary.
-        python = settings.get('python', None)
+        python = self.settings.get('python', None)
 
         persist.debug(
             "{}: wanted python is '{}'".format(self.name, python)
@@ -111,7 +109,7 @@ class PythonLinter(linter.Linter):
 
         # If we're here the user didn't specify anything. This is the default
         # experience. So we kick in some 'magic'
-        cwd = self.get_working_dir(settings)
+        cwd = self.get_working_dir()
         executable = ask_pipenv(cmd[0], cwd)
         if executable:
             persist.debug(

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -445,10 +445,10 @@ class Linter(metaclass=LinterMeta):
         with self._settings_lock:
             self.window_settings.check()
             if (
-                self._settings is None
-                or persist.settings.change_count > self._persisted_settings_change_count
-                or self.window_settings.change_count > self._window_settings_change_count
-                or self.view.file_name() != self._last_file_name
+                self._settings is None or
+                persist.settings.change_count > self._persisted_settings_change_count or
+                self.window_settings.change_count > self._window_settings_change_count or
+                self.view.file_name() != self._last_file_name
             ):
                 self._settings = self._get_view_settings()
                 self._persisted_settings_change_count = persist.settings.change_count

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -438,6 +438,7 @@ class Linter(metaclass=LinterMeta):
     _settings = None
     _persisted_settings_change_count = 0
     _window_settings_change_count = 0
+    _last_file_name = None
 
     def get_view_settings(self):
         # We need to lock here for potential races during settings updates
@@ -447,10 +448,12 @@ class Linter(metaclass=LinterMeta):
                 self._settings is None
                 or persist.settings.change_count > self._persisted_settings_change_count
                 or self.window_settings.change_count > self._window_settings_change_count
+                or self.view.file_name() != self._last_file_name
             ):
                 self._settings = self._get_view_settings()
                 self._persisted_settings_change_count = persist.settings.change_count
                 self._window_settings_change_count = self.window_settings.change_count
+                self._last_file_name = self.view.file_name()
 
             return self._settings
 

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -91,17 +91,14 @@ class WindowSettings:
     """Extract settings for SL from a project file."""
 
     change_count = 0
-    _data = None
+    _cached_data = None
     _window_map = {}
 
     def __init__(self, window):
         self.window = window
 
     def _current_data(self):
-        p_data = self.window.project_data()
-        if not p_data:
-            return {}
-        return p_data.get('SublimeLinter', {})
+        return self.window.project_data() or {}
 
     def check(self):
         """Check whether the underlying data has changed."""
@@ -109,15 +106,18 @@ class WindowSettings:
         self.data()
         return self.change_count != prev_count
 
-    def data(self):
+    def _data(self):
         """Fetch the current data and increase `change_count` if it changed."""
         current_data = self._current_data()
-        if self._data is None:
-            self._data = current_data
-        elif self._data != current_data:
-            self._data = current_data
+        if self._cached_data is None:
+            self._cached_data = current_data
+        elif self._cached_data != current_data:
+            self._cached_data = current_data
             self.change_count += 1
-        return self._data
+        return self._cached_data
+
+    def data(self):
+        return self._data().get('SublimeLinter', {})
 
     def linter_settings(self, linter_name):
         """Return settings for the linter with the specified name."""

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -87,7 +87,6 @@ class Settings:
 
 
 class WindowSettings:
-
     """Extract settings for SL from a project file."""
 
     change_count = 0

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -7,6 +7,9 @@ from jsonschema.exceptions import ValidationError
 class Settings:
     """This class provides global access to and management of plugin settings."""
 
+    # Can be used to check for outdated caches
+    change_count = 0
+
     def __init__(self):
         self._storage = {}
 
@@ -55,6 +58,8 @@ class Settings:
         if not validate_settings():
             return
 
+        self.change_count += 1
+
         from . import style
         from .linter import Linter
 
@@ -75,6 +80,57 @@ class Settings:
 
         from ..sublime_linter import SublimeLinter
         SublimeLinter.lint_all_views()
+
+    def linter_settings(self, linter_name):
+        """Return settings for the linter with the specified name."""
+        return self.get('linters', {}).get(linter_name, {})
+
+
+class WindowSettings:
+
+    """Extract settings for SL from a project file."""
+
+    change_count = 0
+    _data = None
+    _window_map = {}
+
+    def __init__(self, window):
+        self.window = window
+
+    def _current_data(self):
+        p_data = self.window.project_data()
+        if not p_data:
+            return {}
+        return p_data.get('SublimeLinter', {})
+
+    def check(self):
+        """Check whether the underlying data has changed."""
+        prev_count = self.change_count
+        self.data()
+        return self.change_count != prev_count
+
+    def data(self):
+        """Fetch the current data and increase `change_count` if it changed."""
+        current_data = self._current_data()
+        if self._data is None:
+            self._data = current_data
+        elif self._data != current_data:
+            self._data = current_data
+            self.change_count += 1
+        return self._data
+
+    def linter_settings(self, linter_name):
+        """Return settings for the linter with the specified name."""
+        return self.data().get('linters', {}).get(linter_name, {})
+
+    @classmethod
+    def for_window(cls, window):
+        id_ = window.id()
+        instance = cls._window_map.get(id_)
+        if not instance:
+            instance = cls(window)
+            cls._window_map[id_] = instance
+        return instance
 
 
 def get_settings_objects():


### PR DESCRIPTION
We just call get_view_settings in lint and cache it as an instance variable. Too many methods were passing around or re-determining the settings during a single lint for no apparent reason, since it will not
have changed in the meantime.

Fixes #907.