### PR TITLE
Fixes #912 where a file extension is required for some linters

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1298,22 +1298,18 @@ class Linter(metaclass=LinterMeta):
 
     def get_tempfile_suffix(self):
         """Return the mapped tempfile_suffix."""
-        suffix = ''
+        if self.tempfile_suffix and not self.view.file_name():
+            if isinstance(self.tempfile_suffix, dict):
+                suffix = self.tempfile_suffix.get(util.get_syntax(self.view), self.syntax)
+            else:
+                suffix = self.tempfile_suffix
 
-        if isinstance(self.tempfile_suffix, str):
-            suffix = self.tempfile_suffix
-        elif isinstance(self.tempfile_suffix, dict):
-            suffix = self.tempfile_suffix.get(util.get_syntax(self.view), self.syntax)
+            if not suffix.startswith('.'):
+                suffix = '.' + suffix
 
-        # default to plain text
-        if not suffix:
-            suffix = '.txt'
-
-        # prepend period if necessary
-        if not suffix.startswith('.'):
-            suffix = '.' + suffix
-
-        return suffix
+            return suffix
+        else:
+            return ''
 
     # popen wrappers
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1298,18 +1298,22 @@ class Linter(metaclass=LinterMeta):
 
     def get_tempfile_suffix(self):
         """Return the mapped tempfile_suffix."""
-        if self.tempfile_suffix and not self.view.file_name():
-            if isinstance(self.tempfile_suffix, dict):
-                suffix = self.tempfile_suffix.get(util.get_syntax(self.view), self.syntax)
-            else:
-                suffix = self.tempfile_suffix
+        suffix = ''
 
-            if not suffix.startswith('.'):
-                suffix = '.' + suffix
+        if isinstance(self.tempfile_suffix, str):
+            suffix = self.tempfile_suffix
+        elif isinstance(self.tempfile_suffix, dict):
+            suffix = self.tempfile_suffix.get(util.get_syntax(self.view), self.syntax)
 
-            return suffix
-        else:
-            return ''
+        # default to plain text
+        if not suffix:
+            suffix = '.txt'
+
+        # prepend period if necessary
+        if not suffix.startswith('.'):
+            suffix = '.' + suffix
+
+        return suffix
 
     # popen wrappers
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -328,14 +328,6 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
     The result is a string combination of stdout and stderr.
     If env is None, the result of create_environment is used.
     """
-    if not filename:
-        filename = "untitled"
-    else:
-        filename = os.path.basename(filename)
-
-    if suffix:
-        filename = os.path.splitext(filename)[0] + suffix
-
     file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
     path = file.name
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -336,7 +336,12 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
     if suffix:
         filename = os.path.splitext(filename)[0] + suffix
 
-    file = tempfile.NamedTemporaryFile(delete=False)
+    if not suffix:
+        # Some linters require a file extension to run properly.
+        short_filename, file_extension = os.path.splitext(filename)
+        suffix = file_extension
+
+    file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
     path = file.name
 
     try:

--- a/lint/util.py
+++ b/lint/util.py
@@ -336,11 +336,6 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
     if suffix:
         filename = os.path.splitext(filename)[0] + suffix
 
-    if not suffix:
-        # Some linters require a file extension to run properly.
-        short_filename, file_extension = os.path.splitext(filename)
-        suffix = file_extension
-
     file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
     path = file.name
 


### PR DESCRIPTION
I found that some linters like [SublimeLinter-phpcs](https://github.com/SublimeLinter/SublimeLinter-phpcs) stopped working after a recent update. After some debugging of the code I found that most recent versions of PHP CodeSniffer do not work when the file has a different extension than `.php` or has no extension at all.

Before SublimeLinter executes the command specified by the variable `cmd` it creates a temporary file, which on macOS is placed at `$TMPDIR` and then copies the content of the original file there, then it executes the command using `process.Popen`; the problem here is that the files are being created using `tempfile.NamedTemporaryFile` which by default creates file names with this format `/tmp[a-z_]{6}`.

A solution is to pass the `suffix=".ext"` parameter to the method call.

Fixes #912