### PR TITLE
fix line report

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -39,4 +39,4 @@ class SublimeLinterLintCommand(sublime_plugin.TextCommand):
 class SublimeLinterLineReportCommand(sublime_plugin.WindowCommand):
     def run(self):
         from .sublime_linter import SublimeLinter
-        SublimeLinter.shared_plugin().open_tooltip()
+        SublimeLinter.shared_plugin().open_tooltip(line_report=True)

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -338,7 +338,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
             )
         return all_msgs
 
-    def open_tooltip(self, active_view=None, point=None, is_gutter=False):
+    def open_tooltip(self, active_view=None, point=None, line_report=False):
         """Show a tooltip containing all linting errors on a given line."""
         stylesheet = '''
             body {
@@ -378,16 +378,16 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         errors = persist.errors[bid]
         errors = [e for e in errors if e["line"] == line]
-        if not is_gutter:  # do not show tooltip on hovering empty gutter
+        if not line_report:
             errors = [e for e in errors if e["start"] <= col <= e["end"]]
         if not errors:
             return
 
-        tooltip_message = self.join_msgs(errors, is_gutter)
+        tooltip_message = self.join_msgs(errors, line_report)
         if not tooltip_message:
             return
 
-        col = 0 if is_gutter else col
+        col = 0 if line_report else col
         location = active_view.text_point(line, col)
         active_view.show_popup(
             template.format(stylesheet=stylesheet, message=tooltip_message),

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -387,7 +387,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         if not tooltip_message:
             return
 
-        col = 0 if line_report else col
         location = active_view.text_point(line, col)
         active_view.show_popup(
             template.format(stylesheet=stylesheet, message=tooltip_message),


### PR DESCRIPTION
Calling the line report command only displays the error at your cursor. This is incorrect behaviour. This PR changes that:

- show line report when cursor not at error
- don't filter errors for cursor position when requesting line report
- line report really is just the gutter report but not at the gutter