### PR TITLE
Attempt #2 at improving how we expose ERROR/WARNING

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,4 +2,3 @@
 VERSION = 4
 WARNING = "warning"
 ERROR = "error"
-INBUILT_ICONS = ("circle", "dot", "bookmark", "none")

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,4 @@
 """Provides an API version for plugins."""
 VERSION = 4
+WARNING = "warning"
+ERROR = "error"

--- a/__init__.py
+++ b/__init__.py
@@ -2,5 +2,4 @@
 VERSION = 4
 WARNING = "warning"
 ERROR = "error"
-STATUS_KEY = "sublime_linter_status"
 INBUILT_ICONS = ("circle", "dot", "bookmark", "none")

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,6 @@
-"""Provides an API version for plugins."""
+"""Provides an API version and shared constants."""
 VERSION = 4
 WARNING = "warning"
 ERROR = "error"
+STATUS_KEY = "sublime_linter_status"
+INBUILT_ICONS = ("circle", "dot", "bookmark", "none")

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,2 @@
-"""Provides an API version and shared constants."""
+"""Provides an API version for plugins."""
 VERSION = 4
-WARNING = "warning"
-ERROR = "error"

--- a/busy_indicator_view.py
+++ b/busy_indicator_view.py
@@ -3,14 +3,13 @@ import sublime_plugin
 
 import time
 
-from .lint.const import STATUS_BUSY_KEY
 from .lint import events
 
 
 INITIAL_DELAY = 1
 CYCLE_TIME = 200
 TIMEOUT = 20
-
+STATUS_BUSY_KEY = "sublime_linter_status_busy"
 
 State = {
     'active_view': None,

--- a/docs/linter_attributes.rst
+++ b/docs/linter_attributes.rst
@@ -37,7 +37,7 @@ classify the problems.
 If the linter output does not provide information which can be captured with those groups,
 this attribute is used to determine how to classify the linter error.
 
-The value should be ``ERROR`` or ``WARNING`` (constants imported from ``SublimeLinter``).
+The value should be ``ERROR`` or ``WARNING`` (constants imported from ``SublimeLinter.lint``).
 
 The default value is ``ERROR``.
 

--- a/docs/linter_attributes.rst
+++ b/docs/linter_attributes.rst
@@ -36,9 +36,10 @@ Usually the ``error`` and ``warning`` named capture groups in the :ref:`regex`
 classify the problems.
 If the linter output does not provide information which can be captured with those groups,
 this attribute is used to determine how to classify the linter error.
-The value should be ``const.ERROR`` or ``const.WARNING``.
 
-The default value is ``const.ERROR``.
+The value should be ``ERROR`` or ``WARNING`` (constants imported from ``SublimeLinter``).
+
+The default value is ``ERROR``.
 
 
 .. _defaults:

--- a/gutter-themes/Blueberry/cross/Blueberry - cross.gutter-theme
+++ b/gutter-themes/Blueberry/cross/Blueberry - cross.gutter-theme
@@ -1,0 +1,3 @@
+{
+    "colorize": false
+}

--- a/gutter-themes/Blueberry/round/Blueberry - round.gutter-theme
+++ b/gutter-themes/Blueberry/round/Blueberry - round.gutter-theme
@@ -1,0 +1,3 @@
+{
+    "colorize": false
+}

--- a/gutter-themes/Danish Royalty/Danish Royalty.gutter-theme
+++ b/gutter-themes/Danish Royalty/Danish Royalty.gutter-theme
@@ -1,0 +1,3 @@
+{
+    "colorize": false
+}

--- a/gutter-themes/Hands/Hands.gutter-theme
+++ b/gutter-themes/Hands/Hands.gutter-theme
@@ -1,0 +1,3 @@
+{
+    "colorize": false
+}

--- a/gutter-themes/Knob/simple/Knob - simple.gutter-theme
+++ b/gutter-themes/Knob/simple/Knob - simple.gutter-theme
@@ -1,0 +1,3 @@
+{
+    "colorize": false
+}

--- a/gutter-themes/Knob/symbol/Knob - symbol.gutter-theme
+++ b/gutter-themes/Knob/symbol/Knob - symbol.gutter-theme
@@ -1,0 +1,3 @@
+{
+    "colorize": false
+}

--- a/gutter-themes/Koloria/Koloria.gutter-theme
+++ b/gutter-themes/Koloria/Koloria.gutter-theme
@@ -1,0 +1,3 @@
+{
+    "colorize": false
+}

--- a/gutter-themes/ProjectIcons/ProjectIcons.gutter-theme
+++ b/gutter-themes/ProjectIcons/ProjectIcons.gutter-theme
@@ -1,0 +1,3 @@
+{
+    "colorize": false
+}

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -3,7 +3,7 @@ import sublime
 
 from .lint import persist, events
 from .lint import style as style_stores
-from .lint.const import PROTECTED_REGIONS_KEY, INBUILT_ICONS
+from .lint.const import INBUILT_ICONS
 
 
 UNDERLINE_FLAGS = sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE
@@ -19,7 +19,7 @@ MARK_STYLES = {
 
 highlight_store = style_stores.HighlightStyleStore()
 REGION_KEYS = 'SL.{}.region_keys'
-
+PROTECTED_REGIONS_KEY = "sublime_linter.protected_regions"
 
 def remember_region_keys(view, keys):
     view.settings().set(REGION_KEYS.format(view.id()), keys)

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -1,7 +1,6 @@
 from collections import defaultdict, ChainMap
 import sublime
 
-from SublimeLinter import INBUILT_ICONS
 from .lint import persist, events
 from .lint import style as style_stores
 
@@ -103,7 +102,7 @@ def prepare_gutter_data(view, errors):
         if not icon or icon == 'none':
             continue
 
-        if style_stores.GUTTER_ICONS.get('colorize', True) or icon in INBUILT_ICONS:
+        if style_stores.GUTTER_ICONS.get('colorize', True):
             scope = highlight_store.get_val('scope', error['style'], error['error_type'])
         else:
             scope = " "  # set scope to non-existent one

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -20,6 +20,7 @@ highlight_store = style_stores.HighlightStyleStore()
 REGION_KEYS = 'SL.{}.region_keys'
 PROTECTED_REGIONS_KEY = "sublime_linter.protected_regions"
 
+
 def remember_region_keys(view, keys):
     view.settings().set(REGION_KEYS.format(view.id()), keys)
 

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -1,9 +1,9 @@
 from collections import defaultdict, ChainMap
 import sublime
 
+from SublimeLinter import INBUILT_ICONS
 from .lint import persist, events
 from .lint import style as style_stores
-from .lint.const import INBUILT_ICONS
 
 
 UNDERLINE_FLAGS = sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE

--- a/lint/__init__.py
+++ b/lint/__init__.py
@@ -7,16 +7,8 @@ from . import (
     util,
 )
 
-from .const import WARNING, ERROR
-
 from .linter import Linter
 from .base_linter.python_linter import PythonLinter
 from .base_linter.ruby_linter import RubyLinter
 from .base_linter.node_linter import NodeLinter
 from .base_linter.composer_linter import ComposerLinter
-
-
-# For compatibility with SL3, export a pseudo highlight class
-class highlight:
-    WARNING=WARNING
-    ERROR=ERROR

--- a/lint/__init__.py
+++ b/lint/__init__.py
@@ -1,15 +1,18 @@
 # flake8: noqa
 """This module exports the linter classes and the highlight, linter, persist and util submodules."""
 
+WARNING = "warning"
+ERROR = "error"
+
 from . import (
     linter,
     persist,
     util,
 )
 
-from .. import WARNING, ERROR
 from .linter import Linter
 from .base_linter.python_linter import PythonLinter
 from .base_linter.ruby_linter import RubyLinter
 from .base_linter.node_linter import NodeLinter
 from .base_linter.composer_linter import ComposerLinter
+

--- a/lint/__init__.py
+++ b/lint/__init__.py
@@ -7,6 +7,8 @@ from . import (
     util,
 )
 
+from SublimeLinter import WARNING, ERROR
+
 from .linter import Linter
 from .base_linter.python_linter import PythonLinter
 from .base_linter.ruby_linter import RubyLinter

--- a/lint/__init__.py
+++ b/lint/__init__.py
@@ -7,8 +7,7 @@ from . import (
     util,
 )
 
-from SublimeLinter import WARNING, ERROR
-
+from .. import WARNING, ERROR
 from .linter import Linter
 from .base_linter.python_linter import PythonLinter
 from .base_linter.ruby_linter import RubyLinter

--- a/lint/const.py
+++ b/lint/const.py
@@ -1,2 +1,0 @@
-STATUS_KEY = "sublime_linter_status"
-INBUILT_ICONS = ("circle", "dot", "bookmark", "none")

--- a/lint/const.py
+++ b/lint/const.py
@@ -1,5 +1,2 @@
-PROTECTED_REGIONS_KEY = "sublime_linter.protected_regions"
 STATUS_KEY = "sublime_linter_status"
-STATUS_BUSY_KEY = "sublime_linter_status_busy"
-
 INBUILT_ICONS = ("circle", "dot", "bookmark", "none")

--- a/lint/const.py
+++ b/lint/const.py
@@ -2,7 +2,4 @@ PROTECTED_REGIONS_KEY = "sublime_linter.protected_regions"
 STATUS_KEY = "sublime_linter_status"
 STATUS_BUSY_KEY = "sublime_linter_status_busy"
 
-WARNING = "warning"
-ERROR = "error"
-WARN_ERR = (WARNING, ERROR)
 INBUILT_ICONS = ("circle", "dot", "bookmark", "none")

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -9,8 +9,7 @@ import shlex
 import sublime
 
 from . import persist, util
-from .. import highlight_view, status_bar_view
-from SublimeLinter import ERROR, WARNING
+from .. import highlight_view, status_bar_view, ERROR, WARNING
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -9,12 +9,13 @@ import shlex
 import sublime
 
 from . import persist, util
-from .. import highlight_view
-from SublimeLinter import ERROR, WARNING, STATUS_KEY
+from .. import highlight_view, status_bar_view
+from SublimeLinter import ERROR, WARNING
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'
 BASE_CLASSES = ('PythonLinter',)
+STATUS_KEY = "sublime_linter_status"
 
 # Many linters use stdin, and we convert text to utf-8
 # before sending to stdin, so we have to make sure stdin
@@ -1118,7 +1119,7 @@ class Linter(metaclass=LinterMeta):
         if not view:
             return
 
-        view.erase_status(STATUS_KEY)
+        status_bar_view.clear(view)
         highlight_view.clear_view(view)
 
     def clear(self):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -8,8 +8,8 @@ import re
 import shlex
 import sublime
 
-from . import persist, util
-from .. import highlight_view, status_bar_view, ERROR, WARNING
+from . import persist, util, ERROR, WARNING
+from .. import highlight_view, status_bar_view
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -10,7 +10,8 @@ import sublime
 
 from . import persist, util
 from .. import highlight_view
-from .const import STATUS_KEY, WARNING, ERROR
+from SublimeLinter import ERROR, WARNING
+from .const import STATUS_KEY
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -10,8 +10,7 @@ import sublime
 
 from . import persist, util
 from .. import highlight_view
-from SublimeLinter import ERROR, WARNING
-from .const import STATUS_KEY
+from SublimeLinter import ERROR, WARNING, STATUS_KEY
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -14,7 +14,6 @@ from .. import highlight_view, status_bar_view, ERROR, WARNING
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'
 BASE_CLASSES = ('PythonLinter',)
-STATUS_KEY = "sublime_linter_status"
 
 # Many linters use stdin, and we convert text to utf-8
 # before sending to stdin, so we have to make sure stdin

--- a/lint/style.py
+++ b/lint/style.py
@@ -5,8 +5,6 @@ from abc import ABCMeta, abstractmethod
 import os
 from glob import glob
 
-from SublimeLinter import INBUILT_ICONS
-
 GUTTER_ICONS = {}
 linter_style_stores = {}
 
@@ -36,11 +34,11 @@ def load_gutter_icons():
         theme_file = theme_files[0]
         opts = util.load_json(theme_file)
         if not opts:
-            colorize = False
+            colorize = True
         else:
-            colorize = opts.get("colorize", False)
+            colorize = opts.get("colorize", True)
     else:
-        colorize = False
+        colorize = True
 
     new_gutter_dict["colorize"] = colorize
     dir_path, _ = os.path.split(theme_file)
@@ -91,7 +89,7 @@ class HighlightStyleStore(StyleBaseStore, util.Borg):
             else:
                 # returning paths
 
-                if res in INBUILT_ICONS:
+                if res in ("circle", "dot", "bookmark", "none"):  # Sublime Text has some default icons
                     return res
                 elif res != os.path.basename(res):
                     return res

--- a/lint/style.py
+++ b/lint/style.py
@@ -1,15 +1,13 @@
 import sublime
 from . import persist, util
 from abc import ABCMeta, abstractmethod
-from .const import INBUILT_ICONS
 
 import os
 from glob import glob
 
+from SublimeLinter import INBUILT_ICONS
 
 GUTTER_ICONS = {}
-
-
 linter_style_stores = {}
 
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -11,7 +11,7 @@ import tempfile
 
 from copy import deepcopy
 
-from .. import ERROR, WARNING
+from . import ERROR, WARNING
 
 STREAM_STDOUT = 1
 STREAM_STDERR = 2

--- a/lint/util.py
+++ b/lint/util.py
@@ -11,7 +11,7 @@ import tempfile
 
 from copy import deepcopy
 
-from .const import WARNING, ERROR
+from SublimeLinter import ERROR, WARNING
 
 STREAM_STDOUT = 1
 STREAM_STDERR = 2

--- a/lint/util.py
+++ b/lint/util.py
@@ -11,7 +11,7 @@ import tempfile
 
 from copy import deepcopy
 
-from SublimeLinter import ERROR, WARNING
+from .. import ERROR, WARNING
 
 STREAM_STDOUT = 1
 STREAM_STDERR = 2

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -3,9 +3,9 @@ import sublime_plugin
 
 from collections import defaultdict
 
-from .lint import persist
-from .lint.const import STATUS_KEY, WARNING, ERROR
-from .lint import events
+from SublimeLinter import ERROR, WARNING
+from .lint import persist, events
+from .lint.const import STATUS_KEY
 
 
 State = {

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -3,9 +3,8 @@ import sublime_plugin
 
 from collections import defaultdict
 
-from SublimeLinter import ERROR, WARNING
+from SublimeLinter import ERROR, WARNING, STATUS_KEY
 from .lint import persist, events
-from .lint.const import STATUS_KEY
 
 
 State = {

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -3,8 +3,7 @@ import sublime_plugin
 
 from collections import defaultdict
 
-from . import ERROR, WARNING
-from .lint import persist, events
+from .lint import persist, events, ERROR, WARNING
 
 STATUS_KEY = "sublime_linter_status"
 

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -3,9 +3,10 @@ import sublime_plugin
 
 from collections import defaultdict
 
-from SublimeLinter import ERROR, WARNING, STATUS_KEY
+from SublimeLinter import ERROR, WARNING
 from .lint import persist, events
 
+STATUS_KEY = "sublime_linter_status"
 
 State = {
     'we_count': {},
@@ -114,3 +115,7 @@ def get_current_pos(view):
         return view.rowcol(view.sel()[0].begin())
     except (AttributeError, IndexError):
         return -1, -1
+
+
+def clear(view):
+    view.erase_status(STATUS_KEY)

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -3,7 +3,7 @@ import sublime_plugin
 
 from collections import defaultdict
 
-from SublimeLinter import ERROR, WARNING
+from . import ERROR, WARNING
 from .lint import persist, events
 
 STATUS_KEY = "sublime_linter_status"

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -6,12 +6,9 @@ import html
 import sublime
 import sublime_plugin
 
-from . import ERROR, WARNING
-from .lint import events
+from .lint import ERROR, WARNING, events, persist, util, style, backend
 from .lint.linter import Linter
 from .lint.queue import queue
-from .lint import persist, util, style
-from .lint import backend
 
 
 def backup_old_settings():

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -6,11 +6,11 @@ import html
 import sublime
 import sublime_plugin
 
+from SublimeLinter import ERROR, WARNING
 from .lint import events
 from .lint.linter import Linter
 from .lint.queue import queue
 from .lint import persist, util, style
-from .lint.const import WARN_ERR
 from .lint import backend
 
 
@@ -311,7 +311,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         tmpl_sans_code = "{linter}: {escaped_msg}"
 
         all_msgs = ""
-        for error_type in WARN_ERR:
+        for error_type in (WARNING, ERROR):
             heading = error_type
             filled_templates = []
             msg_list = [e for e in errors if e["error_type"] == error_type]

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -6,7 +6,7 @@ import html
 import sublime
 import sublime_plugin
 
-from SublimeLinter import ERROR, WARNING
+from . import ERROR, WARNING
 from .lint import events
 from .lint.linter import Linter
 from .lint.queue import queue


### PR DESCRIPTION
- does away with const.py
- make constants private to their module
- true is the new default for `colorize` because ST defaults to that too and it simplifies stuff
- linter.py shouldn't manipulate the status bar view directly

-----
fixes #915