### PR TITLE
remove bid from errors when closing its last view

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -147,6 +147,16 @@ class Listener:
 
         queue.cleanup(vid)
 
+        # Remove bid from persis.errors if it's the last view on the buffer
+        bid = view.buffer_id()
+        buffers = []
+        for w in sublime.windows():
+            for v in w.views():
+                buffers.append(v.buffer_id())
+
+        if buffers.count(bid) is 1:
+            del persist.errors[bid]
+
     def on_hover(self, view, point, hover_zone):
         """On mouse hover event hook.
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -147,7 +147,7 @@ class Listener:
 
         queue.cleanup(vid)
 
-        # Remove bid from persis.errors if it's the last view on the buffer
+        # Remove bid from persist.errors if it's the last view on the buffer
         bid = view.buffer_id()
         buffers = []
         for w in sublime.windows():

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -147,15 +147,20 @@ class Listener:
 
         queue.cleanup(vid)
 
-        # Remove bid from persist.errors if it's the last view on the buffer
         bid = view.buffer_id()
         buffers = []
+        view_count = 0
         for w in sublime.windows():
             for v in w.views():
+                view_count = view_count + 1
                 buffers.append(v.buffer_id())
 
-        if buffers.count(bid) is 1:
-            del persist.errors[bid]
+        if view_count <= 1:
+            # Wipe clean after last view closes
+            persist.errors.clear()
+        elif buffers.count(bid) <= 1:
+            # Remove bid from persist.errors if it's the last view on the buffer
+            persist.errors.pop(bid, None)
 
     def on_hover(self, view, point, hover_zone):
         """On mouse hover event hook.


### PR DESCRIPTION
`sublime.windows()` and `window.views()` always return lists, we can iterate over them to find all buffer_ids. If the view to be closed is attached to exactly 1 buffer, we also remove that buffer from `persist.errors`.

This seems to work correctly, but I see some bids in `persist.errors` that I don't have views for. They seem to be created when I open e.g. the find panel. Can it be that we create entries in `persist.errors` for such buffers? I couldn't find out if we did. 

We also have the a nuclear option of wiping out `persist.errors` completely if no views remain...

----

fixes #900