### PR TITLE
Inline make_task

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -59,15 +59,12 @@ def run_tasks(tasks, next):
 
 def get_lint_tasks(linters, view, hit_time):
     for (linter, settings, regions) in get_lint_regions(linters, view):
-
-        def make_task(linter, settings, region):
+        tasks = []
+        for region in regions:
             code = view.substr(region)
             offset = view.rowcol(region.begin())
-            return partial(
-                execute_lint_task, linter, code, offset, hit_time, settings
-            )
-
-        yield linter, map(partial(make_task, linter, settings), regions)
+            tasks.append(partial(execute_lint_task, linter, code, offset, hit_time, settings))
+        yield linter, tasks
 
 
 def execute_lint_task(linter, code, offset, hit_time, settings):


### PR DESCRIPTION
Most variables were carried over to `execute_lint_task` anyway,
so we might as well just do everything inline. This way we don't create
a new function object for every iteration.

(After 22f6bc5dd10cf26989f5c6d12286b126a6f0f3c6 and ae4648ccc31da65a5b6f8e826b1450920e5b7e22, the partial call got longer and longer, meaning the benefit from a function was pretty diminishing here anyway.)