### PR TITLE
show errors in a panel

### DIFF
--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -80,10 +80,9 @@ class RubyLinter(linter.Linter):
             ruby = util.which('jruby')
 
         if not rbenv and not ruby:
-            util.printf(
-                'WARNING: {} deactivated, cannot locate ruby, rbenv or rvm-auto-ruby'
-                .format(self.name, cmd[0])
-            )
+            msg = 'WARNING: {} deactivated, cannot locate ruby, rbenv or rvm-auto-ruby'.format(self.name, cmd[0])
+            util.printf(msg)
+            util.message(msg)
             return True, None
 
         if isinstance(cmd, str):
@@ -111,10 +110,9 @@ class RubyLinter(linter.Linter):
                 else:
                     ruby_cmd = [ruby, gem_path]
             else:
-                util.printf(
-                    'WARNING: {} deactivated, cannot locate the gem \'{}\''
-                    .format(self.name, gem)
-                )
+                msg = 'WARNING: {} deactivated, cannot locate the gem \'{}\''.format(self.name, gem)
+                util.printf(msg)
+                util.message(msg)
                 return True, None
         else:
             ruby_cmd = [ruby]

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -692,7 +692,9 @@ class Linter(metaclass=LinterMeta):
             path = self.which(which)
 
         if not path:
-            util.printf('WARNING: {} cannot locate \'{}\''.format(self.name, which))
+            msg = 'WARNING: {} cannot locate \'{}\''.format(self.name, which)
+            util.printf(msg)
+            util.alert(msg)
             return None
 
         cmd[0:1] = util.convert_type(path, [])

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -694,7 +694,7 @@ class Linter(metaclass=LinterMeta):
         if not path:
             msg = 'WARNING: {} cannot locate \'{}\''.format(self.name, which)
             util.printf(msg)
-            util.alert(msg)
+            util.message(msg)
             return None
 
         cmd[0:1] = util.convert_type(path, [])

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1268,10 +1268,10 @@ class Linter(metaclass=LinterMeta):
                 )
                 return True
             else:
-                util.printf(
-                    'WARNING: {} deactivated, version requirement ({}) not fulfilled by {}'
-                    .format(cls.name, cls.version_requirement, cls.executable_version)
-                )
+                warning = 'WARNING: {} deactivated, version requirement ({}) not fulfilled by {}'
+                msg = warning.format(cls.name, cls.version_requirement, cls.executable_version)
+                util.printf(msg)
+                util.message(msg)
 
         return False
 

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -91,16 +91,17 @@ def validate_settings():
     status_msg = "SublimeLinter - Settings invalid!"
     schema_file = "resources/settings-schema.json"
     schema = util.load_json(schema_file, from_sl_dir=True)
-
+    window = sublime.active_window()
+    window.active_view().run_command("sublime_linter_remove_panel")
     good = True
+
     for name, settings in get_settings_objects():
         try:
             validate(settings, schema)
-        except ValidationError as ve:
+        except ValidationError as error:
             good = False
-            ve_msg = ve.message.split("\n")[0]  # reduce verbosity
-            full_msg = "Invalid settings in '{}':\n{}".format(name, ve_msg)
-            window = sublime.active_window()
+            error_msg = error.message.split("\n")[0]  # reduce verbosity
+            full_msg = "Invalid settings in '{}':\n{}".format(name, error_msg)
 
             util.printf(full_msg)
             window.status_message(status_msg)

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -81,9 +81,9 @@ def get_settings_objects():
     for name in sublime.find_resources("SublimeLinter.sublime-settings"):
         try:
             yield name, util.load_json(name, from_sl_dir=False)
-        except IOError as ie:
+        except IOError:
             util.printf("Settings file not found: {}".format(name))
-        except ValueError as ve:
+        except ValueError:
             util.printf("Settings file corrupt: {}".format(name))
 
 

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -88,7 +88,7 @@ def get_settings_objects():
 
 
 def validate_settings():
-    status_msg = "SublimeLinter - Settings invalid. Details in console."
+    status_msg = "SublimeLinter - Settings invalid!"
     schema_file = "resources/settings-schema.json"
     schema = util.load_json(schema_file, from_sl_dir=True)
 
@@ -97,9 +97,12 @@ def validate_settings():
         try:
             validate(settings, schema)
         except ValidationError as ve:
-            ve_msg = ve.message.split("\n")[0]  # reduce verbosity
-            util.printf("Settings in '{}' invalid:\n{}".format(name, ve_msg))
-            sublime.active_window().status_message(status_msg)
             good = False
+            ve_msg = ve.message.split("\n")[0]  # reduce verbosity
+            full_msg = "Invalid settings in '{}':\n{}".format(name, ve_msg)
+            window = sublime.active_window()
 
+            util.printf(full_msg)
+            window.status_message(status_msg)
+            window.active_view().run_command("sublime_linter_display_panel", {"msg": full_msg})
     return good

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -92,7 +92,7 @@ def validate_settings():
     schema_file = "resources/settings-schema.json"
     schema = util.load_json(schema_file, from_sl_dir=True)
     window = sublime.active_window()
-    window.active_view().run_command("sublime_linter_remove_panel")
+    util.clear_message()
     good = True
 
     for name, settings in get_settings_objects():
@@ -104,6 +104,6 @@ def validate_settings():
             full_msg = "Invalid settings in '{}':\n{}".format(name, error_msg)
 
             util.printf(full_msg)
+            util.message(full_msg)
             window.status_message(status_msg)
-            window.active_view().run_command("sublime_linter_display_panel", {"msg": full_msg})
     return good

--- a/lint/util.py
+++ b/lint/util.py
@@ -347,9 +347,9 @@ def popen(cmd, stdout=None, stderr=None, output_stream=STREAM_BOTH, env=None, cw
             cwd=cwd,
         )
     except Exception as err:
-        printf('ERROR: could not launch', repr(cmd))
-        printf('reason:', str(err))
-        printf('PATH:', env.get('PATH', ''))
+        msg = 'ERROR: could not launch ' + repr(cmd) + '\nReason: ' + str(err) + '\nPATH: ' + env.get('PATH', '')
+        printf(msg)
+        message(msg)
 
 
 # view utils

--- a/lint/util.py
+++ b/lint/util.py
@@ -26,14 +26,14 @@ def printf(*args):
 
 
 def message(message):
-    view = sublime.active_window().active_view()
+    window = sublime.active_window()
     msg = 'SublimeLinter: ' + message
-    view.run_command("sublime_linter_display_panel", {"msg": msg})
+    window.run_command("sublime_linter_display_panel", {"msg": msg})
 
 
 def clear_message():
     window = sublime.active_window()
-    window.active_view().run_command("sublime_linter_remove_panel")
+    window.run_command("sublime_linter_remove_panel")
 
 
 def get_syntax(view):

--- a/lint/util.py
+++ b/lint/util.py
@@ -25,6 +25,17 @@ def printf(*args):
     print()
 
 
+def message(message):
+    view = sublime.active_window().active_view()
+    msg = 'SublimeLinter: ' + message
+    view.run_command("sublime_linter_display_panel", {"msg": msg})
+
+
+def clear_message():
+    window = sublime.active_window()
+    window.active_view().run_command("sublime_linter_remove_panel")
+
+
 def get_syntax(view):
     """
     Return the view's syntax.

--- a/message_view.py
+++ b/message_view.py
@@ -7,7 +7,6 @@ PANEL_NAME = "SublimeLinter Messages"
 class SublimeLinterDisplayPanelCommand(sublime_plugin.WindowCommand):
     def run(self, msg=""):
         panel_view = sublime.active_window().create_output_panel(PANEL_NAME, True)
-        panel_view.set_read_only(False)
         panel_view.run_command('append', {'characters': msg})
         panel_view.set_read_only(True)
         panel_view.show(0)

--- a/message_view.py
+++ b/message_view.py
@@ -6,7 +6,7 @@ PANEL_NAME = "SublimeLinter Messages"
 
 class SublimeLinterDisplayPanelCommand(sublime_plugin.TextCommand):
     def run(self, edit, msg=""):
-        panel_view = sublime.active_window().create_output_panel(PANEL_NAME)
+        panel_view = sublime.active_window().create_output_panel(PANEL_NAME, True)
         panel_view.set_read_only(False)
         panel_view.erase(edit, sublime.Region(0, panel_view.size()))
         panel_view.insert(edit, 0, msg)

--- a/message_view.py
+++ b/message_view.py
@@ -5,13 +5,13 @@ PANEL_NAME = "SublimeLinter Messages"
 
 class SublimeLinterDisplayPanelCommand(sublime_plugin.WindowCommand):
     def run(self, msg=""):
-        panel_view = sublime.active_window().create_output_panel(PANEL_NAME, True)
+        panel_view = self.window.create_output_panel(PANEL_NAME, True)
         panel_view.run_command('append', {'characters': msg})
         panel_view.set_read_only(True)
         panel_view.show(0)
-        sublime.active_window().run_command("show_panel", {"panel": "output.{}".format(PANEL_NAME)})
+        self.window.run_command("show_panel", {"panel": "output.{}".format(PANEL_NAME)})
 
 
 class SublimeLinterRemovePanelCommand(sublime_plugin.WindowCommand):
     def run(self):
-        sublime.active_window().destroy_output_panel(PANEL_NAME)
+        self.window.destroy_output_panel(PANEL_NAME)

--- a/message_view.py
+++ b/message_view.py
@@ -4,17 +4,16 @@ import sublime_plugin
 PANEL_NAME = "SublimeLinter Messages"
 
 
-class SublimeLinterDisplayPanelCommand(sublime_plugin.TextCommand):
-    def run(self, edit, msg=""):
+class SublimeLinterDisplayPanelCommand(sublime_plugin.WindowCommand):
+    def run(self, msg=""):
         panel_view = sublime.active_window().create_output_panel(PANEL_NAME, True)
         panel_view.set_read_only(False)
-        panel_view.erase(edit, sublime.Region(0, panel_view.size()))
-        panel_view.insert(edit, 0, msg)
+        panel_view.run_command('append', {'characters': msg})
         panel_view.set_read_only(True)
         panel_view.show(0)
         sublime.active_window().run_command("show_panel", {"panel": "output.{}".format(PANEL_NAME)})
 
 
-class SublimeLinterRemovePanelCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
+class SublimeLinterRemovePanelCommand(sublime_plugin.WindowCommand):
+    def run(self):
         sublime.active_window().destroy_output_panel(PANEL_NAME)

--- a/message_view.py
+++ b/message_view.py
@@ -1,4 +1,3 @@
-import sublime
 import sublime_plugin
 
 PANEL_NAME = "SublimeLinter Messages"

--- a/message_view.py
+++ b/message_view.py
@@ -1,0 +1,15 @@
+import sublime
+import sublime_plugin
+
+PANEL_NAME = "SublimeLinter Messages"
+
+
+class SublimeLinterDisplayPanelCommand(sublime_plugin.TextCommand):
+    def run(self, edit, msg=""):
+        panel_view = sublime.active_window().create_output_panel(PANEL_NAME)
+        panel_view.set_read_only(False)
+        panel_view.erase(edit, sublime.Region(0, panel_view.size()))
+        panel_view.insert(edit, 0, msg)
+        panel_view.set_read_only(True)
+        panel_view.show(0)
+        sublime.active_window().run_command("show_panel", {"panel": "output.{}".format(PANEL_NAME)})

--- a/message_view.py
+++ b/message_view.py
@@ -13,3 +13,8 @@ class SublimeLinterDisplayPanelCommand(sublime_plugin.TextCommand):
         panel_view.set_read_only(True)
         panel_view.show(0)
         sublime.active_window().run_command("show_panel", {"panel": "output.{}".format(PANEL_NAME)})
+
+
+class SublimeLinterRemovePanelCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        sublime.active_window().destroy_output_panel(PANEL_NAME)


### PR DESCRIPTION
fixes #895, #958

Creates an output panel to have more visual feedback that settings are invalid, and also include information about what's wrong.
Removes the panel when settings are valid (i.e. removes it before checking again).
The increased feedback also helps notifying the user about broken settings during load.