### PR TITLE
do something about invalid settings on load

### DIFF
--- a/lint/settings.py
+++ b/lint/settings.py
@@ -12,6 +12,7 @@ class Settings:
 
     def load(self):
         """Load the plugin settings."""
+        validate_settings()
         self.observe()
         self.on_update()
 


### PR DESCRIPTION
I'm not sure it's actually feasible to check the user settings on load. We depend on the ST api which merges the settings immediately, so we can't really use our own defaults if the settings fail. I think. Perhaps someone else has a better idea. The least we can however, is message to the user, so this PR offers that. In combination with #959, at least the user will be aware of his mistake which is essentially what this is about: help the user fix his configuration. If the user repairs his settings, SL should recover and continue working again, so there may not even be a reason to make this more complicated.