### PR TITLE
Iterate on controller/queue/backend integration

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -886,7 +886,7 @@ class Linter(metaclass=LinterMeta):
 
         - Get the command line.
         - Run the linter.
-        - If the view has been modified since the original hit_time, stop.
+        - If the view has been modified in between, stop.
         - Parse the linter output with the regex.
         """
         # We 'name' our threads, for logging purposes.

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -879,7 +879,7 @@ class Linter(metaclass=LinterMeta):
         else:
             return self.default_type
 
-    def lint(self, code, hit_time, settings, task_name):
+    def lint(self, code, view_has_changed, settings, task_name):
         """Perform the lint, retrieve the results, and add marks to the view.
 
         The flow of control is as follows:
@@ -921,7 +921,7 @@ class Linter(metaclass=LinterMeta):
             return []
 
         # If the view has been modified since the lint was triggered, no point in continuing.
-        if hit_time and persist.last_hit_times.get(self.view.id(), 0) > hit_time:
+        if view_has_changed():
             return None  # ABORT
 
         if logger.isEnabledFor(logging.INFO):

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -24,12 +24,6 @@ if 'plugin_is_loaded' not in globals():
     # A mapping between view ids and views
     views = {}
 
-    # Every time a view is modified, this is updated with a mapping between a view id
-    # and the time of the modification. This is checked at various stages of the linting
-    # process. If a view has been modified since the original modification, the
-    # linting process stops.
-    last_hit_times = {}
-
     edits = defaultdict(list)
 
     # Whether sys.path has been imported from the system.

--- a/lint/queue.py
+++ b/lint/queue.py
@@ -9,12 +9,12 @@ timers = {}
 
 
 def hit(view, callback):
-    vid = view.id()
     delay = get_delay()  # [seconds]
-    return _queue_lint(vid, delay, callback)
+    return _queue_lint(view, delay, callback)
 
 
-def _queue_lint(vid, delay, callback):  # <-serial execution
+def _queue_lint(view, delay, callback):  # <-serial execution
+    vid = view.id()
     hit_time = time.monotonic()
 
     try:
@@ -22,7 +22,7 @@ def _queue_lint(vid, delay, callback):  # <-serial execution
     except KeyError:
         pass
 
-    timers[vid] = timer = threading.Timer(delay, lambda: callback(vid, hit_time))
+    timers[vid] = timer = threading.Timer(delay, lambda: callback(view, hit_time))
     timer.start()
 
     return hit_time

--- a/lint/queue.py
+++ b/lint/queue.py
@@ -7,13 +7,11 @@ import threading
 timers = {}
 
 
-def hit(view, callback):
-    delay = get_delay()  # [seconds]
-    debounce(callback, delay, key=view.id())
-
-
-def debounce(callback, delay, key=None):
+def debounce(callback, delay=None, key=None):
+    if delay is None:
+        delay = get_delay()
     key = key or callback
+
     try:
         timers[key].cancel()
     except KeyError:

--- a/lint/queue.py
+++ b/lint/queue.py
@@ -1,7 +1,5 @@
 from . import persist
 
-from functools import partial
-import time
 import threading
 
 
@@ -11,10 +9,7 @@ timers = {}
 
 def hit(view, callback):
     delay = get_delay()  # [seconds]
-    hit_time = time.monotonic()
-
-    debounce(partial(callback, view, hit_time), delay, key=view.id())
-    return hit_time
+    debounce(callback, delay, key=view.id())
 
 
 def debounce(callback, delay, key=None):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -219,7 +219,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         util.apply_to_all_views(apply)
 
-    def lint(self, view_id, hit_time=None):
+    def lint(self, view, hit_time=None):
         """Lint the view with the given id.
 
         This method is called asynchronously by queue.Daemon when a lint
@@ -231,11 +231,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         another lint request is already in the queue.
         """
         # If this is not the latest 'hit' we're processing abort early.
-        if hit_time and persist.last_hit_times.get(view_id, 0) > hit_time:
-            return
-
-        view = persist.views.get(view_id)
-        if not view:
+        if hit_time and persist.last_hit_times.get(view.id(), 0) > hit_time:
             return
 
         events.broadcast(events.LINT_START, {'buffer_id': view.buffer_id()})
@@ -251,14 +247,9 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         This method is called by Linter.lint_view after linting is finished.
         """
-        if not view:
-            return
-
-        vid = view.id()
-
         # If the view has been modified since the lint was triggered,
         # don't draw marks.
-        if hit_time and persist.last_hit_times.get(vid, 0) > hit_time:
+        if hit_time and persist.last_hit_times.get(view.id(), 0) > hit_time:
             return
 
         bid = view.buffer_id()

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -274,7 +274,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         self.linted_views.add(vid)
 
         hit_time = time.monotonic()
-        queue.hit(view, partial(self.lint, view, hit_time))
+        queue.debounce(partial(self.lint, view, hit_time), key=view.id())
         persist.last_hit_times[vid] = hit_time
 
     def check_syntax(self, view):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -2,8 +2,9 @@
 
 from functools import partial
 import logging
-import os
 import html
+import os
+import time
 
 import sublime
 import sublime_plugin
@@ -272,7 +273,9 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         self.check_syntax(view)
         self.linted_views.add(vid)
 
-        persist.last_hit_times[vid] = queue.hit(view, self.lint)
+        hit_time = time.monotonic()
+        queue.hit(view, partial(self.lint, view, hit_time))
+        persist.last_hit_times[vid] = hit_time
 
     def check_syntax(self, view):
         """

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -218,6 +218,18 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         util.apply_to_all_views(apply)
 
+    def hit(self, view):
+        """Record an activity that could trigger a lint and enqueue a desire to lint."""
+        if not view:
+            return
+
+        vid = view.id()
+        self.check_syntax(view)
+        self.linted_views.add(vid)
+
+        view_has_changed = make_view_has_changed_fn(view)
+        queue.debounce(partial(self.lint, view, view_has_changed), key=view.id())
+
     def lint(self, view, view_has_changed):
         """Lint the view with the given id.
 
@@ -253,18 +265,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
             'linter_name': linter.name,
             'errors': errors
         })
-
-    def hit(self, view):
-        """Record an activity that could trigger a lint and enqueue a desire to lint."""
-        if not view:
-            return
-
-        vid = view.id()
-        self.check_syntax(view)
-        self.linted_views.add(vid)
-
-        view_has_changed = make_view_has_changed_fn(view)
-        queue.debounce(partial(self.lint, view, view_has_changed), key=view.id())
 
     def check_syntax(self, view):
         """


### PR DESCRIPTION
- Factor proper debounce function which can be reused
- Exchange 'hit_time' with 'change_count' - #758 
- Exchange 'view_id' with 'buffer_id' (not completely!) - #838 

Fixes #838 
Fixes #758 