### PR TITLE
Stable sort for highlights and panel view

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -120,7 +120,10 @@ def filter_errors(errors, group_fn):
 
     filtered_errors = []
     for errors in grouped.values():
-        head = sorted(errors, key=lambda e: (-e['priority'], e['error_type']))[0]
+        head = sorted(
+            errors,
+            key=lambda e: (-e['priority'], e['error_type'], e['linter'])
+        )[0]
         filtered_errors.append(head)
 
     return filtered_errors

--- a/panel_view.py
+++ b/panel_view.py
@@ -193,7 +193,8 @@ def ensure_panel(window: sublime.Window):
 
 
 def sort_errors(errors):
-    return sorted(errors, key=lambda x: (x["line"], x["start"], x["end"]))
+    return sorted(
+        errors, key=lambda e: (e["line"], e["start"], e["end"], e["linter"]))
 
 
 def filter_and_sort(buf_errors, panel_filter):


### PR DESCRIPTION
Fixes #979 

Sorting by `error['linter']` reduces redraws/flicker. 