### PR TITLE
Refactor `Linter.assign` and remove cruft

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -168,10 +168,11 @@ class LinterMeta(type):
     def register_linter(cls, name):
         """Add a linter class to our mapping of class names <-> linter classes."""
         name = name.lower()
+        reloading = name in persist.linter_classes
         persist.linter_classes[name] = cls
 
         # The sublime plugin API is not available until plugin_loaded is executed
-        if persist.plugin_is_loaded:
+        if reloading:
             persist.settings.load()
 
             for view in persist.views.values():

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -162,11 +162,6 @@ class LinterMeta(type):
             if 'defaults' in attrs and attrs['defaults']:
                 cls.map_args(attrs['defaults'])
 
-            if persist.plugin_is_loaded:
-                # If the plugin has already loaded, then we get here because
-                # a linter was added or reloaded. In that case we run reinitialize.
-                cls.reinitialize()
-
             if 'syntax' in attrs and name not in BASE_CLASSES:
                 cls.register_linter(name)
 
@@ -350,28 +345,6 @@ class Linter(metaclass=LinterMeta):
     #
     disabled = False
     executable_version = None
-
-    @classmethod
-    def initialize(cls):
-        """
-        Perform class-level initialization.
-
-        If subclasses override this, they should call super().initialize() first.
-
-        """
-        pass
-
-    @classmethod
-    def reinitialize(cls):
-        """
-        Perform class-level initialization after plugins have been loaded at startup.
-
-        This occurs if a new linter plugin is added or reloaded after startup.
-        Subclasses may override this to provide custom behavior, then they must
-        call cls.initialize().
-
-        """
-        cls.initialize()
 
     def __init__(self, view, syntax):  # noqa: D107
         self.view = view

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -118,7 +118,6 @@ class LinterMeta(type):
             if name in ('PythonLinter', 'RubyLinter', 'NodeLinter', 'ComposerLinter'):
                 return
 
-            cls.alt_name = cls.make_alt_name(name)
             cmd = attrs.get('cmd')
 
             if isinstance(cmd, str):
@@ -209,21 +208,6 @@ class LinterMeta(type):
             cls.defaults[name] = value
 
         setattr(cls, 'args_map', args_map)
-
-    @staticmethod
-    def make_alt_name(name):
-        """Convert and return a camel-case name to lowercase with dashes."""
-        previous = name[0]
-        alt_name = previous.lower()
-
-        for c in name[1:]:
-            if c.isupper() and previous.islower():
-                alt_name += '-'
-
-            alt_name += c.lower()
-            previous = c
-
-        return alt_name
 
     @property
     def name(cls):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
 NEAR_RE_TEMPLATE = r'(?<!"){}({}){}(?!")'
-BASE_CLASSES = ('PythonLinter',)
+BASE_CLASSES = ('PythonLinter', 'RubyLinter', 'NodeLinter', 'ComposerLinter')
 
 # Many linters use stdin, and we convert text to utf-8
 # before sending to stdin, so we have to make sure stdin
@@ -115,7 +115,7 @@ class LinterMeta(type):
         if bases:
             setattr(cls, 'disabled', False)
 
-            if name in ('PythonLinter', 'RubyLinter', 'NodeLinter', 'ComposerLinter'):
+            if name in BASE_CLASSES:
                 return
 
             cmd = attrs.get('cmd')
@@ -162,7 +162,7 @@ class LinterMeta(type):
             if 'defaults' in attrs and attrs['defaults']:
                 cls.map_args(attrs['defaults'])
 
-            if 'syntax' in attrs and name not in BASE_CLASSES:
+            if 'syntax' in attrs:
                 cls.register_linter(name)
 
     def register_linter(cls, name):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -209,11 +209,6 @@ class LinterMeta(type):
 
         setattr(cls, 'args_map', args_map)
 
-    @property
-    def name(cls):
-        """Return the class name lowercased."""
-        return cls.__name__.lower()
-
 
 class Linter(metaclass=LinterMeta):
     """

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -169,25 +169,21 @@ class LinterMeta(type):
                 cls.reinitialize()
 
             if 'syntax' in attrs and name not in BASE_CLASSES:
-                cls.register_linter(name, attrs)
+                cls.register_linter(name)
 
-    def register_linter(cls, name, attrs):
+    def register_linter(cls, name):
         """Add a linter class to our mapping of class names <-> linter classes."""
-        if name:
-            name = name.lower()
-            persist.linter_classes[name] = cls
+        name = name.lower()
+        persist.linter_classes[name] = cls
 
-            # The sublime plugin API is not available until plugin_loaded is executed
-            if persist.plugin_is_loaded:
-                persist.settings.load()
+        # The sublime plugin API is not available until plugin_loaded is executed
+        if persist.plugin_is_loaded:
+            persist.settings.load()
 
-                for view in persist.views.values():
-                    cls.assign(view)
+            for view in persist.views.values():
+                cls.assign(view)
 
-                logger.info('{} linter reloaded'.format(name))
-
-            else:
-                logger.info('{} linter loaded'.format(name))
+            logger.info('{} linter reloaded'.format(name))
 
     def map_args(cls, defaults):
         """

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -106,9 +106,7 @@ class LinterMeta(type):
 
         - Compile regex patterns.
         - Convert strings to tuples where necessary.
-        - Add a leading dot to the tempfile_suffix if necessary.
         - Build a map between defaults and linter arguments.
-        - Add '@python' as an inline setting to PythonLinter subclasses.
 
         Finally, the class is registered as a linter for its configured syntax.
         """

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -6,26 +6,22 @@ from .util import printf
 from .settings import Settings
 
 
-if 'plugin_is_loaded' not in globals():
-    settings = Settings()
+settings = Settings()
 
-    scheme = None
+scheme = None
 
-    # A mapping between buffer ids and errors,
-    # Dict[buffer_id, [error]]
-    errors = defaultdict(list)
+# A mapping between buffer ids and errors,
+# Dict[buffer_id, [error]]
+errors = defaultdict(list)
 
-    # A mapping between linter class names and linter classes
-    linter_classes = {}
+# A mapping between linter class names and linter classes
+linter_classes = {}
 
-    # A mapping between view ids and a set of linter instances
-    view_linters = {}
+# A mapping between view ids and a set of linter instances
+view_linters = {}
 
-    # A mapping between view ids and views
-    views = {}
-
-    # Set to true when the plugin is loaded at startup
-    plugin_is_loaded = False
+# A mapping between view ids and views
+views = {}
 
 
 def debug_mode():

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -8,8 +8,6 @@ from .settings import Settings
 
 settings = Settings()
 
-scheme = None
-
 # A mapping between buffer ids and errors,
 # Dict[buffer_id, [error]]
 errors = defaultdict(list)

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -24,21 +24,8 @@ if 'plugin_is_loaded' not in globals():
     # A mapping between view ids and views
     views = {}
 
-    edits = defaultdict(list)
-
-    # Whether sys.path has been imported from the system.
-    sys_path_imported = False
-
     # Set to true when the plugin is loaded at startup
     plugin_is_loaded = False
-
-
-def edit(vid, edit):
-    """Perform an operation on a view with the given edit object."""
-    callbacks = edits.pop(vid, [])
-
-    for c in callbacks:
-        c(edit)
 
 
 def debug_mode():

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -51,9 +51,6 @@ def plugin_loaded():
     style.load_gutter_icons()
     style.StyleParser()()
 
-    for linter in persist.linter_classes.values():
-        linter.initialize()
-
     plugin = SublimeLinter.shared_plugin()
 
     # Lint the visible views from the active window on startup

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -246,7 +246,7 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
             self.view_syntax[vid] = syntax
             self.linted_views.discard(vid)
-            Linter.assign(view, reset=True)
+            Linter.assign(view)
             return True
         else:
             return False

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -44,7 +44,6 @@ def plugin_loaded():
     log_handler.install()
     backup_old_settings()
 
-    persist.plugin_is_loaded = True
     persist.settings.load()
     logger.info("debug mode: on")
     logger.info("version: " + util.get_sl_version())


### PR DESCRIPTION
Basically simplify `assign`and `register_linter`

**Important**: **Removes** `initialize` and `reinitialize`, which nobody implemented (if I checked correctly). (We used it for RubyLinter.)