### PR TITLE
User defined syntaxes

### DIFF
--- a/docs/linter_methods.rst
+++ b/docs/linter_methods.rst
@@ -33,19 +33,6 @@ this method does the following:
 - Adds the name/value pair to *options*.
 
 
-can_lint_syntax
----------------
-.. code-block:: python
-
-   can_lint_syntax(cls, syntax)
-
-This method returns ``True`` if a linter can lint a given syntax.
-
-Subclasses may override this if the built in mechanism in the ``can_lint`` method is not sufficient.
-When this method is called, ``cls.executable_path`` has been set to the path of the linter executable.
-If it is ``''``, that means the executable was not specified or could not be found.
-
-
 cmd
 ---
 .. code-block:: python

--- a/lint/base_linter/composer_linter.py
+++ b/lint/base_linter/composer_linter.py
@@ -4,7 +4,6 @@ import json
 import hashlib
 import codecs
 
-from functools import lru_cache
 from os import path, access, X_OK
 from .. import linter, util
 
@@ -176,24 +175,6 @@ class ComposerLinter(linter.Linter):
         return hashlib.sha1(f.read().encode('utf-8')).hexdigest()
 
     @classmethod
-    @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
-        """
-        Determine if the linter can handle the provided syntax.
-
-        This is an optimistic determination based on the linter's syntax alone.
-        """
-        can = False
-        syntax = syntax.lower()
-
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
-            else:
-                can = cls.syntax.match(syntax) is not None
-
-        return can
+    def can_lint(cls):
+        """Assume the linter can lint."""
+        return True

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -7,7 +7,6 @@ import os
 
 import sublime
 
-from functools import lru_cache
 from .. import linter, util
 
 
@@ -171,24 +170,6 @@ class NodeLinter(linter.Linter):
         return hashlib.sha1(f.read().encode('utf-8')).hexdigest()
 
     @classmethod
-    @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
-        """
-        Determine if the linter can handle the provided syntax.
-
-        This is an optimistic determination based on the linter's syntax alone.
-        """
-        can = False
-        syntax = syntax.lower()
-
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
-            else:
-                can = cls.syntax.match(syntax) is not None
-
-        return can
+    def can_lint(cls):
+        """Assume the linter can lint."""
+        return True

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -39,23 +39,9 @@ class PythonLinter(linter.Linter):
     """
 
     @classmethod
-    @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
-        """Determine optimistically if the linter can handle the provided syntax."""
-        can = False
-        syntax = syntax.lower()
-
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
-            else:
-                can = cls.syntax.match(syntax) is not None
-
-        return can
+    def can_lint(cls):
+        """Assume the linter can lint."""
+        return True
 
     def context_sensitive_executable_path(self, cmd):
         """Try to find an executable for a given cmd."""

--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -6,8 +6,6 @@ import re
 import shlex
 import sublime
 
-from functools import lru_cache
-
 from .. import linter, util
 
 
@@ -29,23 +27,9 @@ class RubyLinter(linter.Linter):
     """
 
     @classmethod
-    @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
-        """Determine optimistically if the linter can handle the provided syntax."""
-        can = False
-        syntax = syntax.lower()
-
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
-            else:
-                can = cls.syntax.match(syntax) is not None
-
-        return can
+    def can_lint(cls):
+        """Assume the linter can lint."""
+        return True
 
     def context_sensitive_executable_path(self, cmd):
         """

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1013,13 +1013,14 @@ class Linter(metaclass=LinterMeta):
         if cls.syntax == '*':
             return True
 
-        if hasattr(cls.syntax, 'match'):
+        if hasattr(cls.syntax, 'match'):  # duck type for regex
             return cls.syntax.match(syntax) is not None
 
         syntaxes = (
             [cls.syntax] if isinstance(cls.syntax, str)
             else list(cls.syntax)
-        )
+        ) + cls._get_settings(cls, view.window()).get('syntaxes', [])
+
         return syntax in syntaxes
 
     @classmethod

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -113,10 +113,12 @@ class LinterMeta(type):
         if not bases:
             return
 
-        setattr(cls, 'disabled', False)
-
         if name in BASE_CLASSES:
             return
+
+        name = name.lower()
+        setattr(cls, 'disabled', False)
+        setattr(cls, 'name', name)
 
         cmd = attrs.get('cmd')
 
@@ -131,7 +133,7 @@ class LinterMeta(type):
         except re.error as err:
             logger.error(
                 '{} disabled, error compiling syntax: {}'
-                .format(name.lower(), str(err))
+                .format(name, str(err))
             )
             setattr(cls, 'disabled', True)
 
@@ -148,13 +150,13 @@ class LinterMeta(type):
                     except re.error as err:
                         logger.error(
                             '{} disabled, error compiling {}: {}'
-                            .format(name.lower(), regex, str(err))
+                            .format(name, regex, str(err))
                         )
                         setattr(cls, 'disabled', True)
 
         if not cls.disabled:
             if not cls.syntax or (cls.cmd is not None and not cls.cmd) or not cls.regex:
-                logger.error('{} disabled, not fully implemented'.format(name.lower()))
+                logger.error('{} disabled, not fully implemented'.format(name))
                 setattr(cls, 'disabled', True)
 
         # If this class has its own defaults, create an args_map.
@@ -167,7 +169,6 @@ class LinterMeta(type):
 
     def register_linter(cls, name):
         """Add a linter class to our mapping of class names <-> linter classes."""
-        name = name.lower()
         reloading = name in persist.linter_classes
         persist.linter_classes[name] = cls
 
@@ -359,11 +360,6 @@ class Linter(metaclass=LinterMeta):
     def filename(self):
         """Return the view's file path or '' if unsaved."""
         return self.view.file_name() or ''
-
-    @property
-    def name(self):
-        """Return the class name lowercased."""
-        return self.__class__.__name__.lower()
 
     @staticmethod
     def _get_settings(linter, window=None):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1018,7 +1018,6 @@ class Linter(metaclass=LinterMeta):
         2. If the linter uses an external executable, it must be available.
         3. If there is a version requirement and the executable is available,
            its version must fulfill the requirement.
-        4. can_lint_syntax must return True.
         """
         can = False
         syntax = syntax.lower()
@@ -1057,35 +1056,15 @@ class Linter(metaclass=LinterMeta):
 
             status = None
 
+            if cls.executable_path == '':
+                status = '{} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
+                logger.warning(status)
+                return False
+
             if cls.executable_path:
                 can = cls.fulfills_version_requirement()
 
-                if not can:
-                    status = ''  # Warning was already printed
-
-            if can:
-                can = cls.can_lint_syntax(syntax)
-
-            elif status is None:
-                status = '{} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
-
-            if status:
-                logger.warning(status)
-
         return can
-
-    @classmethod
-    def can_lint_syntax(cls, syntax):
-        """
-        Return whether a linter can lint a given syntax.
-
-        Subclasses may override this if the built in mechanism in can_lint
-        is not sufficient. When this method is called, cls.executable_path
-        has been set. If it is '', that means the executable was not specified
-        or could not be found.
-
-        """
-        return cls.executable_path != ''
 
     @classmethod
     def fulfills_version_requirement(cls):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -482,8 +482,8 @@ class Linter(metaclass=LinterMeta):
             for linter_class in persist.linter_classes.values()
             if (
                 not linter_class.disabled and
-                syntax and
-                linter_class.can_lint(syntax)
+                linter_class.can_lint_view(view) and
+                linter_class.can_lint()
             )
         }
 
@@ -1004,65 +1004,71 @@ class Linter(metaclass=LinterMeta):
     # Helper methods
 
     @classmethod
+    def can_lint_view(cls, view):
+        syntax = util.get_syntax(view).lower()
+
+        if not syntax:
+            return False
+
+        if cls.syntax == '*':
+            return True
+
+        if hasattr(cls.syntax, 'match'):
+            return cls.syntax.match(syntax) is not None
+
+        syntaxes = (
+            [cls.syntax] if isinstance(cls.syntax, str)
+            else list(cls.syntax)
+        )
+        return syntax in syntaxes
+
+    @classmethod
     @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
+    def can_lint(cls, _syntax=None):  # `syntax` stays here for compatibility
         """
-        Determine if a linter class can lint the given syntax.
+        Determine *eager* if the linter plugin can be used.
 
         This method is called when a view has not had a linter assigned
         or when its syntax changes.
 
         The following tests must all pass for this method to return True:
 
-        1. syntax must match one of the syntaxes the linter defines.
-        2. If the linter uses an external executable, it must be available.
-        3. If there is a version requirement and the executable is available,
+        1. If the linter uses an external executable, it must be available.
+        2. If there is a version requirement and the executable is available,
            its version must fulfill the requirement.
         """
-        can = False
-        syntax = syntax.lower()
+        can = True
 
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
+        if cls.executable_path is None:
+            executable = None
+            cmd = cls.cmd
+
+            if cmd and not callable(cmd):
+                if isinstance(cls.cmd, str):
+                    cmd = shlex.split(cmd)
+                executable = cmd[0]
             else:
-                can = cls.syntax.match(syntax) is not None
+                executable = cls.executable
 
-        if can:
-            if cls.executable_path is None:
-                executable = None
-                cmd = cls.cmd
+            if not executable:
+                return True
 
-                if cmd and not callable(cmd):
-                    if isinstance(cls.cmd, str):
-                        cmd = shlex.split(cmd)
-                    executable = cmd[0]
-                else:
-                    executable = cls.executable
+            if executable:
+                cls.executable_path = cls.which(executable) or ''
+            elif cmd is None:
+                cls.executable_path = '<builtin>'
+            else:
+                cls.executable_path = ''
 
-                if not executable:
-                    return True
+        status = None
 
-                if executable:
-                    cls.executable_path = cls.which(executable) or ''
-                elif cmd is None:
-                    cls.executable_path = '<builtin>'
-                else:
-                    cls.executable_path = ''
+        if cls.executable_path == '':
+            status = '{} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
+            logger.warning(status)
+            return False
 
-            status = None
-
-            if cls.executable_path == '':
-                status = '{} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
-                logger.warning(status)
-                return False
-
-            if cls.executable_path:
-                can = cls.fulfills_version_requirement()
+        if cls.executable_path:
+            can = cls.fulfills_version_requirement()
 
         return can
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -348,7 +348,7 @@ class Linter(metaclass=LinterMeta):
     disabled = False
     executable_version = None
 
-    def __init__(self, view, syntax):  # noqa: D107
+    def __init__(self, view, syntax):
         self.view = view
         self.syntax = syntax
         # Using `self.env` is deprecated, bc it can have surprising


### PR DESCRIPTION
🌶 This allows to extend the syntax a linter plugin might support. Since we all know, eslint can basically lint everything. A user can e.g. define
 ```
eslint: {syntaxes: ['php', 'coffeescript', 'python', 'rust', 'java']}
```

in the global or project settings.

**Notable**: **Removed** `can_lint_syntax` API which was again unused by the community.