### PR TITLE
Less error panels

### DIFF
--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -82,7 +82,7 @@ class PythonLinter(linter.Linter):
             if VERSION_RE.match(python):
                 python_bin = find_python_version(python)
                 if python_bin is None:
-                    logger.warning(
+                    logger.error(
                         "{} deactivated, cannot locate '{}' "
                         "for given python '{}'"
                         .format(self.name, cmd_name, python)
@@ -98,7 +98,7 @@ class PythonLinter(linter.Linter):
 
             else:
                 if not os.path.exists(python):
-                    logger.warning(
+                    logger.error(
                         "{} deactivated, cannot locate '{}'"
                         .format(self.name, python)
                     )

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -759,7 +759,7 @@ class Linter(metaclass=LinterMeta):
             if os.path.isdir(cwd):
                 return cwd
             else:
-                logger.warning(
+                logger.error(
                     "{}: wanted working_dir '{}' is not a directory"
                     "".format(self.name, cwd)
                 )

--- a/lint/log_handler.py
+++ b/lint/log_handler.py
@@ -7,16 +7,19 @@ from . import util
 DEBUG_FALSE_LEVEL = logging.WARNING
 DEBUG_TRUE_LEVEL = logging.INFO
 ERROR_PANEL_LEVEL = logging.ERROR
+STATUS_BAR_LEVEL = logging.WARNING
 
 logger = logging.getLogger('SublimeLinter')
 logger.setLevel(logging.DEBUG)
 handler = None
 error_panel_handler = None
+status_bar_handler = None
 
 
 def install():
     install_std_handler()
     install_error_panel_handler()
+    install_status_bar_handler()
 
     settings = sublime.load_settings("SublimeLinter.sublime-settings")
     settings.add_on_change('SublimeLinter._logging', install_std_handler)
@@ -27,6 +30,8 @@ def uninstall():
         logger.removeHandler(handler)
     if error_panel_handler:
         logger.removeHandler(error_panel_handler)
+    if status_bar_handler:
+        logger.removeHandler(status_bar_handler)
 
     settings = sublime.load_settings("SublimeLinter.sublime-settings")
     settings.clear_on_change('SublimeLinter._logging')
@@ -61,7 +66,7 @@ def install_std_handler():
 
     handler.setLevel(level)
     logger.addHandler(handler)
-    logger.setLevel(min(ERROR_PANEL_LEVEL, level))
+    logger.setLevel(min(ERROR_PANEL_LEVEL, STATUS_BAR_LEVEL, level))
     logger.info(
         'Logging installed; log level {}'.format(logging.getLevelName(level))
     )
@@ -81,6 +86,19 @@ def install_error_panel_handler():
     error_panel_handler.setLevel(ERROR_PANEL_LEVEL)
 
     logger.addHandler(error_panel_handler)
+
+
+def install_status_bar_handler():
+    global status_bar_handler
+    if status_bar_handler:
+        logger.removeHandler(status_bar_handler)
+
+    formatter = TaskNumberFormatter(fmt="SublimeLinter: {message}", style="{")
+    status_bar_handler = StatusBarHandler()
+    status_bar_handler.setFormatter(formatter)
+    status_bar_handler.setLevel(STATUS_BAR_LEVEL)
+
+    logger.addHandler(status_bar_handler)
 
 
 class TaskNumberFormatter(logging.Formatter):
@@ -110,5 +128,15 @@ class ErrorPanelHandler(logging.Handler):
         try:
             msg = self.format(record)
             util.message(msg)
+        except Exception:
+            self.handleError(record)
+
+
+class StatusBarHandler(logging.Handler):
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            window = sublime.active_window()
+            window.status_message(msg)
         except Exception:
             self.handleError(record)

--- a/lint/log_handler.py
+++ b/lint/log_handler.py
@@ -6,7 +6,7 @@ from . import util
 
 DEBUG_FALSE_LEVEL = logging.WARNING
 DEBUG_TRUE_LEVEL = logging.INFO
-ERROR_PANEL_LEVEL = logging.WARNING
+ERROR_PANEL_LEVEL = logging.ERROR
 
 logger = logging.getLogger('SublimeLinter')
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
- Show the panel only on errors
- Try to treat configuration errors where the user explicitly set something as errors. Treat all automatic stuff
(e.g. what we do or the plugin author chooses as a default) as warnings.
- Show warnings in the window (not view) status bar

Obviously, this stuff need time and tweaking to not annoy the user. But demoting the message panel, is IMO the right direction.