### PR TITLE
De-emphasize highlights while editing

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -28,7 +28,7 @@
     // Essentially picks a predicate fn from `highlights.py` to hide some
     // lint errors while editing (busy). These errors appear after
     // `time_to_idle` seconds or immediately on save.
-    "highlights.demote_while_editing": "ws_regions",
+    "highlights.demote_while_editing": "none",
 
     // Lint Modes determine when the linter is run
     // background: asynchronously on every change

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -21,6 +21,15 @@
     // to an icon in the theme (they usually include "warning" and "error")
     "gutter_theme": "none",
 
+    // EXPERIMENTAL: See below `demote_while_editing`.
+    "highlights.time_to_idle": 5,
+
+    // EXPERIMENTAL: One of 'none', 'some_ws', 'warnings'
+    // Essentially picks a predicate fn from `highlights.py` to hide some
+    // lint errors while editing (busy). These errors appear after
+    // `time_to_idle` seconds or immediately on save.
+    "highlights.demote_while_editing": "none",
+
     // Lint Modes determine when the linter is run
     // background: asynchronously on every change
     // load_save: when a file is opened and every time it's saved

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -24,11 +24,11 @@
     // EXPERIMENTAL: See below `demote_while_editing`.
     "highlights.time_to_idle": 5,
 
-    // EXPERIMENTAL: One of 'none', 'some_ws', 'warnings'
+    // EXPERIMENTAL: One of 'none', 'ws_regions', 'warnings'
     // Essentially picks a predicate fn from `highlights.py` to hide some
     // lint errors while editing (busy). These errors appear after
     // `time_to_idle` seconds or immediately on save.
-    "highlights.demote_while_editing": "none",
+    "highlights.demote_while_editing": "ws_regions",
 
     // Lint Modes determine when the linter is run
     // background: asynchronously on every change

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -31,6 +31,8 @@ UNDERLINE_STYLES = (
 
 SOME_WS = re.compile('\s')
 FALLBACK_MARK_STYLE = 'outline'
+
+WS_REGIONS = re.compile('(^\s+$|\n)')
 DEMOTE_WHILE_BUSY_MARKER = '%DWB%'
 
 highlight_store = style_stores.HighlightStyleStore()
@@ -107,7 +109,7 @@ def get_demote_predicate():
     if setting == 'none':
         return demote_nothing
 
-    if setting == 'some_ws':
+    if setting == 'ws_regions':
         return demote_ws_regions
 
     if setting == 'warnings':
@@ -119,7 +121,7 @@ def demote_nothing(*args, **kwargs):
 
 
 def demote_ws_regions(selected_text, **kwargs):
-    return bool(SOME_WS.search(selected_text))
+    return bool(WS_REGIONS.search(selected_text))
 
 
 def demote_warnings(selected_text, error_type, **kwargs):

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -16,7 +16,7 @@
         },
         "highlights.demote_while_editing":{
             "type":"string",
-            "pattern":"^(none|some_ws|warnings)$"
+            "pattern":"^(none|ws_regions|warnings)$"
         },
         "lint_mode":{
             "type":"string",

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -11,6 +11,13 @@
         "gutter_theme":{
             "type":"string"
         },
+        "highlights.time_to_idle":{
+            "type":"number"
+        },
+        "highlights.demote_while_editing":{
+            "type":"string",
+            "pattern":"^(none|some_ws|warnings)$"
+        },
         "lint_mode":{
             "type":"string",
             "pattern":"^(background|load_save|manual)$"


### PR DESCRIPTION
- Implement IdleViewController
- De-highlight some regions (none, warnings, ws_errors) while editing, these regions re-appear 'on idle', e.g. after x seconds, or after save
- De-highlight the word(s) under the cursor while editing, these region re-appear as soon as we get updates from the backend

Fixes #941 

