### PR TITLE
Choose linters based on selectors

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -17,8 +17,8 @@ class SublimeLinterLintCommand(sublime_plugin.TextCommand):
         """
         has_non_file_only_linter = False
 
-        vid = self.view.id()
-        linters = persist.view_linters.get(vid, [])
+        bid = self.view.buffer_id()
+        linters = persist.view_linters.get(bid, [])
 
         for lint in linters:
             if lint.tempfile_suffix != '-':

--- a/commands.py
+++ b/commands.py
@@ -32,5 +32,5 @@ class SublimeLinterLintCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         """Lint the current view."""
-        from .sublime_linter import SublimeLinter
-        SublimeLinter.shared_plugin().hit(self.view)
+        from . import sublime_linter
+        sublime_linter.hit(self.view)

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -119,17 +119,14 @@ def translate_lineno_and_column(errors, offset):
 def get_lint_regions(linters, view):
     syntax = util.get_syntax(view)
     for (linter, settings) in linters:
-        selectors = settings.get('selectors')
-        if selectors:
-            joined_selectors = '|'.join(selectors)
-
-            # Inspecting the first char mimics 'file type' matching
-            if view.score_selector(0, joined_selectors):
+        selector = settings.get('selector')
+        if selector:
+            # Inspecting just the first char is faster
+            if view.score_selector(0, selector):
                 yield linter, settings, [sublime.Region(0, view.size())]
             else:
                 yield linter, settings, [
-                    region
-                    for region in view.find_by_selector(joined_selectors)
+                    region for region in view.find_by_selector(selector)
                 ]
 
             continue

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -119,6 +119,16 @@ def translate_lineno_and_column(errors, offset):
 def get_lint_regions(linters, view):
     syntax = util.get_syntax(view)
     for (linter, settings) in linters:
+        selectors = settings.get('selectors', False)
+        if selectors:
+            for selector in selectors:
+                regions = view.find_by_selector(selector)
+                if regions:
+                    yield linter, settings, [region for region in regions]
+                    return
+            return
+
+        # legacy
         if (
             syntax not in linter.selectors and
             WILDCARD_SYNTAX not in linter.selectors

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -156,10 +156,10 @@ def get_selectors(linter, wanted_syntax):
 
 def get_linters(view):
     filename = view.file_name()
-    vid = view.id()
+    bid = view.buffer_id()
 
     enabled, disabled = [], []
-    for linter in persist.view_linters.get(vid, []):
+    for linter in persist.view_linters.get(bid, []):
         # First check to see if the linter can run in the current lint mode.
         if linter.tempfile_suffix == '-' and view.is_dirty():
             disabled.append(linter)

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -8,7 +8,7 @@ import logging
 import os
 import threading
 
-from . import persist, util
+from . import util
 
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ task_count = count(start=1)
 counter_lock = threading.Lock()
 
 
-def lint_view(view, view_has_changed, next):
+def lint_view(linters, view, view_has_changed, next):
     """
     Lint the given view.
 
@@ -39,14 +39,14 @@ def lint_view(view, view_has_changed, next):
     aggregated, and for each selector, if it occurs in sections,
     the corresponding section is linted as embedded code.
     """
-    linters, disabled_linters = get_linters(view)
+    enabled_linters, disabled_linters = filter_linters(linters, view)
 
     # The contract here is that we MUST fire 'updates' for every linter, so
     # that the views (status bar etc) actually update.
     for linter in disabled_linters:
         next(linter, [])
 
-    lint_tasks = get_lint_tasks(linters, view, view_has_changed)
+    lint_tasks = get_lint_tasks(enabled_linters, view, view_has_changed)
 
     run_concurrently(
         partial(run_tasks, tasks, next=partial(next, linter))
@@ -154,12 +154,11 @@ def get_selectors(linter, wanted_syntax):
             pass
 
 
-def get_linters(view):
+def filter_linters(linters, view):
     filename = view.file_name()
-    bid = view.buffer_id()
 
     enabled, disabled = [], []
-    for linter in persist.view_linters.get(bid, []):
+    for linter in linters:
         # First check to see if the linter can run in the current lint mode.
         if linter.tempfile_suffix == '-' and view.is_dirty():
             disabled.append(linter)

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -119,19 +119,19 @@ def translate_lineno_and_column(errors, offset):
 def get_lint_regions(linters, view):
     syntax = util.get_syntax(view)
     for (linter, settings) in linters:
-        selectors = settings.get('selectors', False)
+        selectors = settings.get('selectors')
         if selectors:
-            # Inspecting the first char mimics 'file type' matching
-            if any(view.score_selector(0, selector) for selector in selectors):
-                yield linter, settings, [sublime.Region(0, view.size())]
-                continue
+            joined_selectors = '|'.join(selectors)
 
-            # Now, search for embedded syntaxes
-            for selector in selectors:
-                regions = view.find_by_selector(selector)
-                if regions:
-                    yield linter, settings, [region for region in regions]
-                    break
+            # Inspecting the first char mimics 'file type' matching
+            if view.score_selector(0, joined_selectors):
+                yield linter, settings, [sublime.Region(0, view.size())]
+            else:
+                yield linter, settings, [
+                    region
+                    for region in view.find_by_selector(joined_selectors)
+                ]
+
             continue
 
         # Fallback using deprecated `cls.syntax` and `cls.selectors`

--- a/lint/base_linter/composer_linter.py
+++ b/lint/base_linter/composer_linter.py
@@ -4,7 +4,6 @@ import json
 import hashlib
 import codecs
 
-from functools import lru_cache
 from os import path, access, X_OK
 from .. import linter, util
 
@@ -176,24 +175,6 @@ class ComposerLinter(linter.Linter):
         return hashlib.sha1(f.read().encode('utf-8')).hexdigest()
 
     @classmethod
-    @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
-        """
-        Determine if the linter can handle the provided syntax.
-
-        This is an optimistic determination based on the linter's syntax alone.
-        """
-        can = False
-        syntax = syntax.lower()
-
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
-            else:
-                can = cls.syntax.match(syntax) is not None
-
-        return can
+    def can_lint(cls):
+        """Assume the linter can lint."""
+        return True

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -7,7 +7,6 @@ import os
 
 import sublime
 
-from functools import lru_cache
 from .. import linter, util
 
 
@@ -171,24 +170,6 @@ class NodeLinter(linter.Linter):
         return hashlib.sha1(f.read().encode('utf-8')).hexdigest()
 
     @classmethod
-    @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
-        """
-        Determine if the linter can handle the provided syntax.
-
-        This is an optimistic determination based on the linter's syntax alone.
-        """
-        can = False
-        syntax = syntax.lower()
-
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
-            else:
-                can = cls.syntax.match(syntax) is not None
-
-        return can
+    def can_lint(cls):
+        """Assume the linter can lint."""
+        return True

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -39,23 +39,9 @@ class PythonLinter(linter.Linter):
     """
 
     @classmethod
-    @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
-        """Determine optimistically if the linter can handle the provided syntax."""
-        can = False
-        syntax = syntax.lower()
-
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
-            else:
-                can = cls.syntax.match(syntax) is not None
-
-        return can
+    def can_lint(cls):
+        """Assume the linter can lint."""
+        return True
 
     def context_sensitive_executable_path(self, cmd):
         """Try to find an executable for a given cmd."""

--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -6,8 +6,6 @@ import re
 import shlex
 import sublime
 
-from functools import lru_cache
-
 from .. import linter, util
 
 
@@ -29,23 +27,9 @@ class RubyLinter(linter.Linter):
     """
 
     @classmethod
-    @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
-        """Determine optimistically if the linter can handle the provided syntax."""
-        can = False
-        syntax = syntax.lower()
-
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
-            else:
-                can = cls.syntax.match(syntax) is not None
-
-        return can
+    def can_lint(cls):
+        """Assume the linter can lint."""
+        return True
 
     def context_sensitive_executable_path(self, cmd):
         """

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1050,10 +1050,7 @@ class Linter(metaclass=LinterMeta):
     @lru_cache(maxsize=None)
     def can_lint(cls, _syntax=None):  # `syntax` stays here for compatibility
         """
-        Determine *eager* if the linter plugin can be used.
-
-        This method is called when a view has not had a linter assigned
-        or when its syntax changes.
+        Determine *eagerly* if a linter's 'executable' can run.
 
         The following tests must all pass for this method to return True:
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1017,7 +1017,6 @@ class Linter(metaclass=LinterMeta):
         2. If the linter uses an external executable, it must be available.
         3. If there is a version requirement and the executable is available,
            its version must fulfill the requirement.
-        4. can_lint_syntax must return True.
         """
         can = False
         syntax = syntax.lower()
@@ -1056,35 +1055,15 @@ class Linter(metaclass=LinterMeta):
 
             status = None
 
+            if cls.executable_path == '':
+                status = '{} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
+                logger.warning(status)
+                return False
+
             if cls.executable_path:
                 can = cls.fulfills_version_requirement()
 
-                if not can:
-                    status = ''  # Warning was already printed
-
-            if can:
-                can = cls.can_lint_syntax(syntax)
-
-            elif status is None:
-                status = '{} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
-
-            if status:
-                logger.warning(status)
-
         return can
-
-    @classmethod
-    def can_lint_syntax(cls, syntax):
-        """
-        Return whether a linter can lint a given syntax.
-
-        Subclasses may override this if the built in mechanism in can_lint
-        is not sufficient. When this method is called, cls.executable_path
-        has been set. If it is '', that means the executable was not specified
-        or could not be found.
-
-        """
-        return cls.executable_path != ''
 
     @classmethod
     def fulfills_version_requirement(cls):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -179,10 +179,6 @@ class LinterMeta(type):
         # The sublime plugin API is not available until plugin_loaded is executed
         if persist.api_ready:
             persist.settings.load()
-
-            for view in persist.views.values():
-                cls.assign(view)
-
             logger.info('{} linter reloaded'.format(name))
 
     def map_args(cls, defaults):
@@ -480,7 +476,6 @@ class Linter(metaclass=LinterMeta):
         logger.info("detected syntax: {}".format(syntax))
 
         vid = view.id()
-        persist.views[vid] = view
         old_classes = {
             linter.__class__
             for linter in persist.view_linters.get(vid, set())

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -164,9 +164,9 @@ class LinterMeta(type):
         if 'defaults' in attrs and attrs['defaults']:
             cls.map_args(attrs['defaults'])
 
-        if not cls.syntax and not cls.defaults.get('selectors'):
+        if not cls.syntax and not cls.defaults.get('selector'):
             logger.error(
-                "{} disabled, either 'syntax' or 'selectors' must be specified"
+                "{} disabled, either 'syntax' or 'selector' must be specified"
                 .format(name))
             setattr(cls, 'disabled', True)
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1018,17 +1018,16 @@ class Linter(metaclass=LinterMeta):
 
         return text
 
-    # Helper methods
-
     @classmethod
     def can_lint_view(cls, view):
-        selectors = cls._get_settings(cls, view.window()).get('selectors', False)
+        selectors = cls._get_settings(cls, view.window()).get('selectors')
         if selectors:
-            return any(view.score_selector(0, selector) or
-                       view.find_by_selector(selector)
-                       for selector in selectors)
+            return (
+                any(view.score_selector(0, selector) for selector in selectors) or
+                any(view.find_by_selector(selector) for selector in selectors)
+            )
 
-        # legacy
+        # Fallback using deprecated `cls.syntax`
         syntax = util.get_syntax(view).lower()
 
         if not syntax:

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -470,36 +470,6 @@ class Linter(metaclass=LinterMeta):
         return None
 
     @classmethod
-    def assign(cls, view):
-        """Assign linters to a view."""
-        syntax = util.get_syntax(view)
-        logger.info("detected syntax: {}".format(syntax))
-
-        vid = view.id()
-        old_classes = {
-            linter.__class__
-            for linter in persist.view_linters.get(vid, set())
-        }
-        new_classes = {
-            linter_class
-            for linter_class in persist.linter_classes.values()
-            if (
-                not linter_class.disabled and
-                linter_class.can_lint_view(view) and
-                linter_class.can_lint()
-            )
-        }
-
-        if old_classes != new_classes:
-            persist.view_linters[vid] = {
-                linter_class(view, syntax)
-                for linter_class in new_classes
-            }
-            return True
-
-        return False
-
-    @classmethod
     def which(cls, cmd):
         """Return full path to a given executable.
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -347,7 +347,7 @@ class Linter(metaclass=LinterMeta):
     disabled = False
     executable_version = None
 
-    def __init__(self, view, syntax):  # noqa: D107
+    def __init__(self, view, syntax):
         self.view = view
         self.syntax = syntax
         # Using `self.env` is deprecated, bc it can have surprising

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -985,12 +985,11 @@ class Linter(metaclass=LinterMeta):
 
     @classmethod
     def can_lint_view(cls, view):
-        selectors = cls._get_settings(cls, view.window()).get('selectors')
-        if selectors:
-            joined_selectors = '|'.join(selectors)
+        selector = cls._get_settings(cls, view.window()).get('selector')
+        if selector:
             return (
-                view.score_selector(0, joined_selectors) or
-                view.find_by_selector(joined_selectors)
+                view.score_selector(0, selector) or
+                view.find_by_selector(selector)
             )
 
         # Fallback using deprecated `cls.syntax`

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -481,8 +481,8 @@ class Linter(metaclass=LinterMeta):
             for linter_class in persist.linter_classes.values()
             if (
                 not linter_class.disabled and
-                syntax and
-                linter_class.can_lint(syntax)
+                linter_class.can_lint_view(view) and
+                linter_class.can_lint()
             )
         }
 
@@ -1003,65 +1003,71 @@ class Linter(metaclass=LinterMeta):
     # Helper methods
 
     @classmethod
+    def can_lint_view(cls, view):
+        syntax = util.get_syntax(view).lower()
+
+        if not syntax:
+            return False
+
+        if cls.syntax == '*':
+            return True
+
+        if hasattr(cls.syntax, 'match'):
+            return cls.syntax.match(syntax) is not None
+
+        syntaxes = (
+            [cls.syntax] if isinstance(cls.syntax, str)
+            else list(cls.syntax)
+        )
+        return syntax in syntaxes
+
+    @classmethod
     @lru_cache(maxsize=None)
-    def can_lint(cls, syntax):
+    def can_lint(cls, _syntax=None):  # `syntax` stays here for compatibility
         """
-        Determine if a linter class can lint the given syntax.
+        Determine *eager* if the linter plugin can be used.
 
         This method is called when a view has not had a linter assigned
         or when its syntax changes.
 
         The following tests must all pass for this method to return True:
 
-        1. syntax must match one of the syntaxes the linter defines.
-        2. If the linter uses an external executable, it must be available.
-        3. If there is a version requirement and the executable is available,
+        1. If the linter uses an external executable, it must be available.
+        2. If there is a version requirement and the executable is available,
            its version must fulfill the requirement.
         """
-        can = False
-        syntax = syntax.lower()
+        can = True
 
-        if cls.syntax:
-            if isinstance(cls.syntax, (tuple, list)):
-                can = syntax in cls.syntax
-            elif cls.syntax == '*':
-                can = True
-            elif isinstance(cls.syntax, str):
-                can = syntax == cls.syntax
+        if cls.executable_path is None:
+            executable = None
+            cmd = cls.cmd
+
+            if cmd and not callable(cmd):
+                if isinstance(cls.cmd, str):
+                    cmd = shlex.split(cmd)
+                executable = cmd[0]
             else:
-                can = cls.syntax.match(syntax) is not None
+                executable = cls.executable
 
-        if can:
-            if cls.executable_path is None:
-                executable = None
-                cmd = cls.cmd
+            if not executable:
+                return True
 
-                if cmd and not callable(cmd):
-                    if isinstance(cls.cmd, str):
-                        cmd = shlex.split(cmd)
-                    executable = cmd[0]
-                else:
-                    executable = cls.executable
+            if executable:
+                cls.executable_path = cls.which(executable) or ''
+            elif cmd is None:
+                cls.executable_path = '<builtin>'
+            else:
+                cls.executable_path = ''
 
-                if not executable:
-                    return True
+        status = None
 
-                if executable:
-                    cls.executable_path = cls.which(executable) or ''
-                elif cmd is None:
-                    cls.executable_path = '<builtin>'
-                else:
-                    cls.executable_path = ''
+        if cls.executable_path == '':
+            status = '{} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
+            logger.warning(status)
+            return False
 
-            status = None
-
-            if cls.executable_path == '':
-                status = '{} deactivated, cannot locate \'{}\''.format(cls.name, cls.executable_path)
-                logger.warning(status)
-                return False
-
-            if cls.executable_path:
-                can = cls.fulfills_version_requirement()
+        if cls.executable_path:
+            can = cls.fulfills_version_requirement()
 
         return can
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1022,9 +1022,10 @@ class Linter(metaclass=LinterMeta):
     def can_lint_view(cls, view):
         selectors = cls._get_settings(cls, view.window()).get('selectors')
         if selectors:
+            joined_selectors = '|'.join(selectors)
             return (
-                any(view.score_selector(0, selector) for selector in selectors) or
-                any(view.find_by_selector(selector) for selector in selectors)
+                view.score_selector(0, joined_selectors) or
+                view.find_by_selector(joined_selectors)
             )
 
         # Fallback using deprecated `cls.syntax`

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -164,7 +164,7 @@ class LinterMeta(type):
         if 'defaults' in attrs and attrs['defaults']:
             cls.map_args(attrs['defaults'])
 
-        if not cls.syntax and not cls.defaults['selectors']:
+        if not cls.syntax and not cls.defaults.get('selectors'):
             logger.error(
                 "{} disabled, either 'syntax' or 'selectors' must be specified"
                 .format(name))

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -20,9 +20,6 @@ linter_classes = {}
 # A mapping between view ids and a set of linter instances
 view_linters = {}
 
-# A mapping between view ids and views
-views = {}
-
 
 def debug_mode():
     """Return whether the "debug" setting is True."""

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -17,7 +17,7 @@ errors = defaultdict(list)
 # A mapping between linter class names and linter classes
 linter_classes = {}
 
-# A mapping between view ids and a set of linter instances
+# A mapping between buffer ids and a set of linter instances
 view_linters = {}
 
 

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -70,8 +70,8 @@ class Settings:
         if self.has_changed('gutter_theme'):
             style.load_gutter_icons()
 
-        from ..sublime_linter import SublimeLinter
-        SublimeLinter.lint_all_views()
+        from .. import sublime_linter
+        sublime_linter.lint_all_views()
 
 
 def get_settings_objects():

--- a/lint/util.py
+++ b/lint/util.py
@@ -77,7 +77,6 @@ def is_lintable(view):
 
     """
     if (
-        not view or
         not view.window() or
         view.is_scratch() or
         view.is_read_only() or

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -218,13 +218,9 @@ def check_syntax(view):
 
     if old_linters != wanted_linters:
         bid = view.buffer_id()
-        persist.errors[bid].clear()
-        for linter in old_linters:
-            events.broadcast(events.LINT_RESULT, {
-                'buffer_id': bid,
-                'linter_name': linter.name,
-                'errors': []
-            })
+        unchanged_buffer = lambda: False  # noqa: E731
+        for linter in (old_linters - wanted_linters):
+            update_buffer_errors(bid, unchanged_buffer, linter, [])
 
         syntax = util.get_syntax(view)
         logger.info("detected syntax: {}".format(syntax))

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -131,7 +131,6 @@ class Listener:
         vid = view.id()
         dicts = [
             self.linted_views,
-            self.view_syntax,
             persist.view_linters,
             persist.views
         ]
@@ -167,9 +166,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         # Keeps track of which views have actually been linted
         self.linted_views = set()
-
-        # A mapping between view ids and syntax names
-        self.view_syntax = {}
 
         self.__class__.shared_instance = self
 
@@ -241,7 +237,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
             return
 
         vid = view.id()
-        syntax = util.get_syntax(view)
 
         old_linters = persist.view_linters.get(vid, [])
         changed = Linter.assign(view)
@@ -255,7 +250,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
                     'errors': []
                 })
 
-            self.view_syntax[vid] = syntax
             self.linted_views.discard(vid)
             return True
         else:

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -88,8 +88,7 @@ def visible_views():
             yield view
 
 
-class Listener:
-
+class BackendController(sublime_plugin.EventListener):
     def on_modified_async(self, view):
         if not util.is_lintable(view):
             return
@@ -143,10 +142,6 @@ class Listener:
         if buffers.count(bid) <= 1:
             persist.errors.pop(bid, None)
             queue.cleanup(bid)
-
-
-class SublimeLinter(sublime_plugin.EventListener, Listener):
-    ...
 
 
 def lint_all_views():

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -122,15 +122,7 @@ class BackendController(sublime_plugin.EventListener):
             return
 
         vid = view.id()
-        dicts = [
-            persist.view_linters,
-        ]
-
-        for d in dicts:
-            if type(d) is set:
-                d.discard(vid)
-            else:
-                d.pop(vid, None)
+        persist.view_linters.pop(vid, None)
 
         bid = view.buffer_id()
         buffers = []

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -178,25 +178,26 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         if vid in persist.view_linters:
             view_has_changed = make_view_has_changed_fn(view)
-            fn = partial(self.lint, view, view_has_changed)
+            fn = partial(lint, view, view_has_changed)
             queue.debounce(fn, key=view.buffer_id())
 
-    def lint(self, view, view_has_changed):
-        """Lint the view with the given id.
 
-        This method is called asynchronously by queue.Daemon when a lint
-        request is pulled off the queue.
-        """
-        if view_has_changed():  # abort early
-            return
+def lint(view, view_has_changed):
+    """Lint the view with the given id.
 
-        bid = view.buffer_id()
-        events.broadcast(events.LINT_START, {'buffer_id': bid})
+    This method is called asynchronously by queue.Daemon when a lint
+    request is pulled off the queue.
+    """
+    if view_has_changed():  # abort early
+        return
 
-        next = partial(update_buffer_errors, bid, view_has_changed)
-        backend.lint_view(view, view_has_changed, next)
+    bid = view.buffer_id()
+    events.broadcast(events.LINT_START, {'buffer_id': bid})
 
-        events.broadcast(events.LINT_END, {'buffer_id': bid})
+    next = partial(update_buffer_errors, bid, view_has_changed)
+    backend.lint_view(view, view_has_changed, next)
+
+    events.broadcast(events.LINT_END, {'buffer_id': bid})
 
 
 def update_buffer_errors(bid, view_has_changed, linter, errors):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -132,7 +132,6 @@ class Listener:
         dicts = [
             self.linted_views,
             persist.view_linters,
-            persist.views
         ]
 
         for d in dicts:

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -103,10 +103,7 @@ class Listener:
         if not util.is_lintable(view):
             return
 
-        self.check_syntax(view)
-
-        view_id = view.id()
-        if view_id not in self.linted_views:
+        if self.check_syntax(view):
             lint_mode = persist.settings.get('lint_mode')
             if lint_mode in ('background', 'load_save'):
                 self.hit(view)
@@ -129,7 +126,6 @@ class Listener:
 
         vid = view.id()
         dicts = [
-            self.linted_views,
             persist.view_linters,
         ]
 
@@ -162,9 +158,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Keeps track of which views have actually been linted
-        self.linted_views = set()
-
         self.__class__.shared_instance = self
 
     @classmethod
@@ -182,7 +175,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         vid = view.id()
         self.check_syntax(view)
-        self.linted_views.add(vid)
 
         if vid in persist.view_linters:
             view_has_changed = make_view_has_changed_fn(view)
@@ -256,8 +248,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
                     'linter_name': linter.name,
                     'errors': []
                 })
-
-            self.linted_views.discard(vid)
 
             syntax = util.get_syntax(view)
             logger.info("detected syntax: {}".format(syntax))

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -112,7 +112,7 @@ class Listener:
 
         # check if the project settings changed
         if view.window().project_file_name() == view.file_name():
-            self.lint_all_views()
+            lint_all_views()
         else:
             lint_mode = persist.settings.get('lint_mode')
             if lint_mode != 'manual':
@@ -146,13 +146,15 @@ class Listener:
 
 
 class SublimeLinter(sublime_plugin.EventListener, Listener):
-    @classmethod
-    def lint_all_views(cls):
-        """Mimic a modification of all views, which will trigger a relint."""
-        for window in sublime.windows():
-            for view in window.views():
-                if view.id() in persist.view_linters:
-                    hit(view)
+    ...
+
+
+def lint_all_views():
+    """Mimic a modification of all views, which will trigger a relint."""
+    for window in sublime.windows():
+        for view in window.views():
+            if view.id() in persist.view_linters:
+                hit(view)
 
 
 def hit(view):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -105,7 +105,7 @@ class BackendController(sublime_plugin.EventListener):
         if not util.is_lintable(view):
             return
 
-        if check_syntax(view):
+        if check_linters_for_view(view):
             hit(view)
 
     def on_post_save_async(self, view):
@@ -152,7 +152,7 @@ def hit(view):
         return
 
     vid = view.id()
-    check_syntax(view)
+    check_linters_for_view(view)
 
     if vid in persist.view_linters:
         view_has_changed = make_view_has_changed_fn(view)
@@ -194,12 +194,8 @@ def update_buffer_errors(bid, view_has_changed, linter, errors):
     })
 
 
-def check_syntax(view):
-    """
-    Check and return if view's syntax has changed.
-
-    If the syntax has changed, a new linter is assigned.
-    """
+def check_linters_for_view(view):
+    """Check and eventually instantiate linters for a view."""
     vid = view.id()
 
     old_linters = {

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -90,37 +90,39 @@ def visible_views():
 
 class BackendController(sublime_plugin.EventListener):
     def on_modified_async(self, view):
+        if persist.settings.get('lint_mode') != 'background':
+            return
+
         if not util.is_lintable(view):
             return
 
-        if persist.settings.get('lint_mode') == 'background':
-            hit(view)
+        hit(view)
 
     def on_activated_async(self, view):
+        if persist.settings.get('lint_mode') != 'background':
+            return
+
         if not util.is_lintable(view):
             return
 
         if check_syntax(view):
-            lint_mode = persist.settings.get('lint_mode')
-            if lint_mode in ('background', 'load_save'):
-                hit(view)
+            hit(view)
 
     def on_post_save_async(self, view):
-        if not util.is_lintable(view):
+        if persist.settings.get('lint_mode') == 'manual':
             return
 
         # check if the project settings changed
         if view.window().project_file_name() == view.file_name():
             lint_all_views()
-        else:
-            lint_mode = persist.settings.get('lint_mode')
-            if lint_mode != 'manual':
-                hit(view)
+            return
 
-    def on_pre_close(self, view):
         if not util.is_lintable(view):
             return
 
+        hit(view)
+
+    def on_pre_close(self, view):
         vid = view.id()
         persist.view_linters.pop(vid, None)
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -192,30 +192,31 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
         events.broadcast(events.LINT_START, {'buffer_id': view.buffer_id()})
 
-        next = partial(self.highlight, view, view_has_changed)
+        next = partial(highlight, view, view_has_changed)
         backend.lint_view(view, view_has_changed, next)
 
         events.broadcast(events.LINT_END, {'buffer_id': view.buffer_id()})
 
-    def highlight(self, view, view_has_changed, linter, errors):
-        """
-        Highlight any errors found during a lint of the given view.
 
-        This method is called by Linter.lint_view after linting is finished.
-        """
-        if view_has_changed():  # abort early
-            return
+def highlight(view, view_has_changed, linter, errors):
+    """
+    Highlight any errors found during a lint of the given view.
 
-        bid = view.buffer_id()
-        all_errors = [error for error in persist.errors[bid]
-                      if error['linter'] != linter.name] + errors
-        persist.errors[bid] = all_errors
+    This method is called by Linter.lint_view after linting is finished.
+    """
+    if view_has_changed():  # abort early
+        return
 
-        events.broadcast(events.LINT_RESULT, {
-            'buffer_id': bid,
-            'linter_name': linter.name,
-            'errors': errors
-        })
+    bid = view.buffer_id()
+    all_errors = [error for error in persist.errors[bid]
+                  if error['linter'] != linter.name] + errors
+    persist.errors[bid] = all_errors
+
+    events.broadcast(events.LINT_RESULT, {
+        'buffer_id': bid,
+        'linter_name': linter.name,
+        'errors': errors
+    })
 
 
 def check_syntax(view):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -243,11 +243,12 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
         vid = view.id()
         syntax = util.get_syntax(view)
 
-        # Syntax either has never been set or just changed
-        if vid not in self.view_syntax or self.view_syntax[vid] != syntax:
+        old_linters = persist.view_linters.get(vid, [])
+        changed = Linter.assign(view)
+        if changed:
             bid = view.buffer_id()
             persist.errors[bid].clear()
-            for linter in persist.view_linters.get(vid, []):
+            for linter in old_linters:
                 events.broadcast(events.LINT_RESULT, {
                     'buffer_id': bid,
                     'linter_name': linter.name,
@@ -256,7 +257,6 @@ class SublimeLinter(sublime_plugin.EventListener, Listener):
 
             self.view_syntax[vid] = syntax
             self.linted_views.discard(vid)
-            Linter.assign(view)
             return True
         else:
             return False


### PR DESCRIPTION
~~On top of #994 (bc of the refactoring)~~

~~TODO: Does *not* check on each hit, only when the view's syntax changes.~~

~~TODO: Refactor, `view_syntax` is probably unused. Remove user-defined-syntaxes feature (#994).~~ 

Otherwise this is how I understand #691 

Tested with the following ESLint

![image](https://user-images.githubusercontent.com/8558/36420862-b765e6ca-1636-11e8-94df-9dbbccee0759.png)

If you take your unpatched eslint, you need to specify a user setting `selectors` which will then take precedence over everything the plugin author defined. 