### PR TITLE
fix random behaviour in panel position sync

### DIFF
--- a/panel_view.py
+++ b/panel_view.py
@@ -316,12 +316,12 @@ def get_next_panel_line(line, errors):
     In that case return last error's panel line incremented by one, which will
     place panel selection in empty space between buffer sections.
     """
-    for error in errors:
+    for error in sort_errors(errors):
         if error["line"] > line:
             panel_line = error["panel_line"]
             break
-    else:
-        panel_line = errors[-1]["panel_line"] + 1
+        else:
+            panel_line = errors[-1]["panel_line"] + 1
 
     return panel_line, panel_line
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -317,7 +317,7 @@ def get_next_panel_line(line, col, errors):
     place panel selection in empty space between buffer sections.
     """
     for error in sort_errors(errors):
-        if error["line"] == line and col < error["start"]:
+        if error["line"] == line and error["start"] > col:
             panel_line = error["panel_line"]
             break
         elif error["line"] > line:

--- a/panel_view.py
+++ b/panel_view.py
@@ -317,7 +317,7 @@ def get_next_panel_line(line, errors):
     place panel selection in empty space between buffer sections.
     """
     for error in sort_errors(errors):
-        if error["line"] > line:
+        if error["line"] >= line:
             panel_line = error["panel_line"]
             break
         else:

--- a/panel_view.py
+++ b/panel_view.py
@@ -323,8 +323,8 @@ def get_next_panel_line(line, col, errors):
         elif error["line"] > line:
             panel_line = error["panel_line"]
             break
-        else:
-            panel_line = errors[-1]["panel_line"] + 1
+    else:
+        panel_line = errors[-1]["panel_line"] + 1
 
     return panel_line, panel_line
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -309,7 +309,7 @@ def fill_panel(window, update=False, **panel_filter):
 
 # logic for updating panel selection
 
-def get_next_panel_line(line, errors):
+def get_next_panel_line(line, col, errors):
     """Get panel line for next error in buffer.
 
     If not found this means the current line is past last error's buffer line.
@@ -317,7 +317,10 @@ def get_next_panel_line(line, errors):
     place panel selection in empty space between buffer sections.
     """
     for error in sort_errors(errors):
-        if error["line"] >= line:
+        if error["line"] == line and col < error["start"]:
+            panel_line = error["panel_line"]
+            break
+        elif error["line"] > line:
             panel_line = error["panel_line"]
             break
         else:
@@ -383,7 +386,7 @@ def update_panel_selection(active_view, current_pos, **kwargs):
             is_full_line = True
 
     if not panel_lines:  # fallback: take next panel line
-        panel_lines = get_next_panel_line(line, errors or all_errors)
+        panel_lines = get_next_panel_line(line, col, errors or all_errors)
 
     # logic for changing panel selection
     panel = get_panel(sublime.active_window())


### PR DESCRIPTION
fixes #1014

`get_next_panel_line` tries to find the next nearest error that's visible in the panel, to scroll to that position. However, it breaks out as soon as it finds something, but doesn't sort the errors before doing so. So sometimes it may find the right one by accident but it's super likely to find the wrong one. 