### PR TITLE
Mark 'file-only-linters' using `${real_file}` in cmd

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -20,8 +20,12 @@ class SublimeLinterLintCommand(sublime_plugin.TextCommand):
         bid = self.view.buffer_id()
         linters = persist.view_linters.get(bid, [])
 
-        for lint in linters:
-            if lint.tempfile_suffix != '-':
+        for linter in linters:
+            if (
+                '${real_file}' not in linter.cmd and
+                # legacy SL3 check for compatibility
+                linter.tempfile_suffix != '-'
+            ):
                 has_non_file_only_linter = True
                 break
 

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -160,7 +160,12 @@ def filter_linters(linters, view):
     enabled, disabled = [], []
     for linter in linters:
         # First check to see if the linter can run in the current lint mode.
-        if linter.tempfile_suffix == '-' and view.is_dirty():
+        if (
+            ('${real_file}' in linter.cmd or
+             # legacy SL3 check for compatibility
+             linter.tempfile_suffix == '-') and
+            view.is_dirty()
+        ):
             disabled.append(linter)
             continue
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -259,8 +259,8 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
         if '${file}' in cmd:
             cmd[cmd.index('${file}')] = filename
 
-        if '${tmpfilename}' in cmd:
-            cmd[cmd.index('${tmpfilename}')] = path
+        if '${tmp_file}' in cmd:
+            cmd[cmd.index('${tmp_file}')] = path
         elif '@' in cmd:  # legacy SL3 crypto-identifier
             cmd[cmd.index('@')] = path
         else:


### PR DESCRIPTION
Explains https://github.com/SublimeLinter/SublimeLinter/issues/954#issuecomment-368540796

Maybe fixes #954 

Here we use ${real_file} in `cmd` as a marker to mark 'file-only-linters', we use ${tmp_file} to mark linters that operate on temporary files, everything else (except the compatibility branching) uses STDIN. 
