### PR TITLE
Use underline regions as position markers for the panel view

### DIFF
--- a/panel_view.py
+++ b/panel_view.py
@@ -394,6 +394,8 @@ def update_panel_selection(active_view, current_pos, **kwargs):
         return
 
     if panel_lines[0] == panel_lines[1]:
+        draw_position_marker(panel, panel_lines[0], is_full_line)
+
         region = get_panel_region(panel_lines[0], panel, is_full_line)
     else:  # multiple panel lines
         is_full_line = True
@@ -407,3 +409,15 @@ def update_panel_selection(active_view, current_pos, **kwargs):
     # simulate scrolling to enforce rerendering of panel,
     # otherwise selection is not updated (ST core bug)
     panel.run_command("scroll_lines")
+
+
+def draw_position_marker(panel, line, error_under_cursor):
+    if error_under_cursor:
+        panel.erase_regions('SL.PanelMarker')
+    else:
+        line_start = panel.text_point(line - 1, 0)
+        region = sublime.Region(line_start, line_start)
+        scope = 'region.redish markup.deleted.sublime_linter markup.error.sublime_linter'
+        flags = (sublime.DRAW_SOLID_UNDERLINE | sublime.DRAW_NO_FILL |
+                 sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE)
+        panel.add_regions('SL.PanelMarker', [region], scope=scope, flags=flags)


### PR DESCRIPTION
That's an alternative take for #1010 

![image](https://user-images.githubusercontent.com/8558/36718118-ebbf8894-1ba0-11e8-888c-875ee836c2b2.png)

Fixes #806 