### PR TITLE
Fix: Enforce 'None' check in `communicate`

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1164,7 +1164,7 @@ class Linter(metaclass=LinterMeta):
             cmd[cmd.index('${file}')] = self.filename
         elif '@' in cmd:  # legacy SL3 crypto-identifier
             cmd[cmd.index('@')] = self.filename
-        elif not code:
+        elif code is None:
             cmd.append(self.filename)
 
         settings = self.get_view_settings()


### PR DESCRIPTION
The bug was: The else branch was triggered for the empty string. 🐛 

This is generally the right thing, the original code has a type error here. Otherwise, it is a regression bc SL3 checked for empty views even before it hit the debouncer!