### PR TITLE
always lint files once when they're opened

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -124,6 +124,10 @@ class BackendController(sublime_plugin.EventListener):
         if has_syntax_changed(view):
             hit(view)
 
+    def on_load_async(self, view):
+        if util.is_lintable(view):
+            hit(view)
+
     def on_post_save_async(self, view):
         if persist.settings.get('lint_mode') == 'manual':
             return


### PR DESCRIPTION
fix #1054 when you open a file it isn't linted until you start editing. I think we can just lint right then, regardless of lint_mode.