### PR TITLE
Fix broken code blocks on linter settings page.

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -13,7 +13,7 @@ executable
 
 At any time you can manually set the executable a linter should use.
 
-..code-block:: json
+.. code-block:: json
 
     "executable": "${folder}/node_modules/bin/eslint"
 
@@ -24,7 +24,7 @@ env
 ---
 Set additional environment variables.
 
-..code-block:: json
+.. code-block:: json
 
     "env": "{'GEM_HOME': '~/foo/bar'}"
 


### PR DESCRIPTION
These code blocks are not formatted correctly because of a missing space in the RST markup.