### PR TITLE
Fix non-colorized icon colors for light color schemes

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -152,5 +152,11 @@
         "php": "html",
         "python django": "python",
         "pythonimproved": "python"
-    }
+    },
+
+    // Tell us what scope is a white color in your color scheme.
+    // This is used to render pre-colored icons (e.g. from the Hands gutter theme)
+    // in their original color.
+    // For most dark color schemes, " " should be correct.
+    "white_scope": " "
 }

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -154,9 +154,11 @@
         "pythonimproved": "python"
     },
 
-    // Tell us what scope is a white color in your color scheme.
+    // Tells us what scope is a white color in your color scheme.
     // This is used to render pre-colored icons (e.g. from the Hands gutter theme)
     // in their original color.
-    // For most dark color schemes, " " should be correct.
-    "white_scope": " "
+    // For most dark color schemes, you probably don't need to change this.
+    // You can also put the "SublimeLinterWhiteScope" scope in your color scheme
+    // and set its foreground to white (#FFFFFF).
+    "white_scope": "SublimeLinterWhiteScope"
 }

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -158,7 +158,7 @@
     // This is used to render pre-colored icons (e.g. from the Hands gutter theme)
     // in their original color.
     // For most dark color schemes, you probably don't need to change this.
-    // You can also put the "SublimeLinterWhiteScope" scope in your color scheme
+    // You can also put the "sublime_linter.white" scope in your color scheme
     // and set its foreground to white (#FFFFFF).
-    "white_scope": "SublimeLinterWhiteScope"
+    "white_scope": "sublime_linter.white"
 }

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -358,7 +358,7 @@ def get_icon_scope(icon, error):
     if style_stores.COLORIZE:
         return get_scope(**error)
     else:
-        return " "  # set scope to non-existent one
+        return persist.settings.get('white_scope')
 
 
 def draw(view, linter_name, highlight_regions, gutter_regions,

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -139,7 +139,9 @@
                 "additionalProperties":false
             }
         },
-        "white_scope": "string"
+        "white_scope": {
+            "type": "string"
+        }
     },
     "additionalProperties": false
 }

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -138,7 +138,8 @@
                 ],
                 "additionalProperties":false
             }
-        }
+        },
+        "white_scope": "string"
     },
     "additionalProperties": false
 }


### PR DESCRIPTION
Ok, the problem is this:

When a gutter theme sets "colorize" to false, we set the `" "` scope on the region. ST *always* colorizes the icons, so all this does is make it colorize with the default foreground color. In dark color schemes that color is probably white, which effectively nullifies the colorization. In light color schemes however it's probably black which really f****'s up the icons. You don't want the default foreground color, you want the background color here.

There is no scope we can use that says "use the background color".

bf17720 introduces a scope nobody implemented in their color scheme. This scope can be used to patch a color scheme by adding this:

```xml
<dict>
	<key>name</key>
	<string>SublimeLinter4</string>
	<key>scope</key>
	<string>sublime_linter_non_colored_scope</string>
	<key>settings</key>
	<dict>
		<key>foreground</key>
		<string>#FFFFFF</string>
	</dict>
</dict>
```

This isn't ideal, but at least its possible. The scope `" "` you can't do anything with.

I don't know of other solutions that don't include generating color schemes and we're definitely not going there.