### PR TITLE
Do not reload but ask for a restart.

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -49,11 +49,11 @@ def plugin_loaded():
     try:
         from package_control import events
         if events.install('SublimeLinter'):
-            reloader.reload_linter_plugins()
-            return
+            util.message(
+                'SublimeLinter has been installed. Please restart Sublime Text.')
         elif events.post_upgrade('SublimeLinter'):
-            reloader.reload_everything()
-            return
+            util.message(
+                'SublimeLinter has been upgraded. Please restart Sublime Text.')
     except ImportError:
         pass
 


### PR DESCRIPTION
This would be like an A/B test in the blind. We actually don't have enough information, we never see full logs for the crashes that go away with a restart. 

The command is still very useful for development bc you (definitely I) can tweak something, add a print statement, reload and done.

Actually, we get scary reports here, and the people want something we could only achieve if we send tracebacks and metrics to something like Sentry. If we had that I could just fix the stuff. 😞 

