### PR TITLE
show_panel_on_save if errors in view or window + make it lazy

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -85,6 +85,12 @@
     // Highlight problems in the minimap.
     "show_marks_in_minimap": true,
 
+    // Show the output panel on save if there are problems.
+    // Set to "window" to check if the window has problems.
+    // Set to "view" to only check the current file.
+    // Set to "never" to disable this feature.
+    "show_panel_on_save": "never",
+
     // Display counters in the status bar.
     // {warning} and {error} will be replaced with the actual numbers.
     // Set to "" to display nothing

--- a/keymaps/Default (Linux).sublime-keymap
+++ b/keymaps/Default (Linux).sublime-keymap
@@ -5,18 +5,6 @@
 
     // Show all errors
     { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle" },
-    // To display filtered results in the panel add arguments:
-    // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
-    // whitelist via:
-    //         "types": ["error", "warning"],
-    //         "codes": [],
-    //         "linter": [],
-    // blacklist via:
-    //          "exclude_codes": [],
-    //          "exclude_linter": []
-    //     }
-    // }
-
 
     // You can also trigger the line report with a keybinding:
     // { "keys": ["ctrl+k", "r"], "command": "sublime_linter_line_report" }

--- a/keymaps/Default (OSX).sublime-keymap
+++ b/keymaps/Default (OSX).sublime-keymap
@@ -5,18 +5,6 @@
 
     // Show all errors
     { "keys": ["ctrl+super+a"], "command": "sublime_linter_panel_toggle" },
-    // To display filtered results in the panel add arguments:
-    // { "keys": ["ctrl+super+a"], "command": "sublime_linter_panel_toggle", "args": {
-    // whitelist via:
-    //         "types": ["error", "warning"],
-    //         "codes": [],
-    //         "linter": [],
-    // blacklist via:
-    //          "exclude_codes": [],
-    //          "exclude_linter": []
-    //     }
-    // }
-
 
     // You can also trigger the line report with a keybinding:
     // { "keys": ["ctrl+super+r"], "command": "sublime_linter_line_report" }

--- a/keymaps/Default (Windows).sublime-keymap
+++ b/keymaps/Default (Windows).sublime-keymap
@@ -5,18 +5,6 @@
 
     // Show all errors
     { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle" },
-    // To display filtered results in the panel add arguments:
-    // { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle", "args": {
-    // whitelist via:
-    //         "types": ["error", "warning"],
-    //         "codes": [],
-    //         "linter": [],
-    // blacklist via:
-    //          "exclude_codes": [],
-    //          "exclude_linter": []
-    //     }
-    // }
-
 
     // You can also trigger the line report with a keybinding:
     // { "keys": ["ctrl+k", "r"], "command": "sublime_linter_line_report" }

--- a/messages.json
+++ b/messages.json
@@ -2,5 +2,6 @@
     "install": "messages/install.txt",
     "4.0.0": "messages/4.0.0.txt",
     "4.0.1": "messages/4.0.1.txt",
-    "4.0.3": "messages/4.0.3.txt"
+    "4.0.3": "messages/4.0.3.txt",
+    "4.0.next": "messages/4.0.next.txt"
 }

--- a/messages/4.0.0-rc.1.txt
+++ b/messages/4.0.0-rc.1.txt
@@ -20,7 +20,6 @@ New features
 - The statusbar shows the error for your cursor position instead of all errors
   for that line.
 - A panel displays errors in all open files.
-- The panel can be filtered to just show specific types or severity level.
 - Jump between errors in the current file with sublime_linter_goto_error.
 - A new "styles" setting to configure error highlighting.
 - Each linter setting now accepts such a "styles" setting, so colors, icons and
@@ -72,9 +71,6 @@ Your linter should have settings to modify the rules or severity levels.
 
 Settings tokens (e.g. ${folder}) are now expanded using SublimeText features,
 so there are more tokens you can use. The docs covers this in more detail.
-
-The new output panel and filtering have supplanted the "make_warnings_passive"
-and "show_errors_on_save" features.
 
 Settings can be specified in your user settings, or in project configuration
 (*.sublime-project files). Inline settings, inline overrides, shebang settings

--- a/messages/4.0.0.txt
+++ b/messages/4.0.0.txt
@@ -20,7 +20,6 @@ New features
 - The statusbar shows the error for your cursor position instead of all errors
   for that line.
 - A panel displays errors in all open files.
-- The panel can be filtered to just show specific types or severity level.
 - Jump between errors in the current file with sublime_linter_goto_error.
 - A new "styles" setting to configure error highlighting.
 - Each linter setting now accepts such a "styles" setting, so colors, icons and
@@ -72,9 +71,6 @@ Your linter should have settings to modify the rules or severity levels.
 
 Settings tokens (e.g. ${folder}) are now expanded using SublimeText features,
 so there are more tokens you can use. The docs covers this in more detail.
-
-The new output panel and filtering have supplanted the "make_warnings_passive"
-and "show_errors_on_save" features.
 
 Settings can be specified in your user settings, or in project configuration
 (*.sublime-project files). Inline settings, inline overrides, shebang settings

--- a/messages/4.0.next.txt
+++ b/messages/4.0.next.txt
@@ -1,0 +1,10 @@
+SublimeLinter 4.0.next
+======================
+
+Introduces a setting to show the output panel if there are problems:
+
+"show_panel_on_save"
+
+- Set to "window" to check if the window has problems.
+- Set to "view" to only check the current file.
+- Set to "never" to disable this feature. This is the default

--- a/messages/4.0.next.txt
+++ b/messages/4.0.next.txt
@@ -8,3 +8,9 @@ Introduces a setting to show the output panel if there are problems:
 - Set to "window" to check if the window has problems.
 - Set to "view" to only check the current file.
 - Set to "never" to disable this feature. This is the default
+
+
+Deprecations:
+- The panel can no longer be filtered. The filtering had several problems
+  and not a lot of usage. We will need to rethink this feature if there
+  does appear to be demand for it.

--- a/panel_view.py
+++ b/panel_view.py
@@ -109,12 +109,12 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
         is_active_panel = (active_panel == "output." + PANEL_NAME)
 
         if is_active_panel and not force_show:
-            self.toggle_panel(PANEL_NAME, show=False)
+            self.toggle_panel(show=False)
         else:
             fill_panel(self.window, **kwargs)
-            self.toggle_panel(PANEL_NAME)
+            self.toggle_panel()
 
-    def toggle_panel(self, name, show=True):
+    def toggle_panel(self, show=True):
         """
         Change visibility of panel with given name.
 
@@ -126,7 +126,7 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
         else:
             cmd = "hide_panel"
 
-        self.window.run_command(cmd, {"panel": "output." + name or ""})
+        self.window.run_command(cmd, {"panel": "output." + PANEL_NAME})
 
 
 class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):

--- a/panel_view.py
+++ b/panel_view.py
@@ -93,6 +93,22 @@ class UpdateState(sublime_plugin.EventListener):
                 window.run_command("sublime_linter_panel_toggle", {"force_show": True})
                 return
 
+    def on_post_window_command(self, window, command_name, args):
+        if command_name != 'show_panel':
+            return
+
+        panel_name = args.get('panel')
+        if panel_name == OUTPUT_PANEL:
+            # Apply focus fix to ensure `next_result` is bound to our panel.
+            active_group = window.active_group()
+            active_view = window.active_view()
+
+            panel = get_panel(window)
+            window.focus_view(panel)
+
+            window.focus_group(active_group)
+            window.focus_view(active_view)
+
 
 class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
     def run(self, force_show=False, **kwargs):
@@ -107,17 +123,7 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
 
     def toggle_panel(self, show=True):
         if show:
-            active_group = self.window.active_group()
-            active_view = self.window.active_view()
-
             self.window.run_command("show_panel", {"panel": OUTPUT_PANEL})
-
-            # Apply focus fix to ensure `next_result` is bound to our panel.
-            panel = self.window.find_output_panel(PANEL_NAME)
-            self.window.focus_view(panel)
-
-            self.window.focus_group(active_group)
-            self.window.focus_view(active_view)
         else:
             self.window.run_command("hide_panel", {"panel": OUTPUT_PANEL})
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -94,10 +94,10 @@ class UpdateState(sublime_plugin.EventListener):
         errors_by_bid = get_window_errors(window, persist.errors)
 
         if persist.settings.get('show_panel_on_save') == 'window' and errors_by_bid:
-            window.run_command("sublime_linter_panel_toggle", {"force_show": True})
+            window.run_command("show_panel", {"panel": OUTPUT_PANEL})
         else:
             if view.buffer_id() in errors_by_bid:
-                window.run_command("sublime_linter_panel_toggle", {"force_show": True})
+                window.run_command("show_panel", {"panel": OUTPUT_PANEL})
                 return
 
     def on_post_window_command(self, window, command_name, args):
@@ -120,8 +120,8 @@ class UpdateState(sublime_plugin.EventListener):
 
 
 class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
-    def run(self, force_show=False, **kwargs):
-        if panel_is_active(self.window) and not force_show:
+    def run(self):
+        if panel_is_active(self.window):
             self.window.run_command("hide_panel", {"panel": OUTPUT_PANEL})
         else:
             self.window.run_command("show_panel", {"panel": OUTPUT_PANEL})

--- a/panel_view.py
+++ b/panel_view.py
@@ -350,6 +350,10 @@ def update_panel_selection(active_view, current_pos, **kwargs):
     If current position is past last error, place empty selection on the panel line following that of last error.
 
     """
+    panel = get_panel(sublime.active_window())
+    if not panel:
+        return
+
     if current_pos == (-1, -1):
         return
 
@@ -388,9 +392,6 @@ def update_panel_selection(active_view, current_pos, **kwargs):
         panel_lines = get_next_panel_line(line, col, errors or all_errors)
 
     # logic for changing panel selection
-    panel = get_panel(sublime.active_window())
-    if not panel:
-        return
 
     if panel_lines[0] == panel_lines[1]:
         draw_position_marker(panel, panel_lines[0], is_full_line)

--- a/panel_view.py
+++ b/panel_view.py
@@ -50,6 +50,9 @@ def on_lint_result(buffer_id, **kwargs):
 
 class UpdateState(sublime_plugin.EventListener):
     def on_activated_async(self, active_view):
+        if not has_panel(active_view):
+            return
+
         State.update({
             'active_view': active_view,
             'current_pos': get_current_pos(active_view)
@@ -57,6 +60,9 @@ class UpdateState(sublime_plugin.EventListener):
         update_panel_selection(**State)
 
     def on_selection_modified_async(self, _primary_view_):
+        if not has_panel(_primary_view_):
+            return
+
         active_view = State['active_view']
         current_pos = get_current_pos(active_view)
         if current_pos != State['current_pos']:
@@ -66,6 +72,9 @@ class UpdateState(sublime_plugin.EventListener):
             update_panel_selection(**State)
 
     def on_pre_close(self, view):
+        if not has_panel(view):
+            return
+
         window = view.window()
         # If the user closes the window and not *just* a view, the view is
         # already detached, hence we check.
@@ -141,6 +150,13 @@ class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):
                 sel.add(new_selected_region)
                 return
         sel.add(0)
+
+
+def has_panel(view):
+    if view.window():
+        return view.window().find_output_panel(PANEL_NAME)
+    else:
+        return False
 
 
 def get_current_pos(view):

--- a/panel_view.py
+++ b/panel_view.py
@@ -345,10 +345,6 @@ def update_panel_selection(active_view, current_pos, **kwargs):
     """Alter panel selection according to errors belonging to current position.
 
     If current position is between two errors, place empty panel selection on start of next error's panel line.
-
-
-
-
     If current position is past last error, place empty selection on the panel line following that of last error.
 
     """

--- a/panel_view.py
+++ b/panel_view.py
@@ -5,6 +5,7 @@ import sublime_plugin
 from .lint import persist, events
 
 PANEL_NAME = "SublimeLinter"
+OUTPUT_PANEL = "output." + PANEL_NAME
 OUTPUT_PANEL_SETTINGS = {
     "auto_indent": False,
     "draw_indent_guides": False,
@@ -97,7 +98,7 @@ class UpdateState(sublime_plugin.EventListener):
 class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
     def run(self, force_show=False, **kwargs):
         active_panel = self.window.active_panel()
-        is_active_panel = (active_panel == "output." + PANEL_NAME)
+        is_active_panel = (active_panel == OUTPUT_PANEL)
 
         if is_active_panel and not force_show:
             self.toggle_panel(show=False)
@@ -110,7 +111,7 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
             active_group = self.window.active_group()
             active_view = self.window.active_view()
 
-            self.window.run_command("show_panel", {"panel": "output." + PANEL_NAME})
+            self.window.run_command("show_panel", {"panel": OUTPUT_PANEL})
 
             # Apply focus fix to ensure `next_result` is bound to our panel.
             panel = self.window.find_output_panel(PANEL_NAME)
@@ -119,7 +120,7 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
             self.window.focus_group(active_group)
             self.window.focus_view(active_view)
         else:
-            self.window.run_command("hide_panel", {"panel": "output." + PANEL_NAME})
+            self.window.run_command("hide_panel", {"panel": OUTPUT_PANEL})
 
 
 class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):
@@ -196,7 +197,7 @@ def panel_is_active(window):
     if not window:
         return False
 
-    if window.active_panel() == "output." + PANEL_NAME:
+    if window.active_panel() == OUTPUT_PANEL:
         return True
     else:
         return False

--- a/panel_view.py
+++ b/panel_view.py
@@ -89,10 +89,9 @@ class UpdateState(sublime_plugin.EventListener):
         if persist.settings.get('show_panel_on_save') == 'window' and errors_by_bid:
             window.run_command("sublime_linter_panel_toggle", {"force_show": True})
         else:
-            for bid in errors_by_bid:
-                if bid is view.buffer_id():
-                    window.run_command("sublime_linter_panel_toggle", {"force_show": True})
-                    return
+            if view.buffer_id() in errors_by_bid:
+                window.run_command("sublime_linter_panel_toggle", {"force_show": True})
+                return
 
 
 class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):

--- a/panel_view.py
+++ b/panel_view.py
@@ -88,17 +88,16 @@ class UpdateState(sublime_plugin.EventListener):
     def on_post_save_async(self, view):
         """Show the panel if the view or window has problems, depending on settings."""
         window = view.window()
-        if persist.settings.get('show_panel_on_save') == 'never' or panel_is_active(window):
+        show_panel_on_save = persist.settings.get('show_panel_on_save')
+        if show_panel_on_save == 'never' or panel_is_active(window):
             return
 
         errors_by_bid = get_window_errors(window, persist.errors)
 
-        if persist.settings.get('show_panel_on_save') == 'window' and errors_by_bid:
+        if show_panel_on_save == 'window' and errors_by_bid:
             window.run_command("show_panel", {"panel": OUTPUT_PANEL})
-        else:
-            if view.buffer_id() in errors_by_bid:
-                window.run_command("show_panel", {"panel": OUTPUT_PANEL})
-                return
+        elif view.buffer_id() in errors_by_bid:
+            window.run_command("show_panel", {"panel": OUTPUT_PANEL})
 
     def on_post_window_command(self, window, command_name, args):
         if command_name != 'show_panel':

--- a/panel_view.py
+++ b/panel_view.py
@@ -275,6 +275,7 @@ def format_row(item):
 
 
 def fill_panel(window, update=False):
+    """Create the panel if it doesn't exist, then update its contents."""
     panel = ensure_panel(window)
     # If we're here and the user actually closed the window in the meantime,
     # we cannot create a panel anymore, and just pass.

--- a/panel_view.py
+++ b/panel_view.py
@@ -275,15 +275,14 @@ def format_row(item):
 
 
 def fill_panel(window, update=False):
-    errors_by_bid = get_window_errors(window, persist.errors)
-
-    path_dict, base_dir = create_path_dict(window, errors_by_bid.keys())
-
     panel = ensure_panel(window)
     # If we're here and the user actually closed the window in the meantime,
     # we cannot create a panel anymore, and just pass.
     if not panel:
         return
+
+    errors_by_bid = get_window_errors(window, persist.errors)
+    path_dict, base_dir = create_path_dict(window, errors_by_bid.keys())
 
     settings = panel.settings()
     settings.set("result_base_dir", base_dir)

--- a/panel_view.py
+++ b/panel_view.py
@@ -45,7 +45,7 @@ def plugin_unloaded():
 def on_lint_result(buffer_id, **kwargs):
     for window in sublime.windows():
         if window.find_output_panel(PANEL_NAME) and buffer_id in buffer_ids_per_window(window):
-            fill_panel(window, update=True)
+            fill_panel(window)
 
 
 class UpdateState(sublime_plugin.EventListener):
@@ -79,7 +79,7 @@ class UpdateState(sublime_plugin.EventListener):
         # If the user closes the window and not *just* a view, the view is
         # already detached, hence we check.
         if window:
-            sublime.set_timeout_async(lambda: fill_panel(window, update=True))
+            sublime.set_timeout_async(lambda: fill_panel(window))
 
     def on_post_save_async(self, view):
         """Show the panel if the view or window has problems, depending on settings."""
@@ -273,7 +273,7 @@ def format_row(item):
     return tmpl.format(LINE=line, START=start, **item)
 
 
-def fill_panel(window, update=False):
+def fill_panel(window):
     """Create the panel if it doesn't exist, then update its contents."""
     panel = ensure_panel(window)
     # If we're here and the user actually closed the window in the meantime,

--- a/panel_view.py
+++ b/panel_view.py
@@ -68,13 +68,10 @@ class UpdateState(sublime_plugin.EventListener):
                 update_panel_selection(**State)
 
     def on_pre_close(self, view):
-        if not panel_is_active(view.window()):
-            return
-
         window = view.window()
         # If the user closes the window and not *just* a view, the view is
         # already detached, hence we check.
-        if window:
+        if window and panel_is_active(window):
             sublime.set_timeout_async(lambda: fill_panel(window))
 
     def on_post_save_async(self, view):

--- a/panel_view.py
+++ b/panel_view.py
@@ -212,6 +212,11 @@ def create_panel(window):
     panel.settings().set("result_line_regex", r"^ +(\d+)(?::(\d+))?.*")
 
     syntax_path = "Packages/SublimeLinter/panel/panel.sublime-syntax"
+    try:  # Try the resource first, in case we're in the middle of an upgrade
+        sublime.load_resource(syntax_path)
+    except Exception:
+        return
+
     panel.assign_syntax(syntax_path)
     # Call create_output_panel a second time after assigning the above
     # settings, so that it'll be picked up as a result buffer

--- a/panel_view.py
+++ b/panel_view.py
@@ -82,6 +82,7 @@ class UpdateState(sublime_plugin.EventListener):
             sublime.set_timeout_async(lambda: fill_panel(window, update=True))
 
     def on_post_save_async(self, view):
+        """Show the panel if the view or window has problems, depending on settings."""
         if persist.settings.get('show_panel_on_save') == 'never':
             return
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -30,9 +30,11 @@ State = {
 
 
 def plugin_loaded():
+    active_window = sublime.active_window()
     State.update({
-        'active_view': sublime.active_window().active_view()
+        'active_view': active_window.active_view()
     })
+    ensure_panel(active_window)
 
 
 def plugin_unloaded():
@@ -58,7 +60,9 @@ class UpdateState(sublime_plugin.EventListener):
             'active_view': active_view,
             'current_pos': get_current_pos(active_view)
         })
-        if panel_is_active(active_view.window()):
+        window = active_view.window()
+        ensure_panel(window)
+        if panel_is_active(window):
             update_panel_selection(**State)
 
     def on_selection_modified_async(self, view):
@@ -102,6 +106,8 @@ class UpdateState(sublime_plugin.EventListener):
 
         panel_name = args.get('panel')
         if panel_name == OUTPUT_PANEL:
+            fill_panel(window)
+
             # Apply focus fix to ensure `next_result` is bound to our panel.
             active_group = window.active_group()
             active_view = window.active_view()
@@ -118,7 +124,6 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
         if panel_is_active(self.window) and not force_show:
             self.window.run_command("hide_panel", {"panel": OUTPUT_PANEL})
         else:
-            fill_panel(self.window)
             self.window.run_command("show_panel", {"panel": OUTPUT_PANEL})
 
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -107,9 +107,19 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
 
     def toggle_panel(self, show=True):
         if show:
+            active_group = self.window.active_group()
+            active_view = self.window.active_view()
+
             self.window.run_command("show_panel", {"panel": "output." + PANEL_NAME})
+
+            # Apply focus fix to ensure `next_result` is bound to our panel.
+            panel = self.window.find_output_panel(PANEL_NAME)
+            self.window.focus_view(panel)
+
+            self.window.focus_group(active_group)
+            self.window.focus_view(active_view)
         else:
-            self.window.destroy_output_panel(PANEL_NAME)
+            self.window.run_command("hide_panel", {"panel": "output." + PANEL_NAME})
 
 
 class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):

--- a/panel_view.py
+++ b/panel_view.py
@@ -86,11 +86,11 @@ class UpdateState(sublime_plugin.EventListener):
         errors_by_bid = get_window_errors(window, persist.errors)
 
         if persist.settings.get('show_panel_on_save') == 'window' and errors_by_bid:
-            window.run_command('show_panel', {'panel': 'output.' + PANEL_NAME})
+            window.run_command("sublime_linter_panel_toggle", {"force_show": True})
         else:
             for bid in errors_by_bid:
                 if bid is view.buffer_id():
-                    window.run_command('show_panel', {'panel': 'output.' + PANEL_NAME})
+                    window.run_command("sublime_linter_panel_toggle", {"force_show": True})
                     return
 
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -51,6 +51,9 @@ def on_lint_result(buffer_id, **kwargs):
 
 class UpdateState(sublime_plugin.EventListener):
     def on_activated_async(self, active_view):
+        if active_view.settings().get('is_widget'):
+            return
+
         State.update({
             'active_view': active_view,
             'current_pos': get_current_pos(active_view)

--- a/panel_view.py
+++ b/panel_view.py
@@ -57,14 +57,17 @@ class UpdateState(sublime_plugin.EventListener):
         if panel_is_active(active_view.window()):
             update_panel_selection(**State)
 
-    def on_selection_modified_async(self, _primary_view_):
+    def on_selection_modified_async(self, view):
         active_view = State['active_view']
+        if active_view.buffer_id() != view.buffer_id():
+            return
+
         current_pos = get_current_pos(active_view)
         if current_pos != State['current_pos']:
             State.update({
                 'current_pos': current_pos
             })
-            if panel_is_active(_primary_view_.window()):
+            if panel_is_active(active_view.window()):
                 update_panel_selection(**State)
 
     def on_pre_close(self, view):

--- a/panel_view.py
+++ b/panel_view.py
@@ -285,6 +285,9 @@ def fill_panel(window, update=False):
     if not panel:
         return
 
+    settings = panel.settings()
+    settings.set("result_base_dir", base_dir)
+
     to_render = []
     for bid, buf_errors in errors_by_bid.items():
         # append header

--- a/panel_view.py
+++ b/panel_view.py
@@ -112,20 +112,11 @@ class UpdateState(sublime_plugin.EventListener):
 
 class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
     def run(self, force_show=False, **kwargs):
-        active_panel = self.window.active_panel()
-        is_active_panel = (active_panel == OUTPUT_PANEL)
-
-        if is_active_panel and not force_show:
-            self.toggle_panel(show=False)
+        if panel_is_active(self.window) and not force_show:
+            self.window.run_command("hide_panel", {"panel": OUTPUT_PANEL})
         else:
             fill_panel(self.window)
-            self.toggle_panel()
-
-    def toggle_panel(self, show=True):
-        if show:
             self.window.run_command("show_panel", {"panel": OUTPUT_PANEL})
-        else:
-            self.window.run_command("hide_panel", {"panel": OUTPUT_PANEL})
 
 
 class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):

--- a/panel_view.py
+++ b/panel_view.py
@@ -388,7 +388,7 @@ def update_panel_selection(active_view, current_pos, **kwargs):
         region = sublime.Region(region_a.begin(), region_b.end())
 
     update_selection(panel, region)
-    panel.show_at_center(region)
+    sublime.set_timeout_async(lambda: panel.show_at_center(region))
 
 
 def draw_position_marker(panel, line, error_under_cursor):

--- a/panel_view.py
+++ b/panel_view.py
@@ -103,7 +103,7 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
         if is_active_panel and not force_show:
             self.toggle_panel(show=False)
         else:
-            fill_panel(self.window, **kwargs)
+            fill_panel(self.window)
             self.toggle_panel()
 
     def toggle_panel(self, show=True):

--- a/panel_view.py
+++ b/panel_view.py
@@ -109,12 +109,12 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
         is_active_panel = (active_panel == "output." + PANEL_NAME)
 
         if is_active_panel and not force_show:
-            self.show_panel(PANEL_NAME, show=False)
+            self.toggle_panel(PANEL_NAME, show=False)
         else:
             fill_panel(self.window, **kwargs)
-            self.show_panel(PANEL_NAME)
+            self.toggle_panel(PANEL_NAME)
 
-    def show_panel(self, name, show=True):
+    def toggle_panel(self, name, show=True):
         """
         Change visibility of panel with given name.
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -132,13 +132,6 @@ class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):
         sel.add(0)
 
 
-def has_panel(view):
-    if view.window():
-        return view.window().find_output_panel(PANEL_NAME)
-    else:
-        return False
-
-
 def get_current_pos(view):
     try:
         return view.rowcol(view.sel()[0].begin())

--- a/panel_view.py
+++ b/panel_view.py
@@ -390,10 +390,6 @@ def update_panel_selection(active_view, current_pos, **kwargs):
     update_selection(panel, region)
     panel.show_at_center(region)
 
-    # simulate scrolling to enforce rerendering of panel,
-    # otherwise selection is not updated (ST core bug)
-    panel.run_command("scroll_lines")
-
 
 def draw_position_marker(panel, line, error_under_cursor):
     if error_under_cursor:

--- a/panel_view.py
+++ b/panel_view.py
@@ -122,11 +122,9 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
         Pass show=False for hiding.
         """
         if show:
-            cmd = "show_panel"
+            self.window.run_command("show_panel", {"panel": "output." + PANEL_NAME})
         else:
-            cmd = "hide_panel"
-
-        self.window.run_command(cmd, {"panel": "output." + PANEL_NAME})
+            self.window.destroy_output_panel(PANEL_NAME)
 
 
 class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):

--- a/panel_view.py
+++ b/panel_view.py
@@ -50,26 +50,22 @@ def on_lint_result(buffer_id, **kwargs):
 
 class UpdateState(sublime_plugin.EventListener):
     def on_activated_async(self, active_view):
-        if not panel_is_active(active_view.window()):
-            return
-
         State.update({
             'active_view': active_view,
             'current_pos': get_current_pos(active_view)
         })
-        update_panel_selection(**State)
+        if panel_is_active(active_view.window()):
+            update_panel_selection(**State)
 
     def on_selection_modified_async(self, _primary_view_):
-        if not has_panel(_primary_view_.window()):
-            return
-
         active_view = State['active_view']
         current_pos = get_current_pos(active_view)
         if current_pos != State['current_pos']:
             State.update({
                 'current_pos': current_pos
             })
-            update_panel_selection(**State)
+            if panel_is_active(_primary_view_.window()):
+                update_panel_selection(**State)
 
     def on_pre_close(self, view):
         if not panel_is_active(view.window()):

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -91,6 +91,10 @@
         "show_marks_in_minimap":{
             "type":"boolean"
         },
+        "show_panel_on_save":{
+            "type":"string",
+            "pattern":"^(never|view|window)$"
+        },
         "syntax_map":{
             "type":"object"
         },


### PR DESCRIPTION
Fixes #1084 by introducing a setting to show the output panel if there are problems:

"show_panel_on_save"

- Set to "window" to check if the window has problems.
- Set to "view" to only check the current file/buffer.
- Set to "never" to disable this feature. This is the default.

Additional changes to fix #1163 

- [x] panel is not created until the user does so manually
- [x] the panel and its state aren't updated if the panel doesn't exist
- [ ] make next_result work as soon as you open the panel
- [ ] clean up the panel if it's no longer in use