### PR TITLE
fix #1163 don't fill the panel if it doesn't exist

### DIFF
--- a/panel_view.py
+++ b/panel_view.py
@@ -44,8 +44,9 @@ def plugin_unloaded():
 @events.on(events.LINT_RESULT)
 def on_lint_result(buffer_id, **kwargs):
     for window in sublime.windows():
-        if buffer_id in buffer_ids_per_window(window):
-            fill_panel(window, update=True)
+        if window.find_output_panel(PANEL_NAME):
+            if buffer_id in buffer_ids_per_window(window):
+                fill_panel(window, update=True)
 
 
 class UpdateState(sublime_plugin.EventListener):

--- a/panel_view.py
+++ b/panel_view.py
@@ -44,9 +44,8 @@ def plugin_unloaded():
 @events.on(events.LINT_RESULT)
 def on_lint_result(buffer_id, **kwargs):
     for window in sublime.windows():
-        if window.find_output_panel(PANEL_NAME):
-            if buffer_id in buffer_ids_per_window(window):
-                fill_panel(window, update=True)
+        if window.find_output_panel(PANEL_NAME) and buffer_id in buffer_ids_per_window(window):
+            fill_panel(window, update=True)
 
 
 class UpdateState(sublime_plugin.EventListener):


### PR DESCRIPTION
This introduces a check if the panel exists in the current window. If it doesn't we don't `fill_panel()`, because that would create the panel. This way the user can create the panel and *then* we start updating it. 

This might help with #1122 or at least reduce occurrences of that. In any case it looks like a good idea to not spend effort updating the panel if the user doesn't want to look at it.