### PR TITLE
make the fallback configurable and optional

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -35,6 +35,11 @@
     // the regions. E.g. try 'comment' to get a soft gray.
     "highlights.demote_scope": "",
 
+    // Fall back to "fill" or "outline" when using *_underline mark styles.
+    // Sublime Text doesn't draw underlines on whitespace, so you might
+    // miss information otherwise. Set to "none" to disable the fallback.
+    "highlights.fallback": "outline",
+
     // Lint Modes determine when the linter is run
     // background: asynchronously on every change
     // load_save: when a file is opened and every time it's saved

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -30,7 +30,6 @@ UNDERLINE_STYLES = (
 )
 
 SOME_WS = re.compile('\s')
-FALLBACK_MARK_STYLE = 'outline'
 
 WS_REGIONS = re.compile('(^\s+$|\n)')
 DEMOTE_WHILE_BUSY_MARKER = '%DWB%'
@@ -310,10 +309,12 @@ def prepare_highlights_data(view, linter_name, errors, demote_predicate):
         selected_text = view.substr(region)
 
         demote_while_busy = demote_predicate(selected_text, **error)
+        fallback_style = persist.settings.get('highlights.fallback')
 
         # Work around Sublime bug, which cannot draw 'underlines' on spaces
         if mark_style in UNDERLINE_STYLES and SOME_WS.search(selected_text):
-            mark_style = FALLBACK_MARK_STYLE
+            if fallback_style != 'none':
+                mark_style = fallback_style
 
         flags = MARK_STYLES[mark_style]
         if not persist.settings.get('show_marks_in_minimap'):

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -21,6 +21,9 @@
         "highlights.demote_scope": {
             "type":"string"
         },
+        "highlights.fallback": {
+            "pattern":"^(fill|outline|none)$"
+        },
         "lint_mode":{
             "type":"string",
             "pattern":"^(background|load_save|manual)$"


### PR DESCRIPTION
Fix #1171. I think the fallback is in general nice enough, but I'm not a fan. However, I don't want to force my opinion here. I'm pretty opinionated about a lot of the user-facing stuff we do, but here there is no better or worse, just that I like better. 
I think the outlines are well implemented and suppressing them while editing really works very well for me. They're well done and I can see why you'd want them, but I kinda want the option of not having them. With flake8 it's not so bad, but with eslint you sometimes get outlines over huge areas and it just makes everything harder to read. Another user had similar feedback. 

So, this PR probably doesn't cover what needs to be done to turn of the outlines, I think flake8 and will need to be adjusted to work without them (e.g. get an option)?