### PR TITLE
Add missing documentation on regex group 'code'

### DIFF
--- a/docs/linter_attributes.rst
+++ b/docs/linter_attributes.rst
@@ -165,6 +165,7 @@ The pattern must contain at least the following named capture groups:
 | Name      | Description                                                     |
 +===========+=================================================================+
 | line      | The line number on which the problem occurred                   |
++-----------+-----------------------------------------------------------------+
 | message   | The description of the problem                                  |
 +-----------+-----------------------------------------------------------------+
 
@@ -194,6 +195,8 @@ the pattern should contain the following named capture groups when possible:
 |           | linter provides a column number, you may still use              |
 |           | this capture group and SublimeLinter will highlight that text   |
 |           | (stripped of quotes) exactly.                                   |
++-----------+-----------------------------------------------------------------+
+| code      | The corresponding error code given by the linter, if supported. |
 +-----------+-----------------------------------------------------------------+
 
 


### PR DESCRIPTION
The linter attributes documentation had a couple issues. Firstly,
the 'line' and 'message' name and description appear as one line
in the documentation. This makes it confusing to know that there
are actually two separate capture groups.

Secondly, the capture group 'code' was undocumented. This is a
known group that plugins such as pylint use to show the error code
corresponding to the message.

Signed-off-by: Eric Brown <browne@vmware.com>