### PR TITLE
Fast toggle highlighted regions

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -20,6 +20,11 @@
         }
     },
     {
+        "caption": "SublimeLinter: Toggle highlighted regions",
+        "command": "sublime_linter_toggle_highlights"
+
+    },
+    {
         "caption": "SublimeLinter: Reload SublimeLinter and its Plugins",
         "command": "sublime_linter_reload"
 

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -170,6 +170,9 @@ class IdleViewController(sublime_plugin.EventListener):
 
 def set_idle(view, idle):
     vid = view.id()
+    if vid in State['quiet_views']:
+        return
+
     current_idle = vid in State['idle_views']
     if idle != current_idle:
         if idle:


### PR DESCRIPTION
Related #1149 

This implements fast toggling of the highlighted regions of the current view. 

Since the linter stays active, we have *instant* visual feedback. 