### PR TITLE
fix #1137 add code, type and linter to template

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -99,8 +99,11 @@
 
     // Show the messages for problems at your cursor position
     // {message} will be replaced by the actual messages.
+    // {linter} will be replaced by the linter reporting the error.
+    // {type} will be replaced by either warning or error.
+    // {code} will be replaced by the error code.
     // Set to "" to display nothing
-    "statusbar.messages_template": "{messages}",
+    "statusbar.messages_template": "{message}",
 
     // Global styles for all linters.
     // - mark_style options:

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -96,15 +96,19 @@ def messages_under_cursor(errors, current_pos):
     line, col = current_pos
     msgs = []
     message_template = persist.settings.get('statusbar.messages_template')
-    for error in errors[line]:
-        if error["start"] <= col <= error["end"]:
-            msgs.append(message_template.format(
-                linter=error["linter"],
-                type=error["error_type"],
-                message=error["msg"],
-                code=error["code"]
-            ))
-    return "; ".join(msgs)
+
+    if message_template != "":
+        for error in errors[line]:
+            if error["start"] <= col <= error["end"]:
+                msgs.append(message_template.format(
+                    linter=error["linter"],
+                    type=error["error_type"],
+                    message=error["msg"],
+                    code=error["code"]
+                ))
+        return "; ".join(msgs)
+    else:
+        return ""
 
 
 def errors_per_line(errors):

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -85,22 +85,26 @@ def draw(active_view, we_count, current_pos, errors_per_line, **kwargs):
     else:
         active_view.erase_status(STATUS_COUNTER_KEY)
 
-    msgs = messages_under_cursor(errors_per_line, current_pos)
-    message_template = persist.settings.get('statusbar.messages_template')
-    if msgs:
-        message = message_template.format(messages="; ".join(msgs))
-        if message != active_view.get_status(STATUS_MSG_KEY):
-            active_view.set_status(STATUS_MSG_KEY, message)
+    message = messages_under_cursor(errors_per_line, current_pos)
+    if message != active_view.get_status(STATUS_MSG_KEY):
+        active_view.set_status(STATUS_MSG_KEY, message)
     else:
         active_view.erase_status(STATUS_MSG_KEY)
 
 
 def messages_under_cursor(errors, current_pos):
     line, col = current_pos
-    return [
-        error['msg'] for error in errors[line]
-        if error["start"] <= col <= error["end"]
-    ]
+    msgs = []
+    message_template = persist.settings.get('statusbar.messages_template')
+    for error in errors[line]:
+        if error["start"] <= col <= error["end"]:
+            msgs.append(message_template.format(
+                linter=error["linter"],
+                type=error["error_type"],
+                message=error["msg"],
+                code=error["code"]
+            ))
+    return "; ".join(msgs)
 
 
 def errors_per_line(errors):

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -86,10 +86,10 @@ def draw(active_view, we_count, current_pos, errors_per_line, **kwargs):
         active_view.erase_status(STATUS_COUNTER_KEY)
 
     message = messages_under_cursor(errors_per_line, current_pos)
-    if message != active_view.get_status(STATUS_MSG_KEY):
-        active_view.set_status(STATUS_MSG_KEY, message)
-    else:
+    if not message:
         active_view.erase_status(STATUS_MSG_KEY)
+    elif message != active_view.get_status(STATUS_MSG_KEY):
+        active_view.set_status(STATUS_MSG_KEY, message)
 
 
 def messages_under_cursor(errors, current_pos):


### PR DESCRIPTION
In stead of just "messages", adds the other info available in `errors_per_line` as optional parts in the template. E.g.:

```
"statusbar.messages_template": "{message} -- {type} << {linter} ^^ {code}"
```

Oh yeah, this breaks for people who customized the current template because it’s no longer messages plural. Can’t imagine a lot of people did anything else with it than setting it to “” though.