### PR TITLE
loadsave/manual: show panel on_lint_end if errors

### DIFF
--- a/panel_view.py
+++ b/panel_view.py
@@ -26,7 +26,7 @@ OUTPUT_PANEL_SETTINGS = {
 State = {
     'active_view': None,
     'current_pos': (-1, -1),
-    'awaited_views': set()
+    'just_saved_buffers': set()
 }
 
 
@@ -57,9 +57,9 @@ def on_lint_result(buffer_id, **kwargs):
 def on_finished_linting(buffer_id, **kwargs):
     if (
         persist.settings.get('lint_mode') == 'manual' or
-        buffer_id in State['awaited_views']
+        buffer_id in State['just_saved_buffers']
     ):
-        State['awaited_views'].discard(buffer_id)
+        State['just_saved_buffers'].discard(buffer_id)
 
         for window in sublime.windows():
             if buffer_id in buffer_ids_per_window(window):
@@ -132,15 +132,15 @@ class UpdateState(sublime_plugin.EventListener):
 class JustSavedBufferController(sublime_plugin.EventListener):
     def on_post_save_async(self, view):
         bid = view.buffer_id()
-        State['awaited_views'].add(bid)
+        State['just_saved_buffers'].add(bid)
 
     def on_pre_close(self, view):
         bid = view.buffer_id()
-        State['awaited_views'].discard(bid)
+        State['just_saved_buffers'].discard(bid)
 
     def on_modified_async(self, view):
         bid = view.buffer_id()
-        State['awaited_views'].discard(bid)
+        State['just_saved_buffers'].discard(bid)
 
 
 def buffers_effective_lint_mode_is_background(bid):

--- a/panel_view.py
+++ b/panel_view.py
@@ -56,13 +56,19 @@ def on_lint_result(buffer_id, **kwargs):
 def on_finished_linting(buffer_id, **kwargs):
     show_panel_on_save = persist.settings.get('show_panel_on_save')
     lint_mode = persist.settings.get('lint_mode')
+    save_only_linter = False
+    linters = persist.view_linters.get(buffer_id, [])
 
-    if show_panel_on_save == 'never' or lint_mode == 'background':
-        return
+    for lint in linters:
+        if lint.tempfile_suffix == '-':
+            save_only_linter = True
+            break
 
-    for window in sublime.windows():
-        if buffer_id in buffer_ids_per_window(window) and not panel_is_active(window):
-            show_panel_if_errors(window, buffer_id)
+    if show_panel_on_save != 'never' and (lint_mode != 'background' or save_only_linter):
+        for window in sublime.windows():
+            if buffer_id in buffer_ids_per_window(window) and not panel_is_active(window):
+                show_panel_if_errors(window, buffer_id)
+                break
 
 
 class UpdateState(sublime_plugin.EventListener):

--- a/panel_view.py
+++ b/panel_view.py
@@ -149,8 +149,18 @@ def buffers_effective_lint_mode_is_background(bid):
 
 
 def show_panel_if_errors(window, bid):
+    if window is None:
+        return
+
+    if panel_is_active(window):
+        return
+
+    show_panel_on_save = persist.settings.get('show_panel_on_save')
+    if show_panel_on_save == 'never':
+        return
+
     errors_by_bid = get_window_errors(window, persist.errors)
-    if persist.settings.get('show_panel_on_save') == 'window' and errors_by_bid:
+    if show_panel_on_save == 'window' and errors_by_bid:
         window.run_command("show_panel", {"panel": OUTPUT_PANEL})
     elif bid in errors_by_bid:
         window.run_command("show_panel", {"panel": OUTPUT_PANEL})


### PR DESCRIPTION
This might take some more commits, but attempts to fix #1200.

- [ ] show the panel for load_save and manual modes (ie. on `events.LINT_END`)
- [ ] show the panel if results come in after `on_post_save_async` for background linting
- [ ] show the panel if the panel if there is a lint-only linter active

My first attempt addresses the first issue here by showing the panel if results come in and `lint_mode` is not "background". It should however not show `on_load` I think.

The second issue seems really tricky to me. If you're editing immediately after saving, how do we know if those errors are related to saving? When do we unsubscribe from LINT_END? Asynchronicity breaks my brain, so perhaps someone else should try to tackle that, or perhaps point me in the right direction.

-----

Edit: ok, that's as far as I get right now.