### PR TITLE
fix #1222 On save only mode

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -39,6 +39,7 @@
     // background: asynchronously on every change
     // load_save: when a file is opened and every time it's saved
     // manual: only when calling the Lint This View command
+    // save: only when a file is saved
     "lint_mode": "background",
 
     // Example of linter specific settings.

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -23,7 +23,7 @@
         },
         "lint_mode":{
             "type":"string",
-            "pattern":"^(background|load_save|manual)$"
+            "pattern":"^(background|load_save|manual|save)$"
         },
         "linters":{
             "type":"object",

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -119,7 +119,7 @@ class BackendController(sublime_plugin.EventListener):
         # early. This fires a bit too often for 'load_save' mode but it is
         # good enough.
 
-        if persist.settings.get('lint_mode') == 'manual':
+        if persist.settings.get('lint_mode') in ('manual', 'save'):
             return
 
         if not util.is_lintable(view):


### PR DESCRIPTION
Back by popular demand: "save" `lint_mode`. Kinda like manual because it only runs on demand, kinda like "load_save", but without the "load" part. It's a cheap feature, so why not.