### PR TITLE
Feature - docs: sort linter settings

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -33,6 +33,17 @@ disable
 Disables the linter.
 
 
+env
+---
+Set additional environment variables.
+
+.. code-block:: json
+
+    {
+        "env": "{'GEM_HOME': '~/foo/bar'}"
+    }
+
+
 executable
 ----------
 
@@ -45,17 +56,6 @@ At any time you can manually set the executable a linter should use.
     }
 
 See :ref:`Settings Expansion <settings-expansion>` for more info on using variables.
-
-
-env
----
-Set additional environment variables.
-
-.. code-block:: json
-
-    {
-        "env": "{'GEM_HOME': '~/foo/bar'}"
-    }
 
 
 working_dir

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -90,6 +90,7 @@ binary on your system matching that version (using PATH).
 It then executes ``python -m script_name``
 (where script_name is e.g. ``flake8``).
 
+
 selector
 --------
 

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -44,6 +44,28 @@ Set additional environment variables.
     }
 
 
+excludes
+--------
+This setting specifies a list of path patterns to exclude from linting.
+If there is only a single pattern, the value may be a string.
+Otherwise it must be an array of patterns.
+
+Patterns are matched against a file’s **absolute path** with all symlinks/shortcuts resolved.
+This means to match a filename, you must match everything in the path before the filename.
+For example, to exclude any python files whose name begins with “foo”, you would use this pattern:
+
+.. code-block:: json
+
+    {
+        "excludes": "*/foo*.py"
+    }
+
+The default value is an empty array.
+Untitled views can be ignored with ``<untitled>``,
+and you can use ``!`` to negate a pattern.
+Note that :ref:`Settings Expansion <settings-expansion>` can be used here as well.
+
+
 executable
 ----------
 
@@ -75,28 +97,6 @@ Here the linter will get invoked from the ``${folder}`` directory
 or the file's directory if it is not contained within a project folder.
 
 See :ref:`Settings Expansion <settings-expansion>` for more info on using variables.
-
-
-excludes
---------
-This setting specifies a list of path patterns to exclude from linting.
-If there is only a single pattern, the value may be a string.
-Otherwise it must be an array of patterns.
-
-Patterns are matched against a file’s **absolute path** with all symlinks/shortcuts resolved.
-This means to match a filename, you must match everything in the path before the filename.
-For example, to exclude any python files whose name begins with “foo”, you would use this pattern:
-
-.. code-block:: json
-
-    {
-        "excludes": "*/foo*.py"
-    }
-
-The default value is an empty array. 
-Untitled views can be ignored with ``<untitled>``,
-and you can use ``!`` to negate a pattern. 
-Note that :ref:`Settings Expansion <settings-expansion>` can be used here as well.
 
 
 python

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -3,6 +3,31 @@ Linter Settings
 Each linter plugin can provide its own settings. SublimeLinter already provides these for every linter:
 
 
+args
+----
+Specifies extra arguments to pass to an external binary.
+
+The value may be a string or an array. If it is a string,
+it will be parsed as if it were passed on a command line.
+For example, these values are equivalent:
+
+.. code-block:: json
+
+    {
+        "args": "--foo=bar --bar=7 --no-baz"
+    }
+
+    {
+        "args": [
+            "--foo=bar",
+            "--bar=7",
+            "--no-baz"
+        ]
+    }
+
+The default value is an empty array.
+
+
 disable
 -------
 Disables the linter.
@@ -31,30 +56,6 @@ Set additional environment variables.
     {
         "env": "{'GEM_HOME': '~/foo/bar'}"
     }
-
-args
-----
-Specifies extra arguments to pass to an external binary.
-
-The value may be a string or an array. If it is a string,
-it will be parsed as if it were passed on a command line.
-For example, these values are equivalent:
-
-.. code-block:: json
-
-    {
-        "args": "--foo=bar --bar=7 --no-baz"
-    }
-
-    {
-        "args": [
-            "--foo=bar",
-            "--bar=7",
-            "--no-baz"
-        ]
-    }
-
-The default value is an empty array.
 
 
 working_dir

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -80,25 +80,6 @@ At any time you can manually set the executable a linter should use.
 See :ref:`Settings Expansion <settings-expansion>` for more info on using variables.
 
 
-working_dir
------------
-This setting specifies the linter working directory.
-The value must be a string, corresponding to a valid directory path.
-
-For example (this is also the default):
-
-.. code-block:: json
-
-    {
-        "working_dir": "${folder:$file_path}"
-    }
-
-Here the linter will get invoked from the ``${folder}`` directory
-or the file's directory if it is not contained within a project folder.
-
-See :ref:`Settings Expansion <settings-expansion>` for more info on using variables.
-
-
 python
 ------
 
@@ -139,3 +120,22 @@ To do that, we can override the selector for this linter:
 
 To find out what selector to use for given file type, use the
 "Tools > Developer > Show Scope Name" menu entry.
+
+
+working_dir
+-----------
+This setting specifies the linter working directory.
+The value must be a string, corresponding to a valid directory path.
+
+For example (this is also the default):
+
+.. code-block:: json
+
+    {
+        "working_dir": "${folder:$file_path}"
+    }
+
+Here the linter will get invoked from the ``${folder}`` directory
+or the file's directory if it is not contained within a project folder.
+
+See :ref:`Settings Expansion <settings-expansion>` for more info on using variables.


### PR DESCRIPTION
Move sections of linter_settings.rst in such way, so that they are in alphabetical order.
Section move per commit for easier readability.