### PR TITLE
Variable debounce time and upper limit to reduce concurrency

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -3,7 +3,7 @@
     "debug": false,
 
     // When in the "background" lint mode, this value determines
-    // a delay before a request is send to the linter
+    // the minimum delay before a request is send to the linter
     "delay": 0.3,
 
     // Available gutter themes:

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -4,7 +4,7 @@
 
     // When in the "background" lint mode, this value determines
     // the minimum delay before a request is send to the linter
-    "delay": 0.3,
+    "delay": 0.1,
 
     // Available gutter themes:
     // Blueberry Cross

--- a/lint/queue.py
+++ b/lint/queue.py
@@ -1,5 +1,3 @@
-from . import persist
-
 import threading
 
 
@@ -7,11 +5,7 @@ import threading
 timers = {}
 
 
-def debounce(callback, delay=None, key=None):
-    if delay is None:
-        delay = get_delay()
-    key = key or callback
-
+def debounce(callback, delay, key):
     try:
         timers[key].cancel()
     except KeyError:
@@ -37,15 +31,3 @@ def unload():
             return
         else:
             timer.cancel()
-
-
-def get_delay():
-    """Return the delay between a lint request and when it will be processed.
-
-    If the lint mode is not background, there is no delay. Otherwise, if
-    a "delay" setting is not available in any of the settings, MIN_DELAY is used.
-    """
-    if persist.settings.get('lint_mode') != 'background':
-        return 0
-
-    return persist.settings.get('delay')

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -248,6 +248,7 @@ def hit(view):
     bid = view.buffer_id()
 
     delay = get_delay()
+    logger.info('Delay buffer {} for {:.2}s'.format(bid, delay))
     lock = guard_check_linters_for_view[bid]
     view_has_changed = make_view_has_changed_fn(view)
     fn = partial(lint, view, view_has_changed, lock)
@@ -289,7 +290,9 @@ def lint(view, view_has_changed, lock):
     backend.lint_view(linters, view, view_has_changed, next)
 
     end_time = time.time()
-    remember_runtime(end_time - start_time)
+    runtime = end_time - start_time
+    logger.info('Linting buffer {} took {:.2f}s'.format(bid, runtime))
+    remember_runtime(runtime)
     events.broadcast(events.LINT_END, {'buffer_id': bid})
 
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -416,6 +416,7 @@ def environment_is_ready():
 
 
 elapsed_runtimes = deque([0.6] * 3, maxlen=10)
+MAX_DEBOUNCE_DELAY = 2.0
 
 
 def get_delay():
@@ -427,7 +428,7 @@ def get_delay():
     middle = runtimes[len(runtimes) // 2]
     return max(
         persist.settings.get('delay'),
-        middle / 2)
+        min(MAX_DEBOUNCE_DELAY, middle / 2))
 
 
 def remember_runtime(elapsed_runtime):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -365,7 +365,7 @@ def make_view_has_changed_fn(view):
 
         changed = view.change_count() != initial_change_count
         if changed:
-            persist.debug(
+            logger.info(
                 'Buffer {} inconsistent. Aborting lint.'
                 .format(view.buffer_id()))
 


### PR DESCRIPTION
The debouncer is actually the central station to reduce concurrency and to not overload
the CPU. If the debounce time ("delay") and process time do not "match" we grow unbounded and the queue length 💥 

So, we measure the actual runtime of each lint and adjust the debounce delay. 

Otherwise, we just have a upper limit of n tasks to run in parallel

Fixes #1201 