### PR TITLE
[WIP] Kill old lint processes before starting more

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -61,7 +61,7 @@ def kill_active_popen_calls(bid):
         active_popen = persist.active_popen_calls[bid][:]
 
     for popen in active_popen:
-        popen.kill()
+        popen.terminate()
 
 
 def run_tasks(tasks, next):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1051,7 +1051,8 @@ class Linter(metaclass=LinterMeta):
             code,
             output_stream=self.error_stream,
             env=env,
-            cwd=cwd)
+            cwd=cwd,
+            bid=self.view.buffer_id())
 
     def tmpfile(self, cmd, code, suffix=''):
         """Run an external executable using a temp file to pass code and return its output."""

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -1,6 +1,7 @@
 """This module provides persistent global storage for other modules."""
 
 from collections import defaultdict
+import threading
 
 from .util import printf
 from .settings import Settings
@@ -20,6 +21,11 @@ linter_classes = {}
 
 # A mapping between buffer ids and a set of linter instances
 view_linters = {}
+
+# Dict[buffer_id, [Popen]]
+active_popen_calls = defaultdict(list)
+
+global_lock = threading.RLock()
 
 
 def debug_mode():


### PR DESCRIPTION
**DO NOT MERGE** Just a proof of concept implementation!

Instead of just spawning lint processes (popen) as requested, `kill` outdated procs.

Note: Windows throws `BrokenPipeError` if we kill a proc which we catch and eat. If x systems throw something different, we will need to adjust the `except` clause in util.

Note: Only implemented for STDIN linters.