### PR TITLE
Add a tooltip-on-cusor-move feature

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -83,6 +83,9 @@
     // Show a report for problems on a region by hovering over it.
     "show_hover_region_report": true,
 
+    // Show report for all problems on the cursor's line
+    "show_cursor_line_report": false,
+
     // Highlight problems in the minimap.
     "show_marks_in_minimap": true,
 

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -88,6 +88,9 @@
         "show_hover_region_report":{
             "type":"boolean"
         },
+        "show_cursor_line_report":{
+            "type":"boolean"
+        },
         "show_marks_in_minimap":{
             "type":"boolean"
         },

--- a/tooltips_view.py
+++ b/tooltips_view.py
@@ -8,6 +8,19 @@ from .lint.const import WARNING, ERROR
 
 
 class TooltipController(sublime_plugin.EventListener):
+    def on_selection_modified(self, view):
+      """Fired whenever selection is modified or cursor is moved
+
+        Arguments:
+            view (View): The view which received the event.
+      """
+
+      # In addition to the preference, don't display if any text is selected.
+      if (len(view.sel()) == 1 and
+          view.sel()[0].empty() and
+          persist.settings.get('show_cursor_line_report')):
+        open_tooltip(view, None, True)
+
     def on_hover(self, view, point, hover_zone):
         """On mouse hover event hook.
 


### PR DESCRIPTION
Adds a feature to display tooltips based on cusor position. The preference is disabled by default.

I wanted this for me, but I thought you might want this in the main project as well. I can rework it if there's something you'd like to see before landing it. Or if you decide it's not something you want, no hard feelings.

![linter video](https://user-images.githubusercontent.com/12676/37670029-e186bf9e-2c2d-11e8-9462-f4f2388a4e76.gif)
