### PR TITLE
put killswitch and restart message in sublime_linter

### DIFF
--- a/lint/persist.py
+++ b/lint/persist.py
@@ -7,7 +7,6 @@ from .settings import Settings
 
 
 api_ready = False
-kill_switch = True
 
 settings = Settings()
 


### PR DESCRIPTION
@kaste from #1249

What seems to happen during an upgrade and then reload is that new parts of SL are talking to old parts of SL. We can try to keep things consistent between versions, but even simple renames can break this. We also cannot be sure that users aren't skipping versions, so we cannot deal with this effectively. 

I think we need to make sure that what happens in`events.post_upgrade` doesn't rely on anything outside `sublime_linter.py`, as much as possible. 

- This PR adds a `restart_message()`, because panels are really simple anyway so we don't lose much here by not reusing the other panel.
- Additionally, `kill_switch` isn't used by other parts of SL, so if we don't put it in persist that will perhaps save us some headaches next time we want to refactor this.
