### PR TITLE
Alt take on linter names in the status bar

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -95,10 +95,9 @@
     // Set to "never" to disable this feature.
     "show_panel_on_save": "never",
 
-    // Display counters in the status bar.
-    // {warning} and {error} will be replaced with the actual numbers.
-    // Set to "" to display nothing
-    "statusbar.counters_template": "W: {warning} E: {error}",
+    // DEPRECATED: If you've modified this in your user settings,
+    // remove it now to avoid future breakage.
+    "statusbar.counters_template": "",
 
     // Show the messages for problems at your cursor position
     // {message} will be replaced by the actual messages.

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -108,6 +108,8 @@
     // Set to "" to display nothing
     "statusbar.messages_template": "{message}",
 
+    "statusbar.show_active_linters": true,
+
     // Global styles for all linters.
     // - mark_style options:
     //   "none"

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -4,12 +4,15 @@ import sublime
 import sublime_plugin
 
 from .lint import events, persist
+from .lint.const import WARNING, ERROR
 
 
 STATUS_ACTIVE_KEY = 'sublime_linter_status_active'
 
 State = {
-    'active_linters_per_bid': defaultdict(set),
+    'assigned_linters_per_bid': defaultdict(set),
+    'failed_linters_per_bid': defaultdict(set),
+    'problems_per_bid': defaultdict(dict),
     'needs_redraw': set()
 }
 
@@ -23,50 +26,67 @@ def plugin_unloaded():
 
 
 @events.on(events.LINT_RESULT)
-def redraw_bid(buffer_id, **kwargs):
-    if buffer_id not in State['needs_redraw']:
-        return
+def redraw_bid(buffer_id, linter_name, errors, **kwargs):
+    problems = State['problems_per_bid'][buffer_id]
+    if linter_name in State['failed_linters_per_bid'][buffer_id]:
+        problems[linter_name] = '(erred)'
+    elif linter_name in State['assigned_linters_per_bid'][buffer_id]:
+        we_count = count_problems(errors)
+        if we_count == (0, 0):
+            problems[linter_name] = '(ok)'
+        else:
+            problems[linter_name] = '({}|{})'.format(*we_count)
+    else:
+        problems.pop(linter_name, None)
 
-    State['needs_redraw'].discard(buffer_id)
-    active_linters = State['active_linters_per_bid'][buffer_id]
-    for window in sublime.windows():
-        for view in window.views():
-            if view.buffer_id() == buffer_id:
-                draw(view, active_linters)
+    for view in views_by_buffer(buffer_id):
+        if view.buffer_id() == buffer_id:
+            draw(view, problems)
+
+
+def views_by_buffer(bid):
+    return (view for window in sublime.windows() for view in window.views())
+
+
+def count_problems(errors):
+    w, e = 0, 0
+    for error in errors:
+        error_type = error['error_type']
+        if error_type == WARNING:
+            w += 1
+        elif error_type == ERROR:
+            e += 1
+    return (w, e)
 
 
 class sublime_linter_assigned(sublime_plugin.WindowCommand):
     def run(self, bid, linter_names):
-        current_state = State['active_linters_per_bid'][bid]
+        current_state = State['assigned_linters_per_bid'][bid]
         next_state = set(linter_names)
         if current_state == next_state:
             return
 
-        State['active_linters_per_bid'][bid] = next_state
-        State['needs_redraw'].add(bid)
+        State['assigned_linters_per_bid'][bid] = next_state
+        State['failed_linters_per_bid'][bid] = set()
 
 
 class sublime_linter_deactivated(sublime_plugin.WindowCommand):
     def run(self, bid, linter_name):
-        set_active_status(bid, linter_name, active=False)
+        State['failed_linters_per_bid'][bid].add(linter_name)
 
 
-def set_active_status(bid, linter_name, active):
-    active_linters = State['active_linters_per_bid'][bid]
-    current_state = linter_name in active_linters
-    if current_state == active:
-        return
-
-    if active:
-        active_linters.add(linter_name)
-    else:
-        active_linters.discard(linter_name)
-
-    State['needs_redraw'].add(bid)
+class UpdateState(sublime_plugin.EventListener):
+    # Fires once per view with the actual view, not necessary the primary
+    def on_activated_async(self, active_view):
+        draw(active_view, State['problems_per_bid'][active_view.buffer_id()])
 
 
-def draw(view, active_linters):
+def draw(view, problems):
     if persist.settings.get('statusbar.show_active_linters'):
-        view.set_status(STATUS_ACTIVE_KEY, ', '.join(sorted(active_linters)))
+        message = ', '.join(
+            '{}{}'.format(linter_name, summary)
+            for linter_name, summary in sorted(problems.items())
+        )
+        view.set_status(STATUS_ACTIVE_KEY, message)
     else:
         view.erase_status(STATUS_ACTIVE_KEY)

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -22,7 +22,7 @@ def plugin_unloaded():
             view.erase_status(STATUS_ACTIVE_KEY)
 
 
-@events.on(events.LINT_END)
+@events.on(events.LINT_RESULT)
 def redraw_bid(buffer_id, **kwargs):
     if buffer_id not in State['needs_redraw']:
         return

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -70,7 +70,7 @@ class sublime_linter_assigned(sublime_plugin.WindowCommand):
         State['failed_linters_per_bid'][bid] = set()
 
 
-class sublime_linter_deactivated(sublime_plugin.WindowCommand):
+class sublime_linter_failed(sublime_plugin.WindowCommand):
     def run(self, bid, linter_name):
         State['failed_linters_per_bid'][bid].add(linter_name)
 

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -3,32 +3,56 @@ from collections import defaultdict
 import sublime
 import sublime_plugin
 
+from .lint import events
+
 
 STATUS_ACTIVE_KEY = 'sublime_linter_status_active'
 
 State = {
-    'active_linters_per_vid': defaultdict(set)
+    'active_linters_per_bid': defaultdict(set),
+    'needs_redraw': set()
 }
 
 
 def plugin_unloaded():
+    events.off(redraw_bid)
+
     for window in sublime.windows():
         for view in window.views():
             view.erase_status(STATUS_ACTIVE_KEY)
 
 
-class sublime_linter_activated(sublime_plugin.WindowCommand):
-    def run(self, vid, linter_name):
-        set_active_status(vid, linter_name, active=True)
+@events.on(events.LINT_END)
+def redraw_bid(buffer_id, **kwargs):
+    if buffer_id not in State['needs_redraw']:
+        return
+
+    State['needs_redraw'].discard(buffer_id)
+    active_linters = State['active_linters_per_bid'][buffer_id]
+    for window in sublime.windows():
+        for view in window.views():
+            if view.buffer_id() == buffer_id:
+                draw(view, active_linters)
+
+
+class sublime_linter_assigned(sublime_plugin.WindowCommand):
+    def run(self, bid, linter_names):
+        current_state = State['active_linters_per_bid'][bid]
+        next_state = set(linter_names)
+        if current_state == next_state:
+            return
+
+        State['active_linters_per_bid'][bid] = next_state
+        State['needs_redraw'].add(bid)
 
 
 class sublime_linter_deactivated(sublime_plugin.WindowCommand):
-    def run(self, vid, linter_name):
-        set_active_status(vid, linter_name, active=False)
+    def run(self, bid, linter_name):
+        set_active_status(bid, linter_name, active=False)
 
 
-def set_active_status(vid, linter_name, active):
-    active_linters = State['active_linters_per_vid'][vid]
+def set_active_status(bid, linter_name, active):
+    active_linters = State['active_linters_per_bid'][bid]
     current_state = linter_name in active_linters
     if current_state == active:
         return
@@ -38,9 +62,8 @@ def set_active_status(vid, linter_name, active):
     else:
         active_linters.discard(linter_name)
 
-    view = sublime.View(vid)
-    draw(view, active_linters)
+    State['needs_redraw'].add(bid)
 
 
 def draw(view, active_linters):
-    view.set_status(STATUS_ACTIVE_KEY, ', '.join(active_linters))
+    view.set_status(STATUS_ACTIVE_KEY, ', '.join(sorted(active_linters)))

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -1,0 +1,46 @@
+from collections import defaultdict
+
+import sublime
+import sublime_plugin
+
+
+STATUS_ACTIVE_KEY = 'sublime_linter_status_active'
+
+State = {
+    'active_linters_per_vid': defaultdict(set)
+}
+
+
+def plugin_unloaded():
+    for window in sublime.windows():
+        for view in window.views():
+            view.erase_status(STATUS_ACTIVE_KEY)
+
+
+class sublime_linter_activated(sublime_plugin.WindowCommand):
+    def run(self, vid, linter_name):
+        set_active_status(vid, linter_name, active=True)
+
+
+class sublime_linter_deactivated(sublime_plugin.WindowCommand):
+    def run(self, vid, linter_name):
+        set_active_status(vid, linter_name, active=False)
+
+
+def set_active_status(vid, linter_name, active):
+    active_linters = State['active_linters_per_vid'][vid]
+    current_state = linter_name in active_linters
+    if current_state == active:
+        return
+
+    if active:
+        active_linters.add(linter_name)
+    else:
+        active_linters.discard(linter_name)
+
+    view = sublime.View(vid)
+    draw(view, active_linters)
+
+
+def draw(view, active_linters):
+    view.set_status(STATUS_ACTIVE_KEY, ', '.join(active_linters))

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import sublime
 import sublime_plugin
 
-from .lint import events
+from .lint import events, persist
 
 
 STATUS_ACTIVE_KEY = 'sublime_linter_status_active'
@@ -66,4 +66,7 @@ def set_active_status(bid, linter_name, active):
 
 
 def draw(view, active_linters):
-    view.set_status(STATUS_ACTIVE_KEY, ', '.join(sorted(active_linters)))
+    if persist.settings.get('statusbar.show_active_linters'):
+        view.set_status(STATUS_ACTIVE_KEY, ', '.join(sorted(active_linters)))
+    else:
+        view.erase_status(STATUS_ACTIVE_KEY)

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -43,8 +43,15 @@ def lint_view(linters, view, view_has_changed, next):
 
     # The contract here is that we MUST fire 'updates' for every linter, so
     # that the views (status bar etc) actually update.
+    window = view.window()
+    vid = view.id()
     for linter in disabled_linters:
         next(linter, [])
+        if window:
+            window.run_command('sublime_linter_deactivated', {
+                'vid': vid,
+                'linter_name': linter.name
+            })
 
     lint_tasks = get_lint_tasks(enabled_linters, view, view_has_changed)
 
@@ -168,7 +175,11 @@ def filter_linters(linters, view):
 
     enabled, disabled = [], []
     for linter in linters:
-        # First check to see if the linter can run in the current lint mode.
+        if linter.disabled:
+            disabled.append(linter)
+            continue
+
+        # Check if the linter can run in the current lint mode.
         if linter.tempfile_suffix == '-' and view.is_dirty():
             # Do *not* add to disabled to not invalidate errors `on_modified`
             continue

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -8,7 +8,7 @@ import logging
 import os
 import threading
 
-from . import util
+from . import util, linter as linter_module
 
 
 logger = logging.getLogger(__name__)
@@ -184,7 +184,7 @@ def filter_linters(linters, view):
             # Do *not* add to disabled to not invalidate errors `on_modified`
             continue
 
-        view_settings = linter._get_view_settings()
+        view_settings = linter_module.get_linter_settings(linter, view)
 
         if view_settings.get('disable'):
             disabled.append(linter)

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -171,10 +171,6 @@ def get_selectors(linter, wanted_syntax):
 def filter_linters(linters, view):
     enabled, disabled = [], []
     for linter in linters:
-        if linter.disabled:
-            disabled.append(linter)
-            continue
-
         # Check if the linter can run in the current lint mode.
         if linter.tempfile_suffix == '-' and view.is_dirty():
             # Do *not* add to disabled to not invalidate errors `on_modified`

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -171,11 +171,6 @@ def get_selectors(linter, wanted_syntax):
 def filter_linters(linters, view):
     enabled, disabled = [], []
     for linter in linters:
-        # Check if the linter can run in the current lint mode.
-        if linter.tempfile_suffix == '-' and view.is_dirty():
-            # Do *not* add to disabled to not invalidate errors `on_modified`
-            continue
-
         settings = linter_module.get_linter_settings(linter, view)
         enabled.append((linter, settings))
 

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -81,6 +81,7 @@ def execute_lint_task(linter, code, offset, view_has_changed, settings, task_nam
 
         return errors
     except BaseException:
+        linter.notify_failure()
         # Log while multi-threaded to get a nicer log message
         logger.exception('Linter crashed.\n\n')
         return []  # Empty list here to clear old errors

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -74,7 +74,7 @@ class NodeLinter(linter.Linter):
         filename = self.view.file_name()
         cwd = (
             os.path.dirname(filename) if filename else
-            linter.guess_project_path(self.view.window(), filename)
+            linter.guess_project_root_of_view(self.view)
         )
         return self.rev_parse_manifest_path(cwd) if cwd else None
 

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -74,7 +74,7 @@ class NodeLinter(linter.Linter):
         filename = self.view.file_name()
         cwd = (
             os.path.dirname(filename) if filename else
-            self._guess_project_path(self.view.window(), filename)
+            linter.guess_project_path(self.view.window(), filename)
         )
         return self.rev_parse_manifest_path(cwd) if cwd else None
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -451,6 +451,14 @@ class Linter(metaclass=LinterMeta):
                 "CRITICAL: {}: Calling 'get_view_settings' outside "
                 "of lint context".format(self.name))
 
+    def notify_failure(self):
+        window = self.view.window()
+        if window:
+            window.run_command('sublime_linter_failed', {
+                'bid': self.view.buffer_id(),
+                'linter_name': self.name
+            })
+
     def which(self, cmd):
         """Return full path to a given executable.
 
@@ -759,12 +767,7 @@ class Linter(metaclass=LinterMeta):
         else:
             cmd = self.get_cmd()
             if not cmd:  # We couldn't find an executable
-                window = self.view.window()
-                if window:
-                    window.run_command('sublime_linter_failed', {
-                        'bid': self.view.buffer_id(),
-                        'linter_name': self.name
-                    })
+                self.notify_failure()
                 return None  # ABORT
             output = self.run(cmd, code)
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -735,9 +735,6 @@ class Linter(metaclass=LinterMeta):
         - If the view has been modified in between, stop.
         - Parse the linter output with the regex.
         """
-        if self.disabled:
-            return []
-
         canonical_filename = (
             os.path.basename(self.view.file_name()) if self.view.file_name()
             else '<untitled {}>'.format(self.view.buffer_id()))
@@ -756,7 +753,14 @@ class Linter(metaclass=LinterMeta):
             output = self.run(None, code)
         else:
             cmd = self.get_cmd()
-            if not cmd:  # We couldn't find a executable
+            if not cmd:  # We couldn't find an executable
+                window = self.view.window()
+                if window:
+                    vid = self.view.id()
+                    window.run_command('sublime_linter_deactivated', {
+                        'vid': vid,
+                        'linter_name': self.name
+                    })
                 return []
             output = self.run(cmd, code)
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -107,7 +107,8 @@ def get_linter_settings(linter, window=None):
     return ChainMap({}, project_settings, user_settings, defaults)
 
 
-def guess_project_path(window, filename):
+def guess_project_root_of_view(view):
+    window = view.window()
     if not window:
         return None
 
@@ -115,6 +116,7 @@ def guess_project_path(window, filename):
     if not folders:
         return None
 
+    filename = view.file_name()
     if not filename:
         return folders[0]
 
@@ -422,14 +424,13 @@ class Linter(metaclass=LinterMeta):
         and supports placeholders (`${varname:placeholder}`).
 
         Note that we ship a enhanced version for 'folder' if you have multiple
-        folders open in a window. See `guess_project_path`.
+        folders open in a window. See `guess_project_root_of_view`.
         """
         window = self.view.window()
         variables = ChainMap(
             {}, window.extract_variables() if window else {}, os.environ)
 
-        filename = self.view.file_name()
-        project_folder = guess_project_path(window, filename)
+        project_folder = guess_project_root_of_view(self.view)
         if project_folder:
             variables['folder'] = project_folder
 
@@ -437,6 +438,7 @@ class Linter(metaclass=LinterMeta):
         # `active_view`, so we need to pass in all the relevant data around
         # the filename manually in case the user switches to a different
         # view, before we're done here.
+        filename = self.view.file_name()
         if filename:
             basename = os.path.basename(filename)
             file_base_name, file_extension = os.path.splitext(basename)
@@ -712,7 +714,7 @@ class Linter(metaclass=LinterMeta):
 
         filename = self.view.file_name()
         return (
-            guess_project_path(self.view.window(), filename) or
+            guess_project_root_of_view(self.view) or
             (os.path.dirname(filename) if filename else None)
         )
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -761,12 +761,11 @@ class Linter(metaclass=LinterMeta):
             if not cmd:  # We couldn't find an executable
                 window = self.view.window()
                 if window:
-                    vid = self.view.id()
                     window.run_command('sublime_linter_deactivated', {
-                        'vid': vid,
+                        'bid': self.view.buffer_id(),
                         'linter_name': self.name
                     })
-                return []
+                return None  # ABORT
             output = self.run(cmd, code)
 
         if not output:

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -92,7 +92,15 @@ class VirtualView:
     # def rowcol(self, point) => (row, col)
 
 
-def get_linter_settings(linter, window=None):
+def get_raw_linter_settings(linter, window=None):
+    """Return 'raw' linter settings without variables substituted.
+
+    Settings are merged in the following order:
+
+    default settings (on the class or instance)
+    user settings
+    project settings
+    """
     # Note: linter can be a linter class or a linter instance
 
     defaults = linter.defaults or {}
@@ -443,7 +451,7 @@ class Linter(metaclass=LinterMeta):
         # Note that when files are loaded during quick panel preview,
         # it can happen that they are linted without having a window.
         window = self.view.window()
-        settings = get_linter_settings(self, window)
+        settings = get_raw_linter_settings(self, window)
         context = get_view_context(self.view)
         return substitute_variables(context, settings)
 
@@ -965,7 +973,7 @@ class Linter(metaclass=LinterMeta):
 
     @classmethod
     def can_lint_view(cls, view):
-        settings = get_linter_settings(cls, view.window())
+        settings = get_raw_linter_settings(cls, view.window())
         selector = settings.get('selector')
         if selector:
             return (

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -761,7 +761,7 @@ class Linter(metaclass=LinterMeta):
             if not cmd:  # We couldn't find an executable
                 window = self.view.window()
                 if window:
-                    window.run_command('sublime_linter_deactivated', {
+                    window.run_command('sublime_linter_failed', {
                         'bid': self.view.buffer_id(),
                         'linter_name': self.name
                     })

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -129,6 +129,9 @@ def guess_project_root_of_view(view):
 
 
 def get_view_context(view):
+    # Note that we ship a enhanced version for 'folder' if you have multiple
+    # folders open in a window. See `guess_project_root_of_view`.
+
     window = view.window()
     context = ChainMap(
         {}, window.extract_variables() if window else {}, os.environ)
@@ -156,6 +159,9 @@ def get_view_context(view):
 
 
 def substitute_variables(variables, value):
+    # Utilizes Sublime Text's `expand_variables` API, which uses the
+    # `${varname}` syntax and supports placeholders (`${varname:placeholder}`).
+
     if isinstance(value, str):
         value = sublime.expand_variables(value, variables)
         return os.path.expanduser(value)
@@ -438,21 +444,6 @@ class Linter(metaclass=LinterMeta):
         # it can happen that they are linted without having a window.
         window = self.view.window()
         settings = get_linter_settings(self, window)
-        return self.replace_settings_tokens(settings)
-
-    def replace_settings_tokens(self, settings):
-        """Replace tokens with values in settings.
-
-        Settings can be a string, a mapping or a sequence,
-        and replacement is recursive.
-
-        Utilizes Sublime Text's `expand_variables` API,
-        which uses the `${varname}` syntax
-        and supports placeholders (`${varname:placeholder}`).
-
-        Note that we ship a enhanced version for 'folder' if you have multiple
-        folders open in a window. See `guess_project_root_of_view`.
-        """
         context = get_view_context(self.view)
         return substitute_variables(context, settings)
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -115,6 +115,14 @@ def get_raw_linter_settings(linter, window=None):
     return ChainMap({}, project_settings, user_settings, defaults)
 
 
+def get_linter_settings(linter, view):
+    """Return 'final' linter settings with all variables expanded."""
+    # Note: linter can be a linter class or a linter instance
+    settings = get_raw_linter_settings(linter, view.window())
+    context = get_view_context(view)
+    return substitute_variables(context, settings)
+
+
 def guess_project_root_of_view(view):
     window = view.window()
     if not window:
@@ -436,24 +444,6 @@ class Linter(metaclass=LinterMeta):
             raise RuntimeError(
                 "CRITICAL: {}: Calling 'get_view_settings' outside "
                 "of lint context".format(self.name))
-
-    def _get_view_settings(self):
-        """Return a union of all settings specific to this view's linter.
-
-        The settings are merged in the following order:
-
-        default settings
-        user settings
-        project settings
-
-        After merging, tokens in the settings are replaced.
-        """
-        # Note that when files are loaded during quick panel preview,
-        # it can happen that they are linted without having a window.
-        window = self.view.window()
-        settings = get_raw_linter_settings(self, window)
-        context = get_view_context(self.view)
-        return substitute_variables(context, settings)
 
     def which(self, cmd):
         """Return full path to a given executable.

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -425,6 +425,11 @@ class Linter(metaclass=LinterMeta):
         # bc some ruby linters rely on that behavior.
         self.env = {}
 
+        # Ensure instances have their own copy in case a plugin author
+        # mangles it.
+        if self.defaults is not None:
+            self.defaults = self.defaults.copy()
+
     @property
     def filename(self):
         """Return the view's file path or '' if unsaved."""

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -104,6 +104,9 @@
         "statusbar.messages_template":{
             "type":"string"
         },
+        "statusbar.show_active_linters":{
+            "type":"boolean"
+        },
         "styles":{
             "type":"array",
             "items":{

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -331,14 +331,13 @@ def get_linters_for_view(view):
             for linter_class in wanted_linter_classes
         }
         persist.view_linters[bid] = linters
-        window = view.window()
-        if window:
-            vid = view.id()
-            for linter in linters:
-                window.run_command('sublime_linter_activated', {
-                    'vid': vid,
-                    'linter_name': linter.name
-                })
+
+    window = view.window()
+    if window:
+        window.run_command('sublime_linter_assigned', {
+            'bid': bid,
+            'linter_names': [linter.name for linter in linters]
+        })
 
     return linters
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -323,6 +323,14 @@ def get_linters_for_view(view):
             for linter_class in wanted_linter_classes
         }
         persist.view_linters[bid] = linters
+        window = view.window()
+        if window:
+            vid = view.id()
+            for linter in linters:
+                window.run_command('sublime_linter_activated', {
+                    'vid': vid,
+                    'linter_name': linter.name
+                })
 
     return linters
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -318,6 +318,14 @@ def get_linters_for_view(view):
     }
     current_linter_classes = {linter.__class__ for linter in linters}
 
+    window = view.window()
+    if window:
+        window.run_command('sublime_linter_assigned', {
+            'bid': bid,
+            'linter_names': [
+                linter_class.name for linter_class in wanted_linter_classes]
+        })
+
     if current_linter_classes != wanted_linter_classes:
         unchanged_buffer = lambda: False  # noqa: E731
         for linter in (current_linter_classes - wanted_linter_classes):
@@ -331,13 +339,6 @@ def get_linters_for_view(view):
             for linter_class in wanted_linter_classes
         }
         persist.view_linters[bid] = linters
-
-    window = view.window()
-    if window:
-        window.run_command('sublime_linter_assigned', {
-            'bid': bid,
-            'linter_names': [linter.name for linter in linters]
-        })
 
     return linters
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -303,10 +303,7 @@ def get_linters_for_view(view):
     wanted_linter_classes = {
         linter_class
         for linter_class in persist.linter_classes.values()
-        if (
-            not linter_class.disabled and
-            linter_class.can_lint_view(view)
-        )
+        if linter_class.can_lint_view(view)
     }
     current_linter_classes = {linter.__class__ for linter in linters}
 


### PR DESCRIPTION
Better prototype than talk.

Instead of our we counter, show something like `annotations(ok), flake8(2|12), php(erred)` in the status.

Obviously on top of #1274 
Fixes #1205 