### PR TITLE
Iterate around popen call

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -37,6 +37,10 @@
     // the regions. E.g. try 'comment' to get a soft gray.
     "highlights.demote_scope": "",
 
+    // Send `terminate` signal to old lint processes, if their result would
+    // be thrown away. If false we fire-and-forget processes instead.
+    "kill_old_processes": false,
+
     // Lint Modes determine when the linter is run
     // background: asynchronously on every change
     // load_save: when a file is opened and every time it's saved

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -59,7 +59,7 @@ class PythonLinter(linter.Linter):
                     return True, None
 
                 logger.info(
-                    "{}: Using {} for given python '{}'"
+                    "{}: Using '{}' for given python '{}'"
                     .format(self.name, python_bin, python)
                 )
                 return True, [python_bin, '-m', cmd_name]

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -201,7 +201,7 @@ def get_python_version(path):
     """Return a dict with the major/minor version of the python at path."""
     try:
         # Different python versions use different output streams, so check both
-        output = util.communicate((path, '-V'), '', output_stream=util.STREAM_BOTH)
+        output = util.communicate((path, '-V'), output_stream=util.STREAM_BOTH)
 
         # 'python -V' returns 'Python <version>', extract the version number
         return extract_major_minor_version(output.split(' ')[1])

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1095,7 +1095,7 @@ class Linter(metaclass=LinterMeta):
             output_stream=self.error_stream,
             env=env,
             cwd=cwd,
-            _filename=self.filename)
+            _view=self.view)
 
     def tmpfile(self, cmd, code, suffix=''):
         """Run an external executable using a temp file to pass code and return its output."""

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1119,4 +1119,5 @@ class Linter(metaclass=LinterMeta):
             suffix or self.get_tempfile_suffix(),
             output_stream=self.error_stream,
             env=env,
-            cwd=cwd)
+            cwd=cwd,
+            _view=self.view)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1080,15 +1080,6 @@ class Linter(metaclass=LinterMeta):
         cwd = self.get_working_dir(settings)
         env = self.get_environment(settings)
 
-        if logger.isEnabledFor(logging.INFO):
-            logger.info('{}: {} {}'.format(
-                self.name,
-                os.path.basename(self.filename or '<unsaved>'),
-                cmd)
-            )
-            if cwd:
-                logger.info('{}: cwd: {}'.format(self.name, cwd))
-
         return util.communicate(
             cmd,
             code,
@@ -1102,15 +1093,6 @@ class Linter(metaclass=LinterMeta):
         settings = self.get_view_settings()
         cwd = self.get_working_dir(settings)
         env = self.get_environment(settings)
-
-        if logger.isEnabledFor(logging.INFO):
-            logger.info('{}: {} {}'.format(
-                self.name,
-                os.path.basename(self.filename or '<unsaved>'),
-                cmd)
-            )
-            if cwd:
-                logger.info('{}: cwd: {}'.format(self.name, cwd))
 
         return util.tmpfile(
             cmd,

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1082,7 +1082,7 @@ class Linter(metaclass=LinterMeta):
         env = self.get_environment(settings)
 
         return util.communicate(cmd, code, output_stream=self.error_stream,
-                                env=env, cwd=cwd, _view=self.view)
+                                env=env, cwd=cwd, _linter=self)
 
     def tmpfile(self, cmd, code, suffix=''):
         """Run an external executable using a temp file to pass code and return its output."""
@@ -1111,6 +1111,6 @@ class Linter(metaclass=LinterMeta):
             env = self.get_environment(settings)
 
             return util.communicate(cmd, output_stream=self.error_stream,
-                                    env=env, cwd=cwd, _view=self.view)
+                                    env=env, cwd=cwd, _linter=self)
         finally:
             os.remove(path)

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -1,6 +1,7 @@
 """This module provides persistent global storage for other modules."""
 
 from collections import defaultdict
+import threading
 
 from .util import printf
 from .settings import Settings
@@ -20,6 +21,10 @@ linter_classes = {}
 
 # A mapping between buffer ids and a set of linter instances
 view_linters = {}
+
+# Dict[buffer_id, [Popen]]
+active_procs = defaultdict(list)
+active_procs_lock = threading.Lock()
 
 
 def debug_mode():

--- a/lint/util.py
+++ b/lint/util.py
@@ -172,11 +172,11 @@ RUNNING_TEMPLATE = """{headline}
 
   {cwd}  (working dir)
   {prompt}{pipe} {cmd}
-
 """
 
 PIPE_TEMPLATE = ' type {} |' if os.name == 'nt' else ' cat {} |'
-ENV_TEMPLATE = """  Modified environment:
+ENV_TEMPLATE = """
+  Modified environment:
 
   {env}
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -1,5 +1,6 @@
 """This module provides general utility methods."""
 
+from collections import ChainMap
 from functools import lru_cache
 import locale
 import logging
@@ -239,7 +240,6 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
             startupinfo=create_startupinfo()
         )
     except Exception as err:
-        from collections import ChainMap
         try:
             augmented_env = dict(ChainMap(*env.maps[0:-1]))
         except AttributeError:

--- a/lint/util.py
+++ b/lint/util.py
@@ -242,6 +242,7 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
             stderr=subprocess.PIPE if output_stream & STREAM_STDERR else None,
             startupinfo=create_startupinfo()
         )
+
     except Exception as err:
         try:
             augmented_env = dict(ChainMap(*env.maps[0:-1]))
@@ -256,18 +257,19 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
 
         return ''
 
-    if logger.isEnabledFor(logging.INFO):
-        logger.info(make_nice_log_message(
-            'Running ...', cmd, uses_stdin, cwd, view, None))
+    else:
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(make_nice_log_message(
+                'Running ...', cmd, uses_stdin, cwd, view, None))
 
-    out = proc.communicate(code)
+        out = proc.communicate(code)
 
-    if output_stream == STREAM_STDOUT:
-        return _post_process_fh(out[0])
-    if output_stream == STREAM_STDERR:
-        return _post_process_fh(out[1])
-    if output_stream == STREAM_BOTH:
-        return ''.join(_post_process_fh(fh) for fh in out)
+        if output_stream == STREAM_STDOUT:
+            return _post_process_fh(out[0])
+        if output_stream == STREAM_STDERR:
+            return _post_process_fh(out[1])
+        if output_stream == STREAM_BOTH:
+            return ''.join(_post_process_fh(fh) for fh in out)
 
 
 def _post_process_fh(fh):

--- a/lint/util.py
+++ b/lint/util.py
@@ -216,7 +216,7 @@ def make_nice_log_message(headline, cmd, is_stdin,
 
 
 def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
-                _view=None):
+                _linter=None):
     """
     Return the result of sending code via stdin to an executable.
 
@@ -246,14 +246,16 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
             augmented_env = None
         logger.error(make_nice_log_message(
             '  Execution failed\n\n  {}'.format(str('err')),
-            cmd, code is not None, cwd, _view,
-            augmented_env))
+            cmd, code is not None, cwd,
+            _linter.view if _linter else None, augmented_env))
 
         return ''
 
     if logger.isEnabledFor(logging.INFO):
         logger.info(make_nice_log_message(
-            'Running ...', cmd, code is not None, cwd, _view, None))
+            'Running ...',
+            cmd, code is not None, cwd,
+            _linter.view if _linter else None, None))
 
     out = proc.communicate(code)
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -240,10 +240,14 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
         )
     except Exception as err:
         from collections import ChainMap
+        try:
+            augmented_env = dict(ChainMap(*env.maps[0:-1]))
+        except AttributeError:
+            augmented_env = None
         logger.error(make_nice_log_message(
-            '  Execution failed\n\n  {}'.format(str(err)),
+            '  Execution failed\n\n  {}'.format(str('err')),
             cmd, code is not None, cwd, _filename,
-            dict(ChainMap(*env.maps[0:-1])) if env else None))
+            augmented_env))
 
         return ''
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -194,9 +194,11 @@ def make_nice_log_message(headline, cmd, is_stdin,
     elif not filename:
         rel_filename = '<unsaved>'
 
+    real_cwd = cwd if cwd else os.path.realpath(os.path.curdir)
+
     exec_msg = RUNNING_TEMPLATE.format(
         headline=headline,
-        cwd=cwd,
+        cwd=real_cwd,
         prompt='>' if os.name == 'nt' else '$',
         pipe=PIPE_TEMPLATE.format(rel_filename) if is_stdin else '',
         cmd=' '.join(cmd)

--- a/lint/util.py
+++ b/lint/util.py
@@ -231,6 +231,8 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
     if env is None:
         env = create_environment()
 
+    view = _linter.view if _linter else None
+
     try:
         proc = subprocess.Popen(
             cmd, env=env, cwd=cwd,
@@ -246,8 +248,7 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
             augmented_env = None
         logger.error(make_nice_log_message(
             '  Execution failed\n\n  {}'.format(str('err')),
-            cmd, code is not None, cwd,
-            _linter.view if _linter else None, augmented_env))
+            cmd, code is not None, cwd, view, augmented_env))
 
         if _linter:
             _linter.notify_failure()
@@ -256,9 +257,7 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
 
     if logger.isEnabledFor(logging.INFO):
         logger.info(make_nice_log_message(
-            'Running ...',
-            cmd, code is not None, cwd,
-            _linter.view if _linter else None, None))
+            'Running ...', cmd, code is not None, cwd, view, None))
 
     out = proc.communicate(code)
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -232,11 +232,12 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
         env = create_environment()
 
     view = _linter.view if _linter else None
+    uses_stdin = code is not None
 
     try:
         proc = subprocess.Popen(
             cmd, env=env, cwd=cwd,
-            stdin=subprocess.PIPE if code is not None else None,
+            stdin=subprocess.PIPE if uses_stdin else None,
             stdout=subprocess.PIPE if output_stream & STREAM_STDOUT else None,
             stderr=subprocess.PIPE if output_stream & STREAM_STDERR else None,
             startupinfo=create_startupinfo()
@@ -248,7 +249,7 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
             augmented_env = None
         logger.error(make_nice_log_message(
             '  Execution failed\n\n  {}'.format(str('err')),
-            cmd, code is not None, cwd, view, augmented_env))
+            cmd, uses_stdin, cwd, view, augmented_env))
 
         if _linter:
             _linter.notify_failure()
@@ -257,7 +258,7 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
 
     if logger.isEnabledFor(logging.INFO):
         logger.info(make_nice_log_message(
-            'Running ...', cmd, code is not None, cwd, view, None))
+            'Running ...', cmd, uses_stdin, cwd, view, None))
 
     out = proc.communicate(code)
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -8,7 +8,6 @@ import os
 import re
 import sublime
 import subprocess
-import tempfile
 
 
 logger = logging.getLogger(__name__)
@@ -287,42 +286,6 @@ def decode(bytes):
         return bytes.decode('utf8')
     except UnicodeError:
         return bytes.decode(locale.getpreferredencoding(), errors='replace')
-
-
-def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT,
-            env=None, cwd=None, _view=None):
-    """
-    Return the result of running an executable against a temporary file containing code.
-
-    It is assumed that the executable launched by cmd can take one more argument
-    which is a filename to process.
-
-    The result is a string combination of stdout and stderr.
-    If env is None, the result of create_environment is used.
-    """
-    file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
-    path = file.name
-
-    try:
-        file.write(bytes(code, 'UTF-8'))
-        file.close()
-
-        cmd = list(cmd)
-
-        if '${file}' in cmd:
-            cmd[cmd.index('${file}')] = filename
-
-        if '${temp_file}' in cmd:
-            cmd[cmd.index('${temp_file}')] = path
-        elif '@' in cmd:  # legacy SL3 crypto-identifier
-            cmd[cmd.index('@')] = path
-        else:
-            cmd.append(path)
-
-        return communicate(cmd, output_stream=output_stream,
-                           env=env, cwd=cwd, _view=_view)
-    finally:
-        os.remove(path)
 
 
 def create_startupinfo():

--- a/lint/util.py
+++ b/lint/util.py
@@ -289,7 +289,8 @@ def decode(bytes):
         return bytes.decode(locale.getpreferredencoding(), errors='replace')
 
 
-def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=None, cwd=None):
+def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT,
+            env=None, cwd=None, _view=None):
     """
     Return the result of running an executable against a temporary file containing code.
 
@@ -318,7 +319,8 @@ def tmpfile(cmd, code, filename, suffix='', output_stream=STREAM_STDOUT, env=Non
         else:
             cmd.append(path)
 
-        return communicate(cmd, output_stream=output_stream, env=env, cwd=cwd)
+        return communicate(cmd, output_stream=output_stream,
+                           env=env, cwd=cwd, _view=_view)
     finally:
         os.remove(path)
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -185,14 +185,15 @@ ENV_TEMPLATE = """
 
 
 def make_nice_log_message(headline, cmd, is_stdin,
-                          cwd=None, filename=None, env=None):
+                          cwd=None, view=None, env=None):
     import pprint
     import textwrap
 
+    filename = view.file_name() if view else None
     if filename and cwd:
         rel_filename = os.path.relpath(filename, cwd)
     elif not filename:
-        rel_filename = '<unsaved>'
+        rel_filename = '<buffer {}>'.format(view.buffer_id()) if view else '<?>'
 
     real_cwd = cwd if cwd else os.path.realpath(os.path.curdir)
 
@@ -216,7 +217,7 @@ def make_nice_log_message(headline, cmd, is_stdin,
 
 
 def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
-                _filename=None):
+                _view=None):
     """
     Return the result of sending code via stdin to an executable.
 
@@ -246,14 +247,14 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
             augmented_env = None
         logger.error(make_nice_log_message(
             '  Execution failed\n\n  {}'.format(str('err')),
-            cmd, code is not None, cwd, _filename,
+            cmd, code is not None, cwd, _view,
             augmented_env))
 
         return ''
 
     if logger.isEnabledFor(logging.INFO):
         logger.info(make_nice_log_message(
-            'Running ...', cmd, code is not None, cwd, _filename, None))
+            'Running ...', cmd, code is not None, cwd, _view, None))
 
     out = proc.communicate(code)
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -249,6 +249,9 @@ def communicate(cmd, code=None, output_stream=STREAM_STDOUT, env=None, cwd=None,
             cmd, code is not None, cwd,
             _linter.view if _linter else None, augmented_env))
 
+        if _linter:
+            _linter.notify_failure()
+
         return ''
 
     if logger.isEnabledFor(logging.INFO):

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -18,6 +18,9 @@
             "type":"string",
             "pattern":"^(none|ws_regions|warnings|all)$"
         },
+        "kill_old_processes":{
+            "type":"boolean"
+        },
         "highlights.demote_scope": {
             "type":"string"
         },

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -283,6 +283,9 @@ def lint(view, view_has_changed, lock):
 
     bid = view.buffer_id()
 
+    if persist.settings.get('kill_old_processes'):
+        kill_active_popen_calls(bid)
+
     events.broadcast(events.LINT_START, {'buffer_id': bid})
     start_time = time.time()
 
@@ -302,6 +305,14 @@ def skip_linter(linter, view):
         return True
 
     return False
+
+
+def kill_active_popen_calls(bid):
+    with persist.active_procs_lock:
+        procs = persist.active_procs[bid][:]
+
+    for proc in procs:
+        proc.terminate()
 
 
 def update_buffer_errors(bid, view_has_changed, linter, errors):


### PR DESCRIPTION
- Enable fancy logging for tmpfile
- Inline tmpfile. Move from util to linter
- Do not use STDIN for `python -V` checks

Prepare #1263 , #1290 

Replaces #1250 
Fixes #1288 
Fixes #1201 