### PR TITLE
Sync goto command to actual regions

### DIFF
--- a/goto_commands.py
+++ b/goto_commands.py
@@ -17,12 +17,7 @@ class SublimeLinterGotoError(sublime_plugin.WindowCommand):
 
 def goto(view, direction, count, wrap):
     bid = view.buffer_id()
-
-    try:
-        errors = persist.errors[bid]
-    except KeyError:
-        flash(view, 'No problems')
-        return
+    errors = persist.errors[bid]
 
     if len(errors) == 0:
         flash(view, 'No problems')

--- a/goto_commands.py
+++ b/goto_commands.py
@@ -112,13 +112,6 @@ def move_to(view, point):
         window.open_file(target, sublime.ENCODED_POSITION)
 
 
-def get_current_pos(view):
-    try:
-        return view.rowcol(view.sel()[0].begin())
-    except (AttributeError, IndexError):
-        return -1, -1
-
-
 def flash(view, msg):
     window = view.window() or sublime.active_window()
     window.status_message(msg)

--- a/goto_commands.py
+++ b/goto_commands.py
@@ -66,11 +66,13 @@ def goto(view, direction, count, wrap):
     if not jump_positions:
         if wrap:
             error = errors[-1] if reverse else errors[0]
+            flash(
+                view,
+                'Jumped to {} problem'.format('last' if reverse else 'first'))
         else:
             flash(
                 view,
-                'No more problems {}'.format('above' if reverse else 'below')
-            )
+                'No more problems {}'.format('above' if reverse else 'below'))
             return
     elif len(jump_positions) <= count:
         # If we cannot jump wide enough, do not wrap, but jump as wide as


### PR DESCRIPTION
Instead of jumping to the next/previous error as stated in `persist.errors` we jump to the next/previous highlighted region. This is so that after editing a view (and before the next lint result comes in) we still jump correctly. 

For this to work, we now draw invisible regions if the user set 'mark_style' to 'none'. (Before we dropped these errors.)  