### PR TITLE
Abortable backend

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -81,17 +81,17 @@ def get_lint_tasks(linters, view, view_has_changed):
 
 
 def execute_lint_task(linter, code, offset, view_has_changed, settings, task_name):
+    # We 'name' our threads, for logging purposes.
+    threading.current_thread().name = task_name
+
     start_time = time.time()
     with reduced_concurrency:
+        end_time = time.time()
+        waittime = end_time - start_time
+        if waittime > 0.1:
+            logger.warning('Waited in queue for {:.2f}s'.format(waittime))
+
         try:
-            # We 'name' our threads, for logging purposes.
-            threading.current_thread().name = task_name
-
-            end_time = time.time()
-            waittime = end_time - start_time
-            if waittime > 0.1:
-                logger.warning('Waited in queue for {:.2f}s'.format(waittime))
-
             errors = linter.lint(code, view_has_changed, settings) or []
             finalize_errors(linter.view, errors, offset)
 

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -18,7 +18,7 @@ from . import util, linter as linter_module
 logger = logging.getLogger(__name__)
 
 WILDCARD_SYNTAX = '*'
-MAX_CONCURRENT_TASKS = (multiprocessing.cpu_count() or 1) * 5
+MAX_CONCURRENT_TASKS = multiprocessing.cpu_count() or 1
 
 
 task_count = count(start=1)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -715,13 +715,10 @@ class Linter(metaclass=LinterMeta):
                 self.notify_failure()
                 return []
 
-            try:
-                output = self.run(cmd, code)  # type: util.popen_output
-            except TransientError:
-                return None  # ABORT
+            output = self.run(cmd, code)  # type: util.popen_output
 
         if view_has_changed():
-            return None  # ABORT
+            raise TransientError('View not consistent.')
 
         virtual_view = VirtualView(code)
         return self.parse_output(output, virtual_view)


### PR DESCRIPTION
If `linter.lint` throws TransientError cancel all pending tasks and do not update the error database. E.g. do not draw new highlights.