### PR TITLE
consider the shell_environment setting

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -382,6 +382,13 @@ def environment_is_ready():
     if ready:
         return True
 
+    s = sublime.load_settings("Preferences.sublime-settings")
+    if not s.get('shell_environment', False):
+        # If false, ST will not read the env from the shell,
+        # so it's as ready as it will ever get
+        ENV_IS_READY_STATE['ready'] = True
+        return True
+
     path = os.environ['PATH']
     if '/local/' in path:
         logger.info('Env seems ok: PATH: {}'.format(path))


### PR DESCRIPTION
Via this comment: https://github.com/SublimeLinter/SublimeLinter/pull/1266#issuecomment-385582192

If `shell_environment` is set to false, we only set the env to "ready" after the timeout runs out because ST will never update then env.