### PR TITLE
Reraise exceptions during reloading

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -73,6 +73,7 @@ class SublimeLinterReloadCommand(sublime_plugin.WindowCommand):
             reloader.reload_everything()
         except Exception:
             show_restart_message()
+            raise  # Still write the traceback to the console!
         finally:
             log_handler.install()
 


### PR DESCRIPTION
We reraise here, which basically means we write the traceback to the console.
Otherwise we can never improve here bc we can never see why reloading failed.