### PR TITLE
`cls.disabled` takes precedence over settings

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -220,7 +220,7 @@ class LinterMeta(type):
             return
 
         name = attrs.get('name') or cls_name.lower()
-        setattr(cls, 'disabled', False)
+        setattr(cls, 'disabled', None)
         setattr(cls, 'name', name)
 
         # BEGIN DEPRECATIONS
@@ -451,10 +451,9 @@ class Linter(metaclass=LinterMeta):
     # setting is replaced with <name>.
     defaults = None
 
-    #
-    # Internal class storage, do not set
-    #
-    disabled = False
+    # `disabled` has three states (None, True, False). It takes precedence
+    # over all other user or project settings.
+    disabled = None
 
     def __init__(self, view, syntax):
         self.view = view
@@ -977,12 +976,12 @@ class Linter(metaclass=LinterMeta):
 
     @classmethod
     def can_lint_view(cls, view):
-        if cls.disabled:
+        if cls.disabled is True:
             return False
 
         settings = get_linter_settings(cls, view)
 
-        if settings.get('disable'):
+        if cls.disabled is None and settings.get('disabled'):
             return False
 
         if not cls.matches_selector(view, settings):


### PR DESCRIPTION
Let `cls.disabled` have three states (None, True, False). None
being the default will ask for user settings, a boolean value
though will overwrite any other user settings.

This allows to activate a linter plugin *in-memory* which is
otherwise disabled via user settings.