### PR TITLE
fix list index out of range

### DIFF
--- a/lint/style.py
+++ b/lint/style.py
@@ -1,5 +1,6 @@
 import sublime
 from . import persist, util
+from .const import WARNING, ERROR
 
 import logging
 import os
@@ -96,7 +97,7 @@ class HighlightStyleStore:
         def fetch_style(linter_name):
             x = [v.get(key) for k, v
                  in styles.items()
-                 if linter_name in k and error_type in v.get("types", [])]
+                 if linter_name in k and error_type in v.get("types", [ERROR, WARNING])]
 
             if x[0]:
                 return x[0]


### PR DESCRIPTION
Linter specific styles only require a scope, however, if mark_style was missing you'd get an error.

Example settings:
```json
"flake8": {
    "styles": [
        {
            "scope": "comment",
            "codes": ["W293", "W291", "W292"]
        }
    ]
}
```

Error:
```
Traceback (most recent call last):
  File "/Users/koenlageveen/Library/Application Support/Sublime Text 3/Packages/SublimeLinter/lint/events.py", line 28, in broadcast
    fn(**payload)
  File "/Users/koenlageveen/Library/Application Support/Sublime Text 3/Packages/SublimeLinter/highlight_view.py", line 85, in on_lint_result
    protected_regions = prepare_protected_regions(view, errors_for_the_gutter)
  File "/Users/koenlageveen/Library/Application Support/Sublime Text 3/Packages/SublimeLinter/highlight_view.py", line 353, in prepare_protected_regions
    prepare_gutter_data(view, 'PROTECTED_REGIONS', errors).values()))
  File "/Users/koenlageveen/Library/Application Support/Sublime Text 3/Packages/SublimeLinter/highlight_view.py", line 415, in prepare_gutter_data
    icon = get_icon(**error)
  File "/Users/koenlageveen/Library/Application Support/Sublime Text 3/Packages/SublimeLinter/highlight_view.py", line 487, in get_icon
    return highlight_store.get_val('icon', style, error_type)
  File "/Users/koenlageveen/Library/Application Support/Sublime Text 3/Packages/SublimeLinter/lint/style.py", line 54, in wrapper
    res = f(*args)
  File "/Users/koenlageveen/Library/Application Support/Sublime Text 3/Packages/SublimeLinter/lint/style.py", line 108, in get_val
    val = fetch_style(linter)
  File "/Users/koenlageveen/Library/Application Support/Sublime Text 3/Packages/SublimeLinter/lint/style.py", line 101, in fetch_style
    if x[0]:
IndexError: list index out of range
```