### PR TITLE
show highlights immediately on activation

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -213,10 +213,12 @@ def demote_warnings(selected_text, error_type, **kwargs):
 class IdleViewController(sublime_plugin.EventListener):
     def on_activated_async(self, active_view):
         previous_view = State['active_view']
+        State.update({'active_view': active_view})
+
         if previous_view and previous_view.id() != active_view.id():
             set_idle(previous_view, True)
 
-        State.update({'active_view': active_view})
+        set_idle(active_view, True)
 
     # Called multiple times (once per buffer) but provided *view* is always
     # the same, the primary one.


### PR DESCRIPTION
fixes #1412 

Not 100% sure if this is the correct way to fix it, but it does seem to yield the behaviour I'm looking for. I really want the highlights to show immediately on opening a file. This way I don't have to wait for the timeout before I get a clear picture of what's wrong. Demote_while_editing exists so it doesn't bother me with errors while I'm still typing (ie. when I'm creating vars that aren't used yet and am creating trailing whitespace I'm going to fix immediately), but when I just opened a file I'm not editing yet.