### PR TITLE
Support lint_mode option for specific linters

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -82,6 +82,15 @@ be a string or a list.
 See :ref:`Settings Expansion <settings-expansion>` for more info on using variables.
 
 
+lint_mode
+---------
+Lint Mode determines when the linter is run.
+- background: asynchronously on every change
+- load_save: when a file is opened and every time it's saved
+- manual: only when calling the Lint This View command
+- save: only when a file is saved
+
+
 python
 ------
 This should point to a python binary on your system. Alternatively

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -85,10 +85,10 @@ See :ref:`Settings Expansion <settings-expansion>` for more info on using variab
 lint_mode
 ---------
 Lint Mode determines when the linter is run.
-- background: asynchronously on every change
-- load_save: when a file is opened and every time it's saved
-- manual: only when calling the Lint This View command
-- save: only when a file is saved
+* `background`: asynchronously on every change
+* `load_save`: when a file is opened and every time it's saved
+* `manual`: only when calling the Lint This View command
+* `save`: only when a file is saved
 
 
 python

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -975,7 +975,11 @@ class Linter(metaclass=LinterMeta):
         return text
 
     @classmethod
-    def can_lint_view(cls, view):
+    def can_lint_view(cls, view, reason=None):
+        """
+        can_lint_view takes view and reason to start linting then returns true/false
+        whether the view should be linted or not.
+        """
         if cls.disabled is True:
             return False
 
@@ -1003,6 +1007,16 @@ class Linter(metaclass=LinterMeta):
                         .format(cls.name, filename, pattern)
                     )
                     return False
+
+        lint_mode = settings.get('lint_mode', 'background')
+        logger.info(
+            "checking lint mode {} vs reason {}"
+            .format(lint_mode, reason)
+        )
+        if lint_mode == 'manual':
+            return reason == 'on_user_request'
+        elif lint_mode in ('save', 'load_save'):
+            return reason in ('on_save', 'on_user_request')
 
         return True
 


### PR DESCRIPTION
This is an attempt PR to close this task #244 . In this PR, I add method `should_lint` in the base linter to support:
- decides whether the linter should start or not based on a given reason
- check `lint_mode` with `reason` to decide whether it should check the given view or not
- allows each custom Linter to programmatically decide whether it should take action on each trigger or not
Docs also is added but not sure if it has the correct format. Please help to verify.