### PR TITLE
Showcase: Allow post filters via setting `filter_errors`

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -81,6 +81,18 @@
 
             "excludes": [],
 
+            // Either a string or a list of strings. Each input string is
+            // handled as a case-insensitive regex pattern and matched against
+            // the error_type, code, and message of a particular lint error.
+            // If it matches, the error will be thrown away.
+            // E.g. "warning: " will remove all warnings but keep errors.
+            // "no-trailing-spaces: " will suppress this rule known from eslint.
+            // "W3\d\d: " will suppress some whitespace errors known from flake8
+            // and pyflakes.
+            // "missing <!DOCTYPE> declaration" will suppress that error known
+            // from htmltidy.
+            "filter_errors": "",
+
             // Lint mode determines when the linter is run. The linter setting
             // will take precedence over the global setting.
             "lint_mode": "manual",

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -53,7 +53,7 @@
 
     // Linter specific settings.
     // More info: http://www.sublimelinter.com/en/stable/linter_settings.html
-    // Linter specific settings except for "styles" can also be changed
+    // Linter specific settings except for 'styles' can also be changed
     // in sublime-project settings.
     // What settings are available is documented in the readme of the
     // specific linter plugin.
@@ -64,34 +64,31 @@
             // Disables the linter. The default here is 'not set'
             "disable": false,
 
-            // Additional arguments for the command line. Either a 'string'
-            // or an 'array'. If set to a string, we 'shlex.split' it*.
+            // Additional arguments for the command line. Either a string
+            // or an array. If set to a string, we 'shlex.split' it*.
             // E.g. '--ignore D112' or ['--config', './.config/foo.ini']
             //
             // * Note: Use proper quoting around paths esp. on Windows!
             "args": [],
 
-            // Path to the executable to be used. Either a 'string' or an
-            // 'array'. E.g. ['nvm', 'exec', '8.6', 'eslint']
+            // Path to the executable to be used. Either a string or an
+            // array. E.g. ['nvm', 'exec', '8.6', 'eslint']
             "executable": "<automatically set>",
 
             // A modified runtime environment for the lint job. Settings here
             // override the default, inherited ENV.
             "env": {},
 
+            // Exclude files that match the given pattern(s).
             "excludes": [],
 
-            // Either a string or a list of strings. Each input string is
-            // handled as a case-insensitive regex pattern and matched against
-            // the error_type, code, and message of a particular lint error.
-            // If it matches, the error will be thrown away.
-            // E.g. "warning: " will remove all warnings but keep errors.
-            // "no-trailing-spaces: " will suppress this rule known from eslint.
-            // "W3\d\d: " will suppress some whitespace errors known from flake8
-            // and pyflakes.
-            // "missing <!DOCTYPE> declaration" will suppress that error known
-            // from htmltidy.
-            "filter_errors": "",
+            // Suppress errors that match the the given pattern(s).
+            // Either a 'string' or an 'array'. Each input string is handled as
+            // a case-insensitive regex pattern and matched against the
+            // error_type, code, and message. If it matches, the error will be
+            // thrown away.
+            // E.g. ["warning: ", "W3\d\d: ", "missing <!DOCTYPE> declaration"]
+            "filter_errors": [],
 
             // Lint mode determines when the linter is run. The linter setting
             // will take precedence over the global setting.

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -93,7 +93,7 @@ a case-insensitive regex pattern, and then matched against the error type, code 
 
 .. note::
 
-    This will completely supress some errors. If you only want to visually demote some errors, take a look at the :ref:`styles <linter_styles>` section below.
+    This will completely supress the matching errors. If you only want to visually demote some errors, take a look at the :ref:`styles <linter_styles>` section below.
 
 Some examples:
 

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -223,6 +223,9 @@ Example: this changes the appearance of whitespace warnings in flake8:
         }
     }
 
+.. note::
+
+    If you set both "mark_style" and "icon" to "none", you get a less noisy view and still can see those errors in the panel.
 
 
 working_dir

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -82,6 +82,41 @@ be a string or a list.
 See :ref:`Settings Expansion <settings-expansion>` for more info on using variables.
 
 
+filter_errors
+-------------
+
+This defines a post filter to suppress some problems a linter might report.
+(Useful if the linter cannot be configured very well.)
+
+The value may be a string or an array of strings. Each string is handled as
+a case-insensitive regex pattern, and then matched against the error type, code (or rule), and message of a particular lint problem. If it matches, the lint error will be thrown away.
+
+.. note::
+
+    This will completely supress some errors. If you only want to visually demote some errors, take a look at the :ref:`styles <linter_styles>` section below.
+
+Some examples:
+
+.. code-block:: json
+
+    {
+        // suppress all warnings
+        "filter_errors": "warning: ",
+
+        // suppress a specific eslint rule
+        "filter_errors": "no-trailing-spaces: ",
+
+        // suppress some flake8/pyflakes rules,
+        "filter_errors": "W3\\d\\d: ",
+
+        // typical html tidy message
+        "filter_errors": "missing <!DOCTYPE> declaration"
+    }
+
+Be aware of special escaping since what you're writing must be valid JSON.
+
+Technical note: For each reported problem we construct a string "<error_type>: <error_code>: <error_message". We then match each regex pattern against that virtual line. We keep the error if *none* of the patterns match, otherwise we keep it.
+
 lint_mode
 ---------
 Lint Mode determines when the linter is run.
@@ -146,6 +181,7 @@ For eslint we disable linting in html script attributes:
     The selector setting takes precedence over the deprecated `syntax` property.
 
 
+.. _linter_styles:
 
 styles
 ------

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -923,10 +923,14 @@ class Linter(metaclass=LinterMeta):
         return self.filter_errors(self.parse_output(output, virtual_view))
 
     def filter_errors(self, errors):
+        filter_patterns = self.get_view_settings().get('filter_errors') or []
+        if isinstance(filter_patterns, str):
+            filter_patterns = [filter_patterns]
+
         try:
             filters = [
                 re.compile(pattern, re.I)
-                for pattern in self.get_view_settings().get('filter_errors', [])
+                for pattern in filter_patterns
             ]
         except re.error as err:
             logger.warning("RegEx error in 'filter_errors': '{}'".format(err))

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -933,13 +933,13 @@ class Linter(metaclass=LinterMeta):
                 try:
                     filters.append(re.compile(pattern, re.I))
                 except re.error as err:
-                    logger.warning(
+                    logger.error(
                         "'{}' in 'filter_errors' is not a valid "
                         "regex pattern: '{}'.".format(pattern, err)
                     )
 
         except TypeError:
-            logger.warning(
+            logger.error(
                 "'filter_errors' must be set to a string or a list of strings.\n"
                 "Got '{}' instead".format(filter_patterns))
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -936,7 +936,7 @@ class Linter(metaclass=LinterMeta):
             error
             for error in errors
             if not any(
-                pattern.search(': '.join([error['code'], error['msg']]))
+                pattern.search(': '.join([error['error_type'], error['code'], error['msg']]))
                 for pattern in filters
             )
         ]

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -933,7 +933,12 @@ class Linter(metaclass=LinterMeta):
                 for pattern in filter_patterns
             ]
         except re.error as err:
-            logger.warning("RegEx error in 'filter_errors': '{}'".format(err))
+            logger.warning("Bad RegEx in 'filter_errors': '{}'".format(err))
+            filters = []
+        except TypeError:
+            logger.warning(
+                "'filter_errors' must be set to a string or a list of strings.\n"
+                "Got '{}' instead".format(filter_patterns))
             filters = []
 
         return [

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -927,19 +927,21 @@ class Linter(metaclass=LinterMeta):
         if isinstance(filter_patterns, str):
             filter_patterns = [filter_patterns]
 
+        filters = []
         try:
-            filters = [
-                re.compile(pattern, re.I)
-                for pattern in filter_patterns
-            ]
-        except re.error as err:
-            logger.warning("Bad RegEx in 'filter_errors': '{}'".format(err))
-            filters = []
+            for pattern in filter_patterns:
+                try:
+                    filters.append(re.compile(pattern, re.I))
+                except re.error as err:
+                    logger.warning(
+                        "'{}' in 'filter_errors' is not a valid "
+                        "regex pattern: '{}'.".format(pattern, err)
+                    )
+
         except TypeError:
             logger.warning(
                 "'filter_errors' must be set to a string or a list of strings.\n"
                 "Got '{}' instead".format(filter_patterns))
-            filters = []
 
         return [
             error

--- a/messages.json
+++ b/messages.json
@@ -7,5 +7,6 @@
     "4.3.0": "messages/4.3.0.txt",
     "4.4.0": "messages/4.4.0.txt",
     "4.5.0": "messages/4.5.0.txt",
-    "4.6.0": "messages/4.6.0.txt"
+    "4.6.0": "messages/4.6.0.txt",
+    "4.9.0": "messages/4.9.0.txt"
 }

--- a/messages/4.9.0.txt
+++ b/messages/4.9.0.txt
@@ -1,0 +1,12 @@
+SublimeLinter 4.9
+=================
+
+You can now filter errors using regexes.
+
+If your linter doesn't allow you to suppress some error types in its
+configuration, or you just want your editor to be silent about some errors,
+you can now filter in SublimeLinter. To do so, set the "filter_errors" setting
+for a specific linter.
+
+More information:
+http://www.sublimelinter.com/en/stable/linter_settings.html

--- a/tests/test_filter_results.py
+++ b/tests/test_filter_results.py
@@ -1,0 +1,172 @@
+from functools import partial
+from textwrap import dedent
+from unittest import skip, expectedFailure  # noqa: F401
+
+import sublime
+from SublimeLinter.lint import (
+    backend,
+    Linter,
+    linter as linter_module,
+    util,
+)
+
+from unittesting import DeferrableTestCase
+from SublimeLinter.tests.parameterized import parameterized as p
+from SublimeLinter.tests.mockito import (
+    when,
+    expect,
+    unstub,
+    verifyNoUnwantedInteractions
+)
+
+
+def drop_keys(keys, array, strict=False):
+    for item in array:
+        for k in keys:
+            item.pop(k) if strict else item.pop(k, None)
+
+
+drop_info_keys = partial(drop_keys, ['error_type', 'code', 'msg', 'linter'])
+drop_position_keys = partial(drop_keys, ['line', 'start', 'end', 'region'])
+
+
+class _BaseTestCase(DeferrableTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.view = sublime.active_window().new_file()
+        # make sure we have a window to work with
+        s = sublime.load_settings("Preferences.sublime-settings")
+        s.set("close_windows_when_empty", False)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.view:
+            cls.view.set_scratch(True)
+            cls.view.window().focus_view(cls.view)
+            cls.view.window().run_command("close_file")
+
+    def setUp(self):
+        when(util).which('fake_linter_1').thenReturn('fake_linter_1')
+        # it's just faster if we mock this out
+        when(linter_module.LinterMeta).register_linter(...).thenReturn(None)
+
+    def tearDown(self):
+        unstub()
+
+
+VIEW_UNCHANGED = lambda: False  # noqa: E731
+execute_lint_task = partial(
+    backend.execute_lint_task, offset=(0, 0), view_has_changed=VIEW_UNCHANGED
+)
+
+
+class TestPostFilterResults(_BaseTestCase):
+    def assertResult(self, expected, actual):
+        drop_keys(['uid', 'priority'], actual)
+        self.assertEqual(expected, actual)
+
+    @p.expand([
+        # Ensure 'falsy' values do not filter anything
+        ([], [{'line': 0}, {'line': 1}, {'line': 2}, {'line': 3}]),
+        (None, [{'line': 0}, {'line': 1}, {'line': 2}, {'line': 3}]),
+        (False, [{'line': 0}, {'line': 1}, {'line': 2}, {'line': 3}]),
+
+        (['age'], []),
+        (['massage'], [{'line': 0}, {'line': 1}, {'line': 2}]),
+
+        # For convenience allow strings as input
+        ('age', []),
+        ('massage', [{'line': 0}, {'line': 1}, {'line': 2}]),
+
+        # All input is interpreted as regex strings
+        (['m[ae]ss'], []),
+        (['mess|mass'], []),
+        (['mess', 'mas{2}'], []),
+
+        # the error code (aka rule name) can be checked
+        (['W3:'], [{'line': 1}, {'line': 2}, {'line': 3}]),
+        (['W3: '], [{'line': 1}, {'line': 2}, {'line': 3}]),
+        (['W3:  '], [{'line': 0}, {'line': 1}, {'line': 2}, {'line': 3}]),
+        ([r'W\d*:'], [{'line': 1}, {'line': 2}, {'line': 3}]),
+
+        # filter error_type 'error'
+        (['error'], [{'line': 0}, {'line': 1}]),
+        (['error:'], [{'line': 0}, {'line': 1}]),
+        (['error: '], [{'line': 0}, {'line': 1}]),
+        (['error:  '], [{'line': 0}, {'line': 1}, {'line': 2}, {'line': 3}]),
+
+        # filter error_type 'warning'
+        (['warning'], [{'line': 2}, {'line': 3}]),
+        (['warning:'], [{'line': 2}, {'line': 3}]),
+        (['warning: '], [{'line': 2}, {'line': 3}]),
+        (['warning:  '], [{'line': 0}, {'line': 1}, {'line': 2}, {'line': 3}]),
+    ], doc_func=lambda f, n, param: repr(param.args[0]))
+    def test_post_filter_results(self, filter_errors, expected):
+        class FakeLinter(Linter):
+            cmd = ('fake_linter_1')
+            defaults = {'selector': None}
+            regex = r"""(?x)
+                ^stdin:(?P<line>\d+):(?P<col>\d+)?\s
+                (\[(?P<warning>[^\]]+)\]\s)?
+                (?P<message>.*)$
+            """
+
+        settings = {
+            'filter_errors': filter_errors
+        }
+        linter = FakeLinter(self.view, settings)
+        INPUT = dedent("""
+        I
+        am
+        the
+        swan""")
+        OUTPUT = dedent("""\
+            stdin:1:1 [w3] The message
+            stdin:2:1 [S534] The message
+            stdin:3:1 The mess age
+            stdin:4:1 The massage
+            """)
+
+        when(linter)._communicate(...).thenReturn(OUTPUT)
+        result = execute_lint_task(linter, INPUT)
+        result = [{'line': error['line']} for error in result]
+
+        self.assertEqual(result, expected)
+
+    @p.expand([
+        (['d('], "Bad RegEx in 'filter_errors': 'unbalanced parenthesis'"),
+        (True, "'filter_errors' must be set to a string or a list of strings.\nGot 'True' instead"),
+        (123, "'filter_errors' must be set to a string or a list of strings.\nGot '123' instead"),
+    ])
+    def test_warn_on_illegal_regex_string(self, filter_errors, warning):
+        class FakeLinter(Linter):
+            cmd = ('fake_linter_1')
+            defaults = {'selector': None}
+            regex = r"""(?x)
+                ^stdin:(?P<line>\d+):(?P<col>\d+)?\s
+                (\[(?P<warning>[^\]]+)\]\s)?
+                (?P<message>.*)$
+            """
+
+        settings = {
+            'filter_errors': filter_errors
+        }
+        linter = FakeLinter(self.view, settings)
+        INPUT = dedent("""
+        I
+        am
+        the
+        swan""")
+        OUTPUT = dedent("""\
+            stdin:1:1 [w3] The message
+            stdin:2:1 [S534] The message
+            stdin:3:1 The mess age
+            stdin:4:1 The massage
+            """)
+
+        when(linter)._communicate(...).thenReturn(OUTPUT)
+        expect(linter_module.logger, times=1).warning(warning)
+        execute_lint_task(linter, INPUT)
+        # `execute_lint_task` eats all uncatched errors, so we check again
+        # to get faster and nicer output during the test
+        verifyNoUnwantedInteractions(linter_module.logger)

--- a/tests/test_filter_results.py
+++ b/tests/test_filter_results.py
@@ -20,7 +20,6 @@ from SublimeLinter.tests.mockito import (
 )
 
 
-
 class _BaseTestCase(DeferrableTestCase):
     @classmethod
     def setUpClass(cls):
@@ -122,7 +121,7 @@ class TestPostFilterResults(_BaseTestCase):
         self.assertEqual(result, expected)
 
     @p.expand([
-        (['d('], "Bad RegEx in 'filter_errors': 'unbalanced parenthesis'"),
+        (['d('], "'d(' in 'filter_errors' is not a valid regex pattern: 'unbalanced parenthesis'."),
         (True, "'filter_errors' must be set to a string or a list of strings.\nGot 'True' instead"),
         (123, "'filter_errors' must be set to a string or a list of strings.\nGot '123' instead"),
     ])

--- a/tests/test_filter_results.py
+++ b/tests/test_filter_results.py
@@ -125,7 +125,7 @@ class TestPostFilterResults(_BaseTestCase):
         (True, "'filter_errors' must be set to a string or a list of strings.\nGot 'True' instead"),
         (123, "'filter_errors' must be set to a string or a list of strings.\nGot '123' instead"),
     ])
-    def test_warn_on_illegal_regex_string(self, filter_errors, warning):
+    def test_warn_on_illegal_regex_string(self, filter_errors, message):
         class FakeLinter(Linter):
             cmd = ('fake_linter_1')
             defaults = {'selector': None}
@@ -152,7 +152,7 @@ class TestPostFilterResults(_BaseTestCase):
             """)
 
         when(linter)._communicate(...).thenReturn(OUTPUT)
-        expect(linter_module.logger, times=1).warning(warning)
+        expect(linter_module.logger, times=1).error(message)
         execute_lint_task(linter, INPUT)
         # `execute_lint_task` eats all uncatched errors, so we check again
         # to get faster and nicer output during the test

--- a/tests/test_filter_results.py
+++ b/tests/test_filter_results.py
@@ -20,15 +20,6 @@ from SublimeLinter.tests.mockito import (
 )
 
 
-def drop_keys(keys, array, strict=False):
-    for item in array:
-        for k in keys:
-            item.pop(k) if strict else item.pop(k, None)
-
-
-drop_info_keys = partial(drop_keys, ['error_type', 'code', 'msg', 'linter'])
-drop_position_keys = partial(drop_keys, ['line', 'start', 'end', 'region'])
-
 
 class _BaseTestCase(DeferrableTestCase):
     @classmethod
@@ -61,9 +52,6 @@ execute_lint_task = partial(
 
 
 class TestPostFilterResults(_BaseTestCase):
-    def assertResult(self, expected, actual):
-        drop_keys(['uid', 'priority'], actual)
-        self.assertEqual(expected, actual)
 
     @p.expand([
         # Ensure 'falsy' values do not filter anything


### PR DESCRIPTION
`filter_errors` takes a list of regexes which will get matched against
the string "{code}: {message}".

Typical usage e.g. `"filter_errors": ["W291"]` for flake8

This is a 15 line implementation.

Closes https://github.com/SublimeLinter/SublimeLinter-golint/pull/8
Fixes https://github.com/SublimeLinter/SublimeLinter-html-tidy/issues/39
Fixes https://github.com/SublimeLinter/SublimeLinter-html-tidy/issues/52