### PR TITLE
Showcase: Live filter errors

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -25,6 +25,11 @@
 
     },
     {
+        "caption": "SublimeLinter: Filter Errors",
+        "command": "sublime_linter_filter"
+
+    },
+    {
         "caption": "SublimeLinter: Reload SublimeLinter and its Plugins",
         "command": "sublime_linter_reload"
 


### PR DESCRIPTION
It's 🤹‍♂️ 🤹‍♀️ time again.

Provide command 'sublime_linter_filter' which takes one optional
argument 'pattern'. If omitted a TextInput will open instead (ST >3.1).

Search for 'SublimeLinter: Filter Errors'.

E.g. '-W\d+', '-annotations', 'flake E999'

Has lint errors for easy testing. Implementation doesn't matter.

Closes #1255