### PR TITLE
Do not show error panel on unhandled exceptions

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -93,7 +93,7 @@ def execute_lint_task(linter, code, offset, view_has_changed, settings, task_nam
         except Exception:
             linter.notify_failure()
             # Log while multi-threaded to get a nicer log message
-            logger.exception('Linter crashed.\n\n')
+            logger.exception('Unhandled exception:\n', extra={'demote': True})
             return []  # Empty list here to clear old errors
 
 

--- a/log_handler.py
+++ b/log_handler.py
@@ -120,6 +120,9 @@ shown_error_messages = defaultdict(set)
 
 class ErrorPanelHandler(logging.Handler):
     def emit(self, record):
+        if getattr(record, 'demote', False):
+            return
+
         try:
             msg = self.format(record)
             lines = msg.splitlines()


### PR DESCRIPTION
Although they are a bit useful for developers, these scare and annoy users.

Esp. during live-reload we cannot guarantee to not throw, at least atm. So
popping up the panel in your face is not even appropriate bc the reloading
can still succeed. (These are really transient errors.)

If we demote them, we still log them to the console. Hopefully, users still
see and report non transient errors this way. However, edge-case errors often
*appear* transient to the end user, and we will probably cannot fix those as
quickly or ever. E.g. we actually fixed year old bugs bc of this offensive
throwing.

Closes #1420
Closes #1428