### PR TITLE
Reformat settings docs

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -122,46 +122,54 @@
 
     // Global styles for all linters.
     // Note: Styles can also be specified per linter! See above.
-    // - mark_style:
-    //   - "none"
-    //   - "fill", "outline",
-    //   - "solid_underline", "squiggly_underline", "stippled_underline"
-    //   The underline styles are replaced with outlines when there is
-    //   whitespace in the problem region, because underlines aren't drawn
-    //   on whitespace (ST issue #137).
-    // - icon:
-    //   - "circle", "dot" or "bookmark"
-    //   - "none" to remove the icon
-    //   - A path to an icon file like
-    //     "Packages/SublimeLinter/gutter-themes/Blueberry Cross/error.png"
-    //   - One provided by a gutter theme (e.g. "warning" or "error").
-    //     In theme Default: warning, error, cog, x,
-    //     and diamond, heart, pointer, square, star, triangle, which all
-    //     also have an -outline variant.
-    // - scope:
-    //   Is used to determine the color. E.g. region.<colorish>, with one of
-    //   redish, orangish, yellowish, greenish, bluish, purplish, pinkish.
-    // - priority:
-    //   Determines, for overlapping errors, which one is visualised.
-    // - types:
-    //   An array which can contain "warning" and/or "error".
-    //   If omitted will match both.
+    // Only for linter-styles, there is one more setting:
     // - codes:
     //   An array which can contain error codes provided by a linter.
     //   Only valid as linter style in the "linters" section
+    //
+    // The styles list form a stack evaluated top-down. We call each object
+    // herein a style definition. A style definition must match a specific
+    // linter error, either its code or its error type, to take any effect.
+    //
+    // The default styles cannot be overriden per se, you extend them
+    // in your user settings. The defaults can be read as "All linter problems
+    // are red, outline, dots, but warnings are yellow."
     "styles": [
         {
+            // Used to determine the color. E.g. region.<colorish>, with one of
+            // redish, orangish, yellowish, greenish, bluish, purplish, pinkish.
             "scope": "region.yellowish markup.warning.sublime_linter",
+
+            // The error type this style definition will match for.
+            // An array which can contain "warning" and/or "error".
+            // If omitted will match both.
             "types": ["warning"]
         },
         {
-            "scope": "region.redish markup.error.sublime_linter",
-            "types": ["error"]
-        },
-        {
+            // Determines, for overlapping errors, which one is visualised.
             "priority": 1,
+
+            // The icon displayed in the gutter area
+            // - "circle", "dot" or "bookmark"
+            // - "none" to remove the icon
+            // - A path to an icon file like
+            //   "Packages/SublimeLinter/gutter-themes/Blueberry Cross/error.png"
+            // - One provided by a gutter theme (e.g. "warning" or "error").
+            //   In theme Default: warning, error, cog, x,
+            //   and diamond, heart, pointer, square, star, triangle, which all
+            //   also have an -outline variant.
             "icon": "dot",
-            "mark_style": "outline"
+
+            // The highlight style:
+            // - "none"
+            // - "fill", "outline",
+            // - "solid_underline", "squiggly_underline", "stippled_underline"
+            // The underline styles are replaced with outlines when there is
+            // whitespace in the problem region, because underlines aren't drawn
+            // on whitespace (ST issue #137).
+            "mark_style": "outline",
+
+            "scope": "region.redish markup.error.sublime_linter"
         }
     ],
 

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -54,29 +54,59 @@
     // What settings are available is documented in the readme of the
     // specific linter plugin.
     // Example:
-    // "linters": {
-    //     "somelinter": {
-    //         "disable": false,
-    //         "args": [],
-    //         "excludes": [],
-    //         "styles": [
-    //              {
-    //                  "icon": "diamond"
-    //              }
-    //         ]
-    //     },
-    //     "somepythonlinter": {
-    //         "python": null,
-    //         "disable": false,
-    //         "args": [
-    //             "--max-complexity", "-1",
-    //             "--max-line-length", "100",
-    //             "--ignore", "E731,E402"
-    //         ],
-    //         "excludes": [],
-    //     }
-    // }
-    "linters": {},
+    "linters": {
+        // The name of the linter you installed
+        "linter_name": {
+            // Disables the linter. The default here is 'not set'
+            "disable": false,
+
+            // Additional arguments for the command line. Either a 'string'
+            // or an 'array'. If set to a string, we 'shlex.split' it*.
+            // E.g. '--ignore D112' or ['--config', './.config/foo.ini']
+            //
+            // * Note that 'shlex' does not work for paths on Windows atm.
+            "args": [],
+
+            // Path to the executable to be used. Either a 'string' or an
+            // 'array'. E.g. ['nvm', 'exec', '8.6', 'eslint']
+            "executable": "<automatically set>",
+
+            // A modified runtime environment for the lint job. Settings here
+            // override the default, inherited ENV.
+            "env": {},
+
+            "excludes": [],
+
+            // Lint mode determines when the linter is run. The linter setting
+            // will take precedence over the global setting.
+            "lint_mode": "manual",
+
+            // Determines for which views this linter will run.
+            "selector": "",
+
+            // A list of additional style definition blocks.
+            "styles": [
+                {
+                    // Instead of 'types' you can specify error 'codes' for
+                    // a style definition block
+                    "codes": [""]
+                }
+            ],
+
+            // The current working dir the lint job will run in.
+            "working_dir": "",
+
+            // **Only valid for PythonLinter**
+            // Specify which python to use. Either a number or full path
+            // to a python binary. SL will then basically use 'python -m'
+            // to run the linter.
+            "python": 3,
+
+            // **Only valid for NodeLinter**
+            // If true, will *not* use a globally installed binary
+            "disable_if_not_dependency": false
+        }
+    },
 
     // Determines what happens when a linter reports a problem without column.
     // By default, a mark is put in the gutter and the first character is highlighted.

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -155,7 +155,13 @@
                         "minimum":0
                     },
                     "scope":{
-                        "type":"string"
+                        "type":"string",
+                        "examples": [
+                            "region.redish", "region.orangish",
+                            "region.yellowish", "region.greenish",
+                            "region.bluish", "region.purplish",
+                            "region.pinkish",
+                            "markup.warning", "markup.error"]
                     },
                     "icon":{
                         "type":"string"


### PR DESCRIPTION
Better inline docs in the settings. I will show a PR/plugin which extracts the inline documentation and e.g. provides auto-complete/tooltips for the settings later. 

