### PR TITLE
Use CWD for pipenv check

### DIFF
--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -145,7 +145,7 @@ def get_project_path():
 def ask_pipenv(linter_name, cwd):
     """Ask pipenv for a virtual environment and maybe resolve the linter."""
     # Some pre-checks bc `pipenv` is super slow
-    project_path = get_project_path()
+    project_path = cwd or get_project_path()
     if not project_path:
         return
 


### PR DESCRIPTION
The incoming `cwd` respects projects with relative paths configured, though if it is None, resort to the existing `get_project_path` guess.