### PR TITLE
Iterate demote predicates

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -23,7 +23,9 @@
 
     // Demote the visibility of a class off errors while you're editing.
     // The errors will re-appear after `time_to_idle` and immediately on save.
-    // - ws_regions: erroneous regions that contain whitespace
+    // - ws_only: erroneous regions that contain only whitespace
+    // - some_ws: erroneous regions that contain *some* whitespace
+    // - multilines: multiline errors
     // - warnings: errors of the "warning" type
     // - all: demote all the things
     // - none: disable this feature

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -36,6 +36,8 @@
     "highlights.demote_scope": "",
 
     // How long to wait before showing the demoted errors again.
+    // Tip: A big value like 3600 will essentially hide the regions until
+    // you save the buffer.
     "highlights.time_to_idle": 1.5,
 
     // Send a "terminate" signal to old lint processes, if their result would

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -32,7 +32,8 @@ UNDERLINE_STYLES = (
 SOME_WS = re.compile('\s')
 FALLBACK_MARK_STYLE = 'outline'
 
-WS_REGIONS = re.compile('(^\s+$|\n)')
+WS_ONLY = re.compile('^\s+$')
+MULTILINES = re.compile('\n')
 DEMOTE_WHILE_BUSY_MARKER = '%DWB%'
 HIDDEN_STYLE_MARKER = '%HIDDEN%'
 
@@ -166,8 +167,14 @@ def get_demote_predicate():
     if setting == 'all':
         return demote_all
 
-    if setting == 'ws_regions':
-        return demote_ws_regions
+    if setting == 'ws_only':
+        return demote_ws_only
+
+    if setting in ('some_ws', 'ws_regions'):  # 'ws_regions' is deprecated
+        return demote_some_ws
+
+    if setting == 'multilines':
+        return demote_multilines
 
     if setting == 'warnings':
         return demote_warnings
@@ -185,8 +192,16 @@ def demote_all(*args, **kwargs):
     return True
 
 
-def demote_ws_regions(selected_text, **kwargs):
-    return bool(WS_REGIONS.search(selected_text))
+def demote_ws_only(selected_text, **kwargs):
+    return bool(WS_ONLY.search(selected_text))
+
+
+def demote_some_ws(selected_text, **kwargs):
+    return bool(SOME_WS.search(selected_text))
+
+
+def demote_multilines(selected_text, **kwargs):
+    return bool(MULTILINES.search(selected_text))
 
 
 def demote_warnings(selected_text, error_type, **kwargs):

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -16,7 +16,7 @@
         },
         "highlights.demote_while_editing":{
             "type":"string",
-            "enum":["none", "ws_regions", "warnings", "all"]
+            "enum":["none", "ws_only", "some_ws", "multilines", "warnings", "all"]
         },
         "kill_old_processes":{
             "type":"boolean"


### PR DESCRIPTION
* Remove 'ws_regions'
* Add 'ws_only', 'some_ws', and 'multilines'

For a short period, we use 'some_ws' when the user set 'ws_regions'
previously.

Note that 'some_ws' will match all errors for which we currently use the
fallback style.