### PR TITLE
Fix: Do not provide default 'types' if user set 'codes'

### DIFF
--- a/lint/style.py
+++ b/lint/style.py
@@ -45,7 +45,17 @@ def get_value(key, error, default=None):
             except KeyError:
                 ...
 
-    for style_definition in chain(linter_styles, global_styles, default_styles):
+    for style_definition in linter_styles:
+        # For linter_styles, do not auto fill 'types' if the user already
+        # provided 'codes'
+        default = [] if 'codes' in style_definition else [error_type]
+        if error_type in style_definition.get('types', default):
+            try:
+                return style_definition[key]
+            except KeyError:
+                ...
+
+    for style_definition in chain(global_styles, default_styles):
         if error_type in style_definition.get('types', [error_type]):
             try:
                 return style_definition[key]


### PR DESCRIPTION
Bascically something like this did not work

![image](https://user-images.githubusercontent.com/8558/42692178-0da30ab0-86ab-11e8-8ea5-ad47c9e041b0.png)

(All errors were gone. 👍 😁)

After the patch, you can do

![image](https://user-images.githubusercontent.com/8558/42692229-3c3cf52a-86ab-11e8-884f-efa0eba76f03.png)

e.g. to match a specific code *and* all warnings.