### PR TITLE
separate out error code in panel

### DIFF
--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -63,12 +63,12 @@ contexts:
 
   expect-linter-type:
     - include: pop-at-end
-    - match: (\S+)(:)(\S*)
+    - match: ([^\s:]+)(?:(:)(\S+))?
       captures:
         0: meta.linter-code.sublime_linter
-        1: entity.type.linter-name.sublime_linter
+        1: entity.name.class.linter-name.sublime_linter
         2: punctuation.separator.sublime_linter
-        3: storage.type.error-code.sublime_linter
+        3: entity.name.label.error-code.sublime_linter
       pop: true
 
   expect-linter-message:

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -15,12 +15,14 @@ contexts:
     - match: '^\s+(?=[0-9: ]+error)'
       push:
         - ensure-error-meta-scope
+        - expect-linter-message
         - expect-linter-type
         - expect-linter-severity
         - expect-line-maybe-column
     - match: '^\s+(?=[0-9: ]+warning)'
       push:
         - ensure-warning-meta-scope
+        - expect-linter-message
         - expect-linter-type
         - expect-linter-severity
         - expect-line-maybe-column
@@ -52,6 +54,12 @@ contexts:
         1: entity.type.linter-name.sublime_linter
         2: punctuation.separator.sublime_linter
         3: storage.type.error-code.sublime_linter
+      pop: true
+
+  expect-linter-message:
+    - include: pop-at-end
+    - match: .*$
+      scope: meta.linter.message
       pop: true
 
   expect-line-maybe-column:

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -35,8 +35,11 @@ contexts:
 
   expect-linter-type:
     - include: pop-at-end
-    - match: \S+
-      scope: comment.line.sublime_linter
+    - match: (\S+)(:)(\S*)
+      captures:
+        1: comment.line.sublime_linter
+        2: punctuation.separator.sublime_linter
+        3: storage.type.sublime_linter
       pop: true
 
   expect-line-maybe-column:

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -52,13 +52,13 @@ contexts:
   expect-linter-severity:
     - include: pop-at-end
     - match: \berror\b
-      scope: meta.linter.error-type.sublime_linter markup.error.sublime_linter
+      scope: entity.name.label.error-type.sublime_linter markup.error.sublime_linter
       pop: true
     - match: \bwarning\b
-      scope: meta.linter.error-type.sublime_linter markup.warning.sublime_linter
+      scope: entity.name.label.error-type.sublime_linter markup.warning.sublime_linter
       pop: true
     - match: \b(\S+)\b
-      scope: meta.linter.error-type.sublime_linter
+      scope: entity.name.label.error-type.sublime_linter
       pop: true
 
   expect-linter-type:
@@ -66,7 +66,7 @@ contexts:
     - match: ([^\s:]+)(?:(:)(\S+))?
       captures:
         0: meta.linter-code.sublime_linter
-        1: entity.name.class.linter-name.sublime_linter
+        1: entity.name.label.linter-name.sublime_linter
         2: punctuation.separator.sublime_linter
         3: entity.name.label.error-code.sublime_linter
       pop: true
@@ -74,7 +74,7 @@ contexts:
   expect-linter-message:
     - include: pop-at-end
     - match: .*$
-      scope: meta.linter.message
+      scope: markup.quote.linter-message.sublime_linter
       pop: true
 
   expect-line-maybe-column:

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -12,16 +12,27 @@ contexts:
     - match: '^(.+):$'
       captures:
         1: entity.name.filename.sublime_linter
-    - match: '^\s+(?=\d)'
+    - match: '^\s+(?=[0-9: ]+error)'
       push:
-        - ensure-linter-meta-scope
+        - ensure-error-meta-scope
+        - expect-linter-type
+        - expect-linter-severity
+        - expect-line-maybe-column
+    - match: '^\s+(?=[0-9: ]+warning)'
+      push:
+        - ensure-warning-meta-scope
         - expect-linter-type
         - expect-linter-severity
         - expect-line-maybe-column
 
-  ensure-linter-meta-scope:
-    - meta_scope: meta.linter.body.sublime_linter
-    - match: ""  # match the empty string
+  ensure-error-meta-scope:
+    - meta_scope: meta.linter.error.body.sublime_linter
+    - match: (?=$)
+      pop: true
+
+  ensure-warning-meta-scope:
+    - meta_scope: meta.linter.warning.body.sublime_linter
+    - match: (?=$)
       pop: true
 
   expect-linter-severity:
@@ -37,18 +48,20 @@ contexts:
     - include: pop-at-end
     - match: (\S+)(:)(\S*)
       captures:
-        1: comment.line.sublime_linter
+        0: meta.linter-code.sublime_linter
+        1: entity.type.linter_name.sublime_linter
         2: punctuation.separator.sublime_linter
-        3: storage.type.sublime_linter
+        3: storage.type.error_code.sublime_linter
       pop: true
 
   expect-line-maybe-column:
     - include: pop-at-end
     - match: (\d+)(?:(:)(\d+))?
       captures:
+        0: meta.line-col.sublime_linter
         1: constant.numeric.line-number.sublime_linter
         2: punctuation.separator.sublime_linter
-        3: constant.numeric.line-number.sublime_linter
+        3: constant.numeric.col-number.sublime_linter
       pop: true
 
   pop-at-end:

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -26,6 +26,13 @@ contexts:
         - expect-linter-type
         - expect-linter-severity
         - expect-line-maybe-column
+    - match: '^\s+(?=[0-9: ]+)'
+      push:
+        - ensure-warning-other-scope
+        - expect-linter-message
+        - expect-linter-type
+        - expect-linter-severity
+        - expect-line-maybe-column
 
   ensure-error-meta-scope:
     - meta_scope: meta.linter.body.error.sublime_linter
@@ -37,13 +44,21 @@ contexts:
     - match: (?=$)
       pop: true
 
+  ensure-warning-other-scope:
+    - meta_scope: meta.linter.body.sublime_linter
+    - match: (?=$)
+      pop: true
+
   expect-linter-severity:
     - include: pop-at-end
     - match: \berror\b
-      scope: markup.error.sublime_linter
+      scope: meta.linter.error-type.sublime_linter markup.error.sublime_linter
       pop: true
     - match: \bwarning\b
-      scope: markup.warning.sublime_linter
+      scope: meta.linter.error-type.sublime_linter markup.warning.sublime_linter
+      pop: true
+    - match: \b(\S+)\b
+      scope: meta.linter.error-type.sublime_linter
       pop: true
 
   expect-linter-type:

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -49,9 +49,9 @@ contexts:
     - match: (\S+)(:)(\S*)
       captures:
         0: meta.linter-code.sublime_linter
-        1: entity.type.linter_name.sublime_linter
+        1: entity.type.linter-name.sublime_linter
         2: punctuation.separator.sublime_linter
-        3: storage.type.error_code.sublime_linter
+        3: storage.type.error-code.sublime_linter
       pop: true
 
   expect-line-maybe-column:

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -52,13 +52,13 @@ contexts:
   expect-linter-severity:
     - include: pop-at-end
     - match: \berror\b
-      scope: entity.name.label.error-type.sublime_linter markup.error.sublime_linter
+      scope: entity.name.tag.error-type.sublime_linter markup.error.sublime_linter
       pop: true
     - match: \bwarning\b
-      scope: entity.name.label.error-type.sublime_linter markup.warning.sublime_linter
+      scope: entity.name.tag.error-type.sublime_linter markup.warning.sublime_linter
       pop: true
     - match: \b(\S+)\b
-      scope: entity.name.label.error-type.sublime_linter
+      scope: entity.name.tag.error-type.sublime_linter
       pop: true
 
   expect-linter-type:
@@ -68,7 +68,7 @@ contexts:
         0: meta.linter-code.sublime_linter
         1: entity.name.label.linter-name.sublime_linter
         2: punctuation.separator.sublime_linter
-        3: entity.name.label.error-code.sublime_linter
+        3: entity.name.class.error-code.sublime_linter
       pop: true
 
   expect-linter-message:

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -26,12 +26,12 @@ contexts:
         - expect-line-maybe-column
 
   ensure-error-meta-scope:
-    - meta_scope: meta.linter.error.body.sublime_linter
+    - meta_scope: meta.linter.body.error.sublime_linter
     - match: (?=$)
       pop: true
 
   ensure-warning-meta-scope:
-    - meta_scope: meta.linter.warning.body.sublime_linter
+    - meta_scope: meta.linter.body.warning.sublime_linter
     - match: (?=$)
       pop: true
 

--- a/panel/syntax_test_panel
+++ b/panel/syntax_test_panel
@@ -37,6 +37,10 @@ highlight_view.py:
 #                               ^ punctuation.separator.sublime_linter
 #                                ^^^^ storage.type.error-code.sublime_linter
 
+   669:1    error         flake8              unexpected indentation
+#                         ^^^^^^ meta.linter-code.sublime_linter
+#                         ^^^^^^ entity.type.linter-name.sublime_linter
+#                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
 
    669:1    error         flake8:E113         unexpected indentation
 #                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message

--- a/panel/syntax_test_panel
+++ b/panel/syntax_test_panel
@@ -33,13 +33,13 @@ highlight_view.py:
 
    669:1    error         flake8:E113         unexpected indentation
 #                         ^^^^^^^^^^^ meta.linter-code.sublime_linter
-#                         ^^^^^^ entity.type.linter-name.sublime_linter
+#                         ^^^^^^ entity.name.class.linter-name.sublime_linter
 #                               ^ punctuation.separator.sublime_linter
-#                                ^^^^ storage.type.error-code.sublime_linter
+#                                ^^^^ entity.name.label.error-code.sublime_linter
 
    669:1    error         flake8              unexpected indentation
 #                         ^^^^^^ meta.linter-code.sublime_linter
-#                         ^^^^^^ entity.type.linter-name.sublime_linter
+#                         ^^^^^^ entity.name.class.linter-name.sublime_linter
 #                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
 
    669:1    error         flake8:E113         unexpected indentation

--- a/panel/syntax_test_panel
+++ b/panel/syntax_test_panel
@@ -1,0 +1,47 @@
+# SYNTAX TEST "Packages/SublimeLinter/panel/panel.sublime-syntax"
+
+highlight_view.py:
+# <- entity.name.filename.sublime_linter
+
+
+   667:14   warning       flake8:E211         whitespace before '('
+#  ^^^^^^ meta.line-col.sublime_linter
+#  ^^^ constant.numeric.line-number.sublime_linter
+#     ^ punctuation.separator.sublime_linter
+#      ^^ constant.numeric.col-number.sublime_linter
+
+
+   667:14   warning       flake8:E211         whitespace before '('
+# <- meta.linter.body.warning.sublime_linter
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body.warning.sublime_linter
+#           ^^^^^^^ meta.linter.error-type.sublime_linter
+#           ^^^^^^^ markup.warning.sublime_linter
+
+
+   668:18   error         flake8:E999         SyntaxError: invalid syntax
+# <- meta.linter.body.error.sublime_linter
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body.error.sublime_linter
+#           ^^^^^ meta.linter.error-type.sublime_linter
+#           ^^^^^ markup.error.sublime_linter
+
+
+   668:18   info         flake8:E999         SyntaxError: invalid syntax
+# <- meta.linter.body
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body
+#           ^^^^ meta.linter.error-type.sublime_linter
+
+
+   669:1    error         flake8:E113         unexpected indentation
+#                         ^^^^^^^^^^^ meta.linter-code.sublime_linter
+#                         ^^^^^^ entity.type.linter-name.sublime_linter
+#                               ^ punctuation.separator.sublime_linter
+#                                ^^^^ storage.type.error-code.sublime_linter
+
+
+   669:1    error         flake8:E113         unexpected indentation
+#                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
+   669:1    warning       flake8:E113         unexpected indentation
+#                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
+   669:1    info          flake8:E113         unexpected indentation
+#                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
+

--- a/panel/syntax_test_panel
+++ b/panel/syntax_test_panel
@@ -14,38 +14,38 @@ highlight_view.py:
    667:14   warning       flake8:E211         whitespace before '('
 # <- meta.linter.body.warning.sublime_linter
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body.warning.sublime_linter
-#           ^^^^^^^ meta.linter.error-type.sublime_linter
+#           ^^^^^^^ entity.name.label.error-type.sublime_linter
 #           ^^^^^^^ markup.warning.sublime_linter
 
 
    668:18   error         flake8:E999         SyntaxError: invalid syntax
 # <- meta.linter.body.error.sublime_linter
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body.error.sublime_linter
-#           ^^^^^ meta.linter.error-type.sublime_linter
+#           ^^^^^ entity.name.label.error-type.sublime_linter
 #           ^^^^^ markup.error.sublime_linter
 
 
    668:18   info         flake8:E999         SyntaxError: invalid syntax
 # <- meta.linter.body
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body
-#           ^^^^ meta.linter.error-type.sublime_linter
+#           ^^^^ entity.name.label.error-type.sublime_linter
 
 
    669:1    error         flake8:E113         unexpected indentation
 #                         ^^^^^^^^^^^ meta.linter-code.sublime_linter
-#                         ^^^^^^ entity.name.class.linter-name.sublime_linter
+#                         ^^^^^^ entity.name.label.linter-name.sublime_linter
 #                               ^ punctuation.separator.sublime_linter
 #                                ^^^^ entity.name.label.error-code.sublime_linter
 
    669:1    error         flake8              unexpected indentation
 #                         ^^^^^^ meta.linter-code.sublime_linter
-#                         ^^^^^^ entity.name.class.linter-name.sublime_linter
-#                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
+#                         ^^^^^^ entity.name.label.linter-name.sublime_linter
+#                                             ^^^^^^^^^^^^^^^^^^^^^^ markup.quote.linter-message.sublime_linter
 
    669:1    error         flake8:E113         unexpected indentation
-#                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
+#                                             ^^^^^^^^^^^^^^^^^^^^^^ markup.quote.linter-message.sublime_linter
    669:1    warning       flake8:E113         unexpected indentation
-#                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
+#                                             ^^^^^^^^^^^^^^^^^^^^^^ markup.quote.linter-message.sublime_linter
    669:1    info          flake8:E113         unexpected indentation
-#                                             ^^^^^^^^^^^^^^^^^^^^^^ meta.linter.message
+#                                             ^^^^^^^^^^^^^^^^^^^^^^ markup.quote.linter-message.sublime_linter
 

--- a/panel/syntax_test_panel
+++ b/panel/syntax_test_panel
@@ -14,28 +14,28 @@ highlight_view.py:
    667:14   warning       flake8:E211         whitespace before '('
 # <- meta.linter.body.warning.sublime_linter
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body.warning.sublime_linter
-#           ^^^^^^^ entity.name.label.error-type.sublime_linter
+#           ^^^^^^^ entity.name.tag.error-type.sublime_linter
 #           ^^^^^^^ markup.warning.sublime_linter
 
 
    668:18   error         flake8:E999         SyntaxError: invalid syntax
 # <- meta.linter.body.error.sublime_linter
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body.error.sublime_linter
-#           ^^^^^ entity.name.label.error-type.sublime_linter
+#           ^^^^^ entity.name.tag.error-type.sublime_linter
 #           ^^^^^ markup.error.sublime_linter
 
 
    668:18   info         flake8:E999         SyntaxError: invalid syntax
 # <- meta.linter.body
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.linter.body
-#           ^^^^ entity.name.label.error-type.sublime_linter
+#           ^^^^ entity.name.tag.error-type.sublime_linter
 
 
    669:1    error         flake8:E113         unexpected indentation
 #                         ^^^^^^^^^^^ meta.linter-code.sublime_linter
 #                         ^^^^^^ entity.name.label.linter-name.sublime_linter
 #                               ^ punctuation.separator.sublime_linter
-#                                ^^^^ entity.name.label.error-code.sublime_linter
+#                                ^^^^ entity.name.class.error-code.sublime_linter
 
    669:1    error         flake8              unexpected indentation
 #                         ^^^^^^ meta.linter-code.sublime_linter

--- a/panel_view.py
+++ b/panel_view.py
@@ -348,8 +348,9 @@ def run_update_panel_cmd(panel, text=None):
 def format_row(item):
     line = item["line"] + 1
     start = item["start"] + 1
-    tmpl = " {LINE:>5}:{START:<4} {error_type:7} {linter:>12}:{code:12} {msg}"
-    return tmpl.format(LINE=line, START=start, **item)
+    code = ":{code:12}".format(**item) if item['code'] else ''
+    tmpl = " {LINE:>5}:{START:<4} {error_type:7} {linter:>12}{CODE} {msg}"
+    return tmpl.format(LINE=line, START=start, CODE=code, **item)
 
 
 def fill_panel(window):

--- a/panel_view.py
+++ b/panel_view.py
@@ -348,7 +348,7 @@ def run_update_panel_cmd(panel, text=None):
 def format_row(item):
     line = item["line"] + 1
     start = item["start"] + 1
-    tmpl = " {LINE:>5}:{START:<4} {error_type:7} {linter:>12}: {code:12} {msg}"
+    tmpl = " {LINE:>5}:{START:<4} {error_type:7} {linter:>12}:{code:12} {msg}"
     return tmpl.format(LINE=line, START=start, **item)
 
 


### PR DESCRIPTION
Error codes, especially when they're more texty than your average pythonesque numbered code, kinda get lost in the panel sometimes.

Before:
<img width="816" alt="screen shot 2018-08-11 at 08 52 41" src="https://user-images.githubusercontent.com/2543659/43989112-edf549c6-9d43-11e8-8c91-6f772a83c261.png">

After:
<img width="783" alt="screen shot 2018-08-11 at 08 52 08" src="https://user-images.githubusercontent.com/2543659/43989115-f349431e-9d43-11e8-8f88-b6a8494d6519.png">