### PR TITLE
Handle str cmd in ask_pipenv

### DIFF
--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -77,7 +77,7 @@ class PythonLinter(linter.Linter):
         # If we're here the user didn't specify anything. This is the default
         # experience. So we kick in some 'magic'
         cwd = self.get_working_dir(settings)
-        executable = ask_pipenv(cmd[0], cwd)
+        executable = ask_pipenv(cmd_name, cwd)
         if executable:
             logger.info(
                 "{}: Using {} according to 'pipenv'"


### PR DESCRIPTION
`ask_pipenv` needs the `cmd_name` because `cmd` isn't always list/tuple, sometimes it's a str.

Small change to fix a bug I experienced using [SublimeLinter-contrib-mypy ](https://github.com/fredcallaway/SublimeLinter-contrib-mypy/blob/6a956fd5afeacbed5626ec7db481f010e277172d/linter.py#L39)which calls `cmd` with a str instead of a list. Seems like other linters might do that. 

By the way, thank you all so much for maintaining this project using Sublime's ancient python. Trying to setup the environment for Sublime packages was really a nightmare for me today. You are doing great work.