### PR TITLE
Remove `util.distinct_until_selection_changed` abstraction

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -59,23 +59,6 @@ def distinct_until_buffer_changed(method):
     return wrapper
 
 
-def distinct_until_selection_changed(method):
-    last_call = None
-
-    @wraps(method)
-    def wrapper(self, view):
-        nonlocal last_call
-
-        this_call = (view.buffer_id(),) + tuple(s for s in view.sel())
-        if this_call == last_call:
-            return
-
-        last_call = this_call
-        method(self, view)
-
-    return wrapper
-
-
 def canonical_filename(view):
     return (
         os.path.basename(view.file_name()) if view.file_name()

--- a/panel_view.py
+++ b/panel_view.py
@@ -86,10 +86,13 @@ class UpdateState(sublime_plugin.EventListener):
         if panel_is_active(window):
             update_panel_selection(**State)
 
-    @util.distinct_until_selection_changed
     def on_selection_modified_async(self, view):
         active_view = State['active_view']
-        if not active_view or active_view.buffer_id() != view.buffer_id():
+        # Do not race between `plugin_loaded` and this event handler
+        if active_view is None:
+            return
+
+        if view.buffer_id() != active_view.buffer_id():
             return
 
         current_pos = get_current_pos(active_view)


### PR DESCRIPTION
Fixes #1496

`distinct_until_selection_changed` as a decorator is a mistake bc
different views into the same buffer all have their own selection
(`view.sel()`). So we really have to readout and evaluate
`active_view-sel()` somewhere in these event handler.

Note that the all selection modified event handlers did this already
(for them adding the decorator is double the work) except the one in
`highlight_view.py`.