### PR TITLE
Error msg hotfix#1418

### DIFF
--- a/lint/base_linter/composer_linter.py
+++ b/lint/base_linter/composer_linter.py
@@ -55,7 +55,9 @@ class ComposerLinter(linter.Linter):
         if global_cmd:
             return True, global_cmd
         else:
-            logger.warning("{} cannot locate '{}'".format(self.name, cmd[0]))
+            logger.warning('{} cannot locate \'{}\'\n'
+                           'Please refer to the readme of this plugin and our troubleshooting guide: '
+                           'http://www.sublimelinter.com/en/stable/troubleshooting.html'.format(self.name, cmd[0]))
             return True, None
 
     def get_manifest_path(self):

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -57,7 +57,9 @@ class NodeLinter(linter.Linter):
         if global_cmd:
             return True, global_cmd
         else:
-            logger.warning('{} cannot locate \'{}\''.format(self.name, cmd[0]))
+            logger.warning('{} cannot locate \'{}\'\n'
+                           'Please refer to the readme of this plugin and our troubleshooting guide: '
+                           'http://www.sublimelinter.com/en/stable/troubleshooting.html'.format(self.name, cmd[0]))
             return True, None
 
     def get_manifest_path(self):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -660,7 +660,9 @@ class Linter(metaclass=LinterMeta):
                 path = self.which(which)
 
             if not path:
-                logger.warning('{} cannot locate \'{}\''.format(self.name, which))
+                logger.warning('{} cannot locate \'{}\'\n'
+                               'Please refer to the readme of this plugin and our troubleshooting guide: '
+                               'http://www.sublimelinter.com/en/stable/troubleshooting.html'.format(self.name, which))
                 return None
 
         cmd[0:1] = util.convert_type(path, [])


### PR DESCRIPTION
Improved error msg that directs user to readme and troubleshooting guide when executable cannot be found for base linter, node linter, and composer linter. #1418 