### PR TITLE
Fix lint errors

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -29,10 +29,10 @@ UNDERLINE_STYLES = (
     'solid_underline', 'squiggly_underline', 'stippled_underline'
 )
 
-SOME_WS = re.compile('\s')
+SOME_WS = re.compile(r'\s')
 FALLBACK_MARK_STYLE = 'outline'
 
-WS_ONLY = re.compile('^\s+$')
+WS_ONLY = re.compile(r'^\s+$')
 MULTILINES = re.compile('\n')
 DEMOTE_WHILE_BUSY_MARKER = '%DWB%'
 HIDDEN_STYLE_MARKER = '%HIDDEN%'

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,17 @@ max-line-length = 120
 # D104  Missing docstring in public package
 # D105  Missing docstring in magic method
 # D107  Missing docstring in __init__
-ignore = D100,D101,D102,D103,D105,D107,D205, D400
+ignore =
+  D100,
+  D101,
+  D102,
+  D103,
+  D105,
+  D107,
+  D205,
+  D400,
+
+  W504
 
 exclude =
   ./docs/


### PR DESCRIPTION
`flake8` updated. We ignore W504 for now, new pep recommendation is to put the binary operators (and/or) on the new line. E.g.:

```
    maybe_toggle_panel_automatically = (
        persist.settings.get('lint_mode') == 'manual' 
		or buffer_id in State['just_saved_buffers']  # <======
    )
```