### PR TITLE
WIP: Support linter messages from multiple files

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -143,11 +143,11 @@ def finalize_errors(linter, errors, offsets):
                 belongs_to_main_file = False
 
         line, start, end = error['line'], error['start'], error['end']
-        if line == 0:
-            start += col_offset
-            end += col_offset
-
         if belongs_to_main_file:  # offsets are for the main file only
+            if line == 0:
+                start += col_offset
+                end += col_offset
+
             line += line_offset
 
         try:

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1103,11 +1103,19 @@ class Linter(metaclass=LinterMeta):
             col = max(min(col, (end - start) - 1), 0)
 
         line, start, end = self.reposition_match(line, col, m, vv)
+
+        # find the region to highlight for this error
+        line_start, _ = vv.full_line(line)
+        region = sublime.Region(line_start + start, line_start + end)
+        if len(region) == 0:
+            region.b += 1
+
         return {
             "filename": filename,
             "line": line,
             "start": start,
             "end": end,
+            "region": region,
             "error_type": error_type,
             "code": m.error or m.warning or '',
             "msg": m.message.strip(),

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1073,7 +1073,11 @@ class Linter(metaclass=LinterMeta):
         error_type = self.get_error_type(m.error, m.warning)
 
         # determine a filename for this match
-        filename = m.match.groupdict().get("filename", None)
+        try:
+            filename = m.match.groupdict().get("filename", None)
+        except AttributeError:
+            pass
+
         if filename:
             # ensure that the filename is absolute by basing relative paths on
             # the working directory

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -150,7 +150,7 @@ class VirtualView:
     @staticmethod
     def from_file(filename):
         """Return a VirtualView with the contents of file."""
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf8') as f:
             return VirtualView(f.read())
 
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1075,6 +1075,10 @@ class Linter(metaclass=LinterMeta):
         # determine a filename for this match
         filename = m.match.groupdict().get("filename", None)
         if filename:
+            # ensure that the filename is absolute by basing relative paths on
+            # the working directory
+            filename = os.path.normpath(os.path.join(self.get_working_dir(self.settings), filename))
+
             # if this is a match for a different file we need its contents for the below checks
             if not self.filename or not os.path.samefile(filename, self.filename):
                 vv = VirtualView.from_file(filename)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1076,7 +1076,7 @@ class Linter(metaclass=LinterMeta):
         try:
             filename = m.match.groupdict().get("filename", None)
         except AttributeError:
-            pass
+            filename = None
 
         if filename:
             # ensure that the filename is absolute by basing relative paths on

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1118,10 +1118,7 @@ class Linter(metaclass=LinterMeta):
         code = m.code or m.error or m.warning or ''
 
         # determine a filename for this match
-        try:
-            filename = m.match.groupdict().get("filename", None)
-        except AttributeError:
-            filename = None
+        filename = m.filename
 
         if filename:
             # ensure that the filename is absolute by basing relative paths on

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1084,7 +1084,7 @@ class Linter(metaclass=LinterMeta):
                 # for the below checks
                 if not self.filename or not os.path.samefile(filename, self.filename):
                     vv = VirtualView.from_file(filename)
-            except (FileNotFoundError, OSError) as err:
+            except OSError as err:
                 # warn about the error and drop this match
                 logger.warning('Exception: {}'.format(str(err)))
                 self.notify_failure()

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1190,13 +1190,17 @@ class Linter(metaclass=LinterMeta):
             # the working directory
             filename = os.path.normpath(os.path.join(self.get_working_dir(self.settings), filename))
 
-            # when the command was run on a temporary file we need to compare
-            # this filename with that temporary filename
-            cmd_filename = self.temp_filename or self.filename
-
             # only return a filename if it is a different file
-            if os.path.normcase(filename) != os.path.normcase(cmd_filename):
-                return filename
+            normed_filename = os.path.normcase(filename)
+            if normed_filename == os.path.normcase(self.filename):
+                return None
+
+            # when the command was run on a temporary file we also need to
+            # compare this filename with that temporary filename
+            if self.temp_filename and normed_filename == os.path.normcase(self.temp_filename):
+                return None
+
+            return filename
 
         # must be the main file
         return None

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1072,14 +1072,15 @@ class Linter(metaclass=LinterMeta):
     def process_match(self, m, vv):
         error_type = self.get_error_type(m.error, m.warning)
 
-        # discard a linter provided filename if it points to the linted file itself
+        # determine a filename for this match
         filename = m.match.groupdict().get("filename", None)
-        if filename and self.filename and os.path.samefile(filename, self.filename):
-            filename = None
-
-        # if this is a match for a different file we need its contents for the below checks
         if filename:
-            vv = VirtualView.from_file(filename)
+            # if this is a match for a different file we need its contents for the below checks
+            if not self.filename or not os.path.samefile(filename, self.filename):
+                vv = VirtualView.from_file(filename)
+        else:
+            # use the filename of the current view
+            filename = self.view.file_name() or "<untitled {}>".format(self.view.buffer_id())
 
         col = m.col
         line = m.line

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1079,16 +1079,16 @@ class Linter(metaclass=LinterMeta):
             # the working directory
             filename = os.path.normpath(os.path.join(self.get_working_dir(self.settings), filename))
 
-            try:
-                # if this is a match for a different file we need its contents
-                # for the below checks
-                if not self.filename or not os.path.samefile(filename, self.filename):
+            # if this is a match for a different file we need its contents for
+            # the below checks
+            if os.path.normcase(filename) != os.path.normcase(self.filename):
+                try:
                     vv = VirtualView.from_file(filename)
-            except OSError as err:
-                # warn about the error and drop this match
-                logger.warning('Exception: {}'.format(str(err)))
-                self.notify_failure()
-                return None
+                except OSError as err:
+                    # warn about the error and drop this match
+                    logger.warning('Exception: {}'.format(str(err)))
+                    self.notify_failure()
+                    return None
         else:
             # use the filename of the current view
             filename = self.view.file_name() or "<untitled {}>".format(self.view.buffer_id())

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1120,7 +1120,7 @@ class Linter(metaclass=LinterMeta):
         # determine a filename for this match
         filename = m.filename
 
-        if filename:
+        if filename and not self.is_stdin_filename(filename):
             # ensure that the filename is absolute by basing relative paths on
             # the working directory
             filename = os.path.normpath(os.path.join(self.get_working_dir(self.settings), filename))
@@ -1185,6 +1185,10 @@ class Linter(metaclass=LinterMeta):
             return WARNING
         else:
             return self.default_type
+
+    @staticmethod
+    def is_stdin_filename(filename):
+        return filename in ["stdin", "<stdin>", "-"]
 
     def maybe_fix_tab_width(self, line, col, vv):
         # Adjust column numbers to match the linter's tabs if necessary

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1188,7 +1188,8 @@ class Linter(metaclass=LinterMeta):
         if filename and not self.is_stdin_filename(filename):
             # ensure that the filename is absolute by basing relative paths on
             # the working directory
-            filename = os.path.normpath(os.path.join(self.get_working_dir(self.settings), filename))
+            cwd = self.get_working_dir(self.settings) or os.path.realpath('.')
+            filename = os.path.normpath(os.path.join(cwd, filename))
 
             # only return a filename if it is a different file
             normed_filename = os.path.normcase(filename)

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -347,6 +347,11 @@ def group_by_filename_and_update(bid, view_has_changed, linter, errors):
             view = window.find_open_file(filename)
             if view:
                 this_bid = view.buffer_id()
+
+                # ignore errors of other files if their view is dirty
+                if this_bid != bid and view.is_dirty() and errors:
+                    continue
+
                 update_buffer_errors(this_bid, view_has_changed, linter, errors)
 
                 if this_bid == bid:

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -338,6 +338,7 @@ def group_by_filename_and_update(bid, view_has_changed, linter, errors):
     for filename in clean_files:
         grouped[filename]  # For the side-effect of creating a new empty `list`
 
+    did_update_main_view = False
     for filename, errors in grouped.items():
         if not filename:  # backwards compatibility
             update_buffer_errors(bid, view_has_changed, linter, errors)
@@ -345,7 +346,17 @@ def group_by_filename_and_update(bid, view_has_changed, linter, errors):
             # search for an open view for this file to get a bid
             view = window.find_open_file(filename)
             if view:
-                update_buffer_errors(view.buffer_id(), view_has_changed, linter, errors)
+                this_bid = view.buffer_id()
+                update_buffer_errors(this_bid, view_has_changed, linter, errors)
+
+                if this_bid == bid:
+                    did_update_main_view = True
+
+    # For the main view we MUST *always* report an outcome. This is not for
+    # cleanup but functions as a signal that we're done. Merely for the status
+    # bar view.
+    if not did_update_main_view:
+        update_buffer_errors(bid, view_has_changed, linter, [])
 
     affected_filenames_per_bid[lint_id] = current_filenames
 

--- a/tests/test_filter_results.py
+++ b/tests/test_filter_results.py
@@ -46,7 +46,7 @@ class _BaseTestCase(DeferrableTestCase):
 
 VIEW_UNCHANGED = lambda: False  # noqa: E731
 execute_lint_task = partial(
-    backend.execute_lint_task, offset=(0, 0), view_has_changed=VIEW_UNCHANGED
+    backend.execute_lint_task, offsets=(0, 0, 0), view_has_changed=VIEW_UNCHANGED
 )
 
 

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -805,7 +805,8 @@ class TestRegexBasedParsing(_BaseTestCase):
         })
         when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
 
-        result = execute_lint_task(linter, INPUT)
+        # the offsets must be ignored because this is not the main file
+        result = execute_lint_task(linter, INPUT, offsets=(42, 42, 42))
         self.assertEqual(
             result[0]['filename'],
             os.path.join(working_dir, 'other_file')

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -197,7 +197,7 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         result = execute_lint_task(linter, INPUT)
         drop_position_keys(result)
-        drop_keys(['code', 'msg', 'linter'], result)
+        drop_keys(['code', 'msg', 'linter', 'filename'], result)
 
         self.assertResult([{'error_type': ERROR_TYPE}], result)
 
@@ -228,7 +228,7 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         result = execute_lint_task(linter, INPUT)
         drop_position_keys(result)
-        drop_keys(['error_type', 'msg', 'linter'], result)
+        drop_keys(['error_type', 'msg', 'linter', 'filename'], result)
 
         self.assertResult([{'code': CODE}], result)
 

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -30,7 +30,7 @@ version = sublime.version()
 
 VIEW_UNCHANGED = lambda: False  # noqa: E731
 execute_lint_task = partial(
-    backend.execute_lint_task, offset=(0, 0), view_has_changed=VIEW_UNCHANGED
+    backend.execute_lint_task, offsets=(0, 0, 0), view_has_changed=VIEW_UNCHANGED
 )
 
 
@@ -184,7 +184,7 @@ class TestRegexBasedParsing(_BaseTestCase):
     # that the input string starts at the position (line, col) in the buffer.
     # If the linter then reports an error on line 1, the error is actually
     # on line (line + 1) in the buffer.
-    def test_if_col_and_on_a_word_apply_offset_first_line(self, offset=(5, 10)):
+    def test_if_col_and_on_a_word_apply_offset_first_line(self, offsets=(5, 10, 20)):
         PREFIX = dedent("""\
         0
         1
@@ -201,7 +201,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         linter = self.create_linter()
         when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
 
-        result = execute_lint_task(linter, INPUT, offset=offset)
+        result = execute_lint_task(linter, INPUT, offsets=offsets)
         drop_info_keys(result)
 
         # Whereby the offset is (line, col), regions represent ranges between
@@ -221,7 +221,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         )
 
     # See comment above
-    def test_if_col_and_on_a_word_apply_offset_next_line(self, offset=(5, 10)):
+    def test_if_col_and_on_a_word_apply_offset_next_line(self, offsets=(5, 10, 20)):
         PREFIX = dedent("""\
         0
         1
@@ -238,7 +238,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         linter = self.create_linter()
         when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
 
-        result = execute_lint_task(linter, INPUT, offset=offset)
+        result = execute_lint_task(linter, INPUT, offsets=offsets)
         drop_info_keys(result)
 
         char_offset = len(PREFIX) + len('First line\n')

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -870,6 +870,22 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         verify(linter_module.VirtualView, times=0).from_file(...)
 
+    def test_ensure_no_new_virtual_view_for_main_file_with_temp_file(self):
+        TEMP = os.path.join(tempfile.gettempdir(), "file.tmp")
+        INPUT = "0123456789"
+        OUTPUT = __file__ + ":1:1 ERROR: The message"
+
+        linter = self.create_linter(FakeLinterCaptureTempFilename)
+        when(self.view).file_name().thenReturn(__file__)
+
+        when(linter).tmpfile(...).thenReturn(OUTPUT)
+        linter.temp_filename = TEMP
+
+        spy2(linter_module.VirtualView.from_file)
+        execute_lint_task(linter, INPUT)
+
+        verify(linter_module.VirtualView, times=0).from_file(...)
+
     def test_invalid_filename_is_dropped(self):
         INPUT = "0123456789"
         OUTPUT = "non_existing_file:1:1 ERROR: The message"

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -112,7 +112,7 @@ class _BaseTestCase(DeferrableTestCase):
         unstub()
 
     def assertResult(self, expected, actual):
-        drop_keys(['uid', 'priority'], actual)
+        drop_keys(['uid', 'priority', 'filename'], actual)
         self.assertEqual(expected, actual)
 
     def create_view(self, window):

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -124,7 +124,7 @@ class _BaseTestCase(DeferrableTestCase):
         unstub()
 
     def assertResult(self, expected, actual):
-        drop_keys(['uid', 'priority', 'filename'], actual)
+        drop_keys(['uid', 'priority'], actual)
         self.assertEqual(expected, actual)
 
     def create_view(self, window):
@@ -164,6 +164,7 @@ class TestRegexBasedParsing(_BaseTestCase):
                     'code': 'ERROR',
                     'msg': 'The message',
                     'linter': 'fakelinter',
+                    'filename': '<untitled {}>'.format(self.view.buffer_id())
                 }
             ],
             result,
@@ -931,5 +932,5 @@ def drop_keys(keys, array, strict=False):
             item.pop(k) if strict else item.pop(k, None)
 
 
-drop_info_keys = partial(drop_keys, ['error_type', 'code', 'msg', 'linter'])
+drop_info_keys = partial(drop_keys, ['error_type', 'code', 'msg', 'linter', 'filename'])
 drop_position_keys = partial(drop_keys, ['line', 'start', 'end', 'region'])

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -813,6 +813,24 @@ class TestRegexBasedParsing(_BaseTestCase):
         self.assertEqual(result[0]['filename'], __file__)
 
     @p.expand([
+        (FakeLinterCaptureFilename, "0123456789", "stdin:1:1 ERROR: The message"),
+        (FakeLinterCaptureFilename, "0123456789", "<stdin>:1:1 ERROR: The message"),
+        (FakeLinterCaptureFilename, "0123456789", "-:1:1 ERROR: The message"),
+    ])
+    def test_ensure_stdin_filename_is_replaced_with_main_filename(
+        self, linter_class, INPUT, OUTPUT
+    ):
+        linter = self.create_linter(linter_class, {
+            'working_dir': os.path.dirname(__file__)
+        })
+        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
+        when(self.view).file_name().thenReturn(__file__)
+
+        result = execute_lint_task(linter, INPUT)
+
+        self.assertEqual(result[0]['filename'], __file__)
+
+    @p.expand([
         (FakeLinter, "0123456789", "stdin:1:1 ERROR: The message"),
         (FakeLinterCaptureFilename, "0123456789", "test_regex_parsing.py:1:1 ERROR: The message"),
         (FakeLinterCaptureFilename, "0123456789", "./test_regex_parsing.py:1:1 ERROR: The message"),

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -124,8 +124,8 @@ class _BaseTestCase(DeferrableTestCase):
         view.set_scratch(True)
         view.close()
 
-    def create_linter(self, linter_factory=FakeLinter):
-        linter = linter_factory(self.view, settings={})
+    def create_linter(self, linter_factory=FakeLinter, settings={}):
+        linter = linter_factory(self.view, settings)
         when(util).which('fake_linter_1').thenReturn('fake_linter_1')
 
         return linter

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -982,6 +982,24 @@ class TestSplitMatchContract(_BaseTestCase):
 
         self.assertEqual(0, len(result))
 
+    @p.expand([('dict', {'foo': 'bar'}), ('true', True)])
+    def test_allow_arbitrary_truthy_values_for_match(self, _, TRUTHY):
+        linter = self.create_linter()
+
+        INPUT = "0123456789"
+        OUTPUT = "stdin:1:1 ERROR: The message"
+        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
+
+        def split_match(match):
+            m = Linter.split_match(linter, match)
+            match_, line, col, error, warning, message, near = m
+            return TRUTHY, line, col, error, warning, message, near
+
+        with expect(linter, times=1).split_match(...).thenAnswer(split_match):
+            result = linter.lint(INPUT, VIEW_UNCHANGED)
+
+        self.assertEqual(1, len(result))
+
 
 def drop_keys(keys, array, strict=False):
     for item in array:

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -982,6 +982,8 @@ class TestSplitMatchContract(_BaseTestCase):
 
         self.assertEqual(0, len(result))
 
+    # Plugin authors used `match` to pass arbitrary additional information
+    # around. We support this for compatibility.
     @p.expand([('dict', {'foo': 'bar'}), ('true', True)])
     def test_allow_arbitrary_truthy_values_for_match(self, _, TRUTHY):
         linter = self.create_linter()


### PR DESCRIPTION
This enables support to show messages from multiple files correctly. For example [clang-tidy](https://github.com/rwols/SublimeLinter-contrib-clang-tidy) can be configured to also show messages from files that are included in the linted file. Right now these messages are treated as coming from the linted file which is confusing and can lead to errors like #1379.

These changes try to format such messages nicely and make them behave just like messages from the linted file. It is already possible to jump to the mentioned line. Currently it looks like this:
![grafik](https://user-images.githubusercontent.com/17482215/49884131-73d69f80-fe34-11e8-9356-5c1c9ed4fe47.png)

There are some issues I have found so far:
- [ ] Columns in other files are always shown as `1`
- [ ] The panel is not updated when navigating other files
- [ ] Tests are missing

Some parts of the code are still a bit ugly. For example to get the filename a message refers to it accesses the regex match directly because I couldn't find a practical way to extend the `LintMatch` tuple.

It would be great if someone else would be also able to test this or even provide some improvements.