### PR TITLE
Forgivness for of bounds lines

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1060,7 +1060,6 @@ class Linter(metaclass=LinterMeta):
             start, end = vv.full_line(line)
             col = max(min(col, (end - start) - 1), 0)
 
-
         line, start, end = self.reposition_match(line, col, m, vv)
         return {
             "line": line,

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -94,6 +94,9 @@ class VirtualView:
         start, end = self.full_line(line)
         return self._code[start:end]
 
+    def max_lines(self):
+        return len(self._newlines) - 2
+
     # Actual Sublime API would look like:
     # def full_line(self, region)
     # def full_line(self, point) => Region
@@ -1038,15 +1041,27 @@ class Linter(metaclass=LinterMeta):
         error_type = self.get_error_type(m.error, m.warning)
 
         col = m.col
+        line = m.line
+
+        # Ensure `line` is within bounds
+        line = max(min(line, vv.max_lines()), 0)
+        if line != m.line:
+            logger.warning(
+                "Reported line '{}' is not within the code we're linting.\n"
+                "Maybe the linter reports problems from multiple files "
+                "or `line_col_base` is not set correctly."
+                .format(m.line + self.line_col_base[0])
+            )
 
         if col is not None:
-            col = self.maybe_fix_tab_width(m.line, col, vv)
+            col = self.maybe_fix_tab_width(line, col, vv)
 
             # Pin the column to the start/end line offsets
-            start, end = vv.full_line(m.line)
+            start, end = vv.full_line(line)
             col = max(min(col, (end - start) - 1), 0)
 
-        line, start, end = self.reposition_match(m.line, col, m, vv)
+
+        line, start, end = self.reposition_match(line, col, m, vv)
         return {
             "line": line,
             "start": start,

--- a/tests/test_command_generation.py
+++ b/tests/test_command_generation.py
@@ -11,6 +11,7 @@ from unittesting import DeferrableTestCase
 from SublimeLinter.tests.parameterized import parameterized as p
 from SublimeLinter.tests.mockito import (
     when,
+    verifyNoUnwantedInteractions,
     expect,
     unstub,
     mock
@@ -242,6 +243,10 @@ class TestWorkingDirSetting(_BaseTestCase):
             "{}: wanted working_dir '{}' is not a directory".format('fakelinter', dir)
         ):
             actual = linter.get_working_dir(settings)
+
+            # Looks like we're using an outdated version of mockito,
+            # which does not automatically verify on `__exit__`.
+            verifyNoUnwantedInteractions(linter_module.logger)
 
         self.assertEqual(None, actual)
 

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -684,6 +684,26 @@ class TestRegexBasedParsing(_BaseTestCase):
             # which does not automatically verify on `__exit__`.
             verifyNoUnwantedInteractions(linter_module.logger)
 
+    @p.expand([
+        ((0, 0), "0\n1", "stdin:0:1 ERROR: The message"),
+        ((0, 0), "0\n1", "stdin:1:1 ERROR: The message"),
+
+        ((1, 0), "1\n2", "stdin:1:1 ERROR: The message"),
+        ((1, 0), "1\n2", "stdin:2:1 ERROR: The message"),
+    ])
+    def test_correct_line_does_not_produce_a_warning(
+        self, LINE_COL_BASE, INPUT, OUTPUT
+    ):
+        linter = self.create_linter()
+        linter.line_col_base = LINE_COL_BASE
+
+        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
+        when(linter_module.logger).warning(...)
+
+        execute_lint_task(linter, INPUT)
+
+        verify(linter_module.logger, times=0).warning(...)
+
 
 class TestSplitMatchContract(_BaseTestCase):
     # Here we execute `linter.lint` bc `backend.execute_lint_task` eats all

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,5 +1,6 @@
 {
     "deferred": true,
+    "fast_timings": true,
     "reload_package_on_testing": true,
     "start_coverage_after_reload": false,
     "show_reload_progress": true,


### PR DESCRIPTION
Fixes #1379 

We pin the line between (0, max_lines) but at the same time log warnings if the linter reports out of bound lines.

cc @mheinzler Not as interesting as #1528 just to get it out of our way.