### PR TITLE
Add typical arg dsl test for documentation

### DIFF
--- a/tests/test_user_args_dsl.py
+++ b/tests/test_user_args_dsl.py
@@ -93,6 +93,7 @@ class TestArgsDSL(_BaseTestCase):
         ('--a ', {'a': 'foo'}, ['--a', 'foo']),
         ('--a ', {'a': ['foo']}, ['--a', 'foo']),
         ('--a ', {'a': ['foo', 'bar']}, ['--a', 'foo bar']),
+        ('--a,', {'a': ['foo', 'bar']}, ['--a', 'foo,bar']),
         ('@a ', {'a': 'foo'}, ['foo']),
         ('@a ', {'a': ['foo']}, ['foo']),
         ('@a ', {'a': ['foo', 'bar']}, ['foo bar']),


### PR DESCRIPTION
The `,` case is probably the most common separator used, so explicitly
ensure and protect its behavior. This also acts as documentation.