### PR TITLE
Extensible `LintMatch`

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1096,7 +1096,7 @@ class Linter(metaclass=LinterMeta):
         return error
 
     def process_match(self, m, vv):
-        error_type = self.get_error_type(m.error, m.warning)
+        error_type = m.get('error_type', None) or self.get_error_type(m.error, m.warning)
 
         col = m.col
         line = m.line

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -836,14 +836,6 @@ class Linter(metaclass=LinterMeta):
         """Return runtime environment for this lint."""
         return ChainMap({}, settings.get('env', {}), self.env, BASE_LINT_ENVIRONMENT)
 
-    def get_error_type(self, error, warning):  # noqa:D102
-        if error:
-            return ERROR
-        elif warning:
-            return WARNING
-        else:
-            return self.default_type
-
     @classmethod
     def can_lint_view(cls, view, settings):
         if cls.disabled is True:
@@ -1135,6 +1127,14 @@ class Linter(metaclass=LinterMeta):
             "code": m.error or m.warning or '',
             "msg": m.message.strip(),
         }
+
+    def get_error_type(self, error, warning):
+        if error:
+            return ERROR
+        elif warning:
+            return WARNING
+        else:
+            return self.default_type
 
     def maybe_fix_tab_width(self, line, col, vv):
         # Adjust column numbers to match the linter's tabs if necessary

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1097,6 +1097,7 @@ class Linter(metaclass=LinterMeta):
 
     def process_match(self, m, vv):
         error_type = m.get('error_type', None) or self.get_error_type(m.error, m.warning)
+        code = m.get('code', None) or m.error or m.warning or ''
 
         col = m.col
         line = m.line
@@ -1124,7 +1125,7 @@ class Linter(metaclass=LinterMeta):
             "start": start,
             "end": end,
             "error_type": error_type,
-            "code": m.error or m.warning or '',
+            "code": code,
             "msg": m.message.strip(),
         }
 

--- a/tests/test_loose_lintmatch.py
+++ b/tests/test_loose_lintmatch.py
@@ -26,10 +26,13 @@ class TestLooseLintMatch(DeferrableTestCase):
         self.assertEqual(rv.message, "message_txt")
         self.assertEqual(rv.near, "near_txt")
 
-    def test_attribute_access_returns_defaults_for_missing_legacy_values(self):
+    def test_attribute_access_returns_defaults_for_missing_common_names(self):
         rv = LintMatch()
 
-        for k in ("match", "line", "col", "error", "warning", "message", "near"):
+        for k in (
+            "match", "line", "col", "error", "warning", "message", "near",
+            "filename", "error_type", "code",
+        ):
             self.assertEqual(getattr(rv, k), '' if k == 'message' else None)
 
     def test_unknown_keys_raise_on_attribute_access(self):

--- a/tests/test_loose_lintmatch.py
+++ b/tests/test_loose_lintmatch.py
@@ -148,6 +148,11 @@ class TestLooseLintMatch(DeferrableTestCase):
         self.assertEqual(rv['message'], "message_txt")
         self.assertEqual(rv['near'], "near_txt")
 
+    def test_standard_item_access_throws_on_unknown_keys(self):
+        rv = LintMatch()
+
+        self.assertRaises(KeyError, lambda: rv['line'])
+
     def test_create_from_tuple(self):
         m = object()
         match = (m, 1, 2, "error_txt", "warning_txt", "message_txt", "near_txt")

--- a/tests/test_loose_lintmatch.py
+++ b/tests/test_loose_lintmatch.py
@@ -1,0 +1,165 @@
+from unittesting import DeferrableTestCase
+
+from SublimeLinter.lint.linter import LintMatch
+
+
+class TestLooseLintMatch(DeferrableTestCase):
+    def test_attribute_access(self):
+        m = object()
+        match = {
+            "match": m,
+            "line": 1,
+            "col": 2,
+            "error": "error_txt",
+            "warning": "warning_txt",
+            "message": "message_txt",
+            "near": "near_txt"
+        }
+
+        rv = LintMatch(**match)
+
+        self.assertEqual(rv.match, m)
+        self.assertEqual(rv.line, 1)
+        self.assertEqual(rv.col, 2)
+        self.assertEqual(rv.error, "error_txt")
+        self.assertEqual(rv.warning, "warning_txt")
+        self.assertEqual(rv.message, "message_txt")
+        self.assertEqual(rv.near, "near_txt")
+
+    def test_attribute_access_returns_defaults_for_missing_legacy_values(self):
+        rv = LintMatch()
+
+        for k in ("match", "line", "col", "error", "warning", "message", "near"):
+            self.assertEqual(getattr(rv, k), '' if k == 'message' else None)
+
+    def test_unknown_keys_raise_on_attribute_access(self):
+        rv = LintMatch()
+
+        try:
+            rv.foo
+        except AttributeError as e:
+            self.assertEqual(str(e), "'LintMatch' object has no attribute 'foo'")
+        except Exception:
+            self.fail('Should have thrown AttributeError.')
+        else:
+            self.fail('Should have thrown AttributeError.')
+
+    def test_self_repr(self):
+        rv = LintMatch(foo='bar')
+
+        self.assertEqual(str(rv), "LintMatch({'foo': 'bar'})")
+        self.assertEqual(eval(repr(rv)), rv)
+
+    def test_copy_lint_match(self):
+        rv = LintMatch(foo='bar')
+
+        self.assertEqual(rv.copy(), rv)
+        self.assertEqual(type(rv.copy()), LintMatch)
+
+    def test_double_star_unpacking_to_dict(self):
+        m = object()
+        match = {
+            "match": m,
+            "line": 1,
+            "col": 2,
+            "error": "error_txt",
+            "warning": "warning_txt",
+            "message": "message_txt",
+            "near": "near_txt"
+        }
+
+        expected = LintMatch(match)
+        actual = dict(**expected)
+        self.assertEqual(actual, expected)
+
+    def test_tuple_like_unpacking(self):
+        m = object()
+        match = {
+            "match": m,
+            "line": 1,
+            "col": 2,
+            "error": "error_txt",
+            "warning": "warning_txt",
+            "message": "message_txt",
+            "near": "near_txt"
+        }
+        rv = LintMatch(**match)
+
+        match, line, col, error, warning, message, near = rv
+
+        self.assertEqual(match, m)
+        self.assertEqual(line, 1)
+        self.assertEqual(col, 2)
+        self.assertEqual(error, "error_txt")
+        self.assertEqual(warning, "warning_txt")
+        self.assertEqual(message, "message_txt")
+        self.assertEqual(near, "near_txt")
+
+    def test_tuple_like_index_access(self):
+        m = object()
+        match = {
+            "match": m,
+            "line": 1,
+            "col": 2,
+            "error": "error_txt",
+            "warning": "warning_txt",
+            "message": "message_txt",
+            "near": "near_txt"
+        }
+        rv = LintMatch(**match)
+
+        self.assertEqual(rv[0], m)
+        self.assertEqual(rv[1], 1)
+        self.assertEqual(rv[2], 2)
+        self.assertEqual(rv[3], "error_txt")
+        self.assertEqual(rv[4], "warning_txt")
+        self.assertEqual(rv[5], "message_txt")
+        self.assertEqual(rv[6], "near_txt")
+
+        self.assertRaises(IndexError, lambda: rv[7])
+
+    def test_namedtuple_like_mutating(self):
+        rv = LintMatch({'foo': 'bar'})
+        rv2 = rv._replace(foo='baz')
+
+        self.assertEqual(rv2.foo, 'baz')
+
+        # unlike namedtuple LintMatch is mutable
+        self.assertEqual(rv.foo, 'baz')
+
+    def test_standard_items_access(self):
+        m = object()
+        match = {
+            "match": m,
+            "line": 1,
+            "col": 2,
+            "error": "error_txt",
+            "warning": "warning_txt",
+            "message": "message_txt",
+            "near": "near_txt"
+        }
+        rv = LintMatch(**match)
+
+        self.assertEqual(rv['match'], m)
+        self.assertEqual(rv['line'], 1)
+        self.assertEqual(rv['col'], 2)
+        self.assertEqual(rv['error'], "error_txt")
+        self.assertEqual(rv['warning'], "warning_txt")
+        self.assertEqual(rv['message'], "message_txt")
+        self.assertEqual(rv['near'], "near_txt")
+
+    def test_create_from_tuple(self):
+        m = object()
+        match = (m, 1, 2, "error_txt", "warning_txt", "message_txt", "near_txt")
+        actual = LintMatch(*match)
+        expected = LintMatch({
+            "match": m,
+            "line": 1,
+            "col": 2,
+            "error": "error_txt",
+            "warning": "warning_txt",
+            "message": "message_txt",
+            "near": "near_txt"
+        })
+
+        self.assertEqual(actual, expected)

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -188,6 +188,37 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         self.assertResult([{'error_type': ERROR_TYPE}], result)
 
+    @p.expand([
+        ("stdin:1:1 XCODE: The message", 'XCODE'),
+        ("stdin:1:1 XCODEERROR: The message", 'XCODE'),
+        ("stdin:1:1 XCODEWARNING: The message", 'XCODE'),
+        ("stdin:1:1 XCODEERRORWARNING: The message", 'XCODE'),
+        ("stdin:1:1 ERROR: The message", 'ERROR'),
+        ("stdin:1:1 ERRORWARNING: The message", 'ERROR'),
+        ("stdin:1:1 WARNING: The message", 'WARNING'),
+    ])
+    def test_determine_error_code(self, OUTPUT, CODE):
+        class FakeLinter(Linter):
+            defaults = {'selector': 'NONE'}
+            cmd = 'fake_linter_1'
+            regex = (
+                r"^stdin:(?P<line>\d+):(?P<col>\d+)\s"
+                r"(?P<code>XCODE)?(?P<error>ERROR)?(?P<warning>WARNING)?"
+                r":\s(?P<message>.*)$"
+            )
+
+        linter = FakeLinter(self.view, settings={})
+        when(util).which(...).thenReturn('fake_linter_1')
+
+        INPUT = "This is the source code."
+        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
+
+        result = execute_lint_task(linter, INPUT)
+        drop_position_keys(result)
+        drop_keys(['error_type', 'msg', 'linter'], result)
+
+        self.assertResult([{'code': CODE}], result)
+
     @p.expand(
         [
             ((0, 0), "stdin:0:0 ERROR: The message"),


### PR DESCRIPTION
`LintMatch` is now a basically a dict. It is roughly compatible with the previous namedtuple, tuple. 

Added `filename`, `error_type`, and `code` as common capture groups in the regex. That means if the user explicitly captures `code` or `error_type` we will just take that value and don't compute it using `m.error or m.warning` anymore. 

`filename` is obviously for #1528.

Unlike a dict, _all present_ keys can be accessed using dot chaining. E.g.

```
	error = LintMatch(foo='bar)
	error.foo  # 'bar'
	error.quux  # AttributeError
```

All commonly used names like `line`, `col` etc. can be accessed using the dot even if there are not present. 

```
	error = LintMatch()
	error.line  # None
```

This is basically user convenience since a lot of plugin authors probably are not used to python that much. 

'Proper' python in usually

```
	error.get('line', None)
	# OR:
	try:
		line = error['line']
	except KeyError:
		...
	else:
		# Do something with line
```

We also do NOT normalize the `match.groupdict()`. The groudict has a value for every named group in the regex, this value includes `None` and the empty string. So, we could say *we* as framework authors have three falsy values to deal with: KeyError, None, `''`. I think this is again for the user: she can be sure that every name from the regex finds it place in the dict. 

Fixes #1475 