### PR TITLE
Highlight nearby error row in panel

### DIFF
--- a/lint/persist.py
+++ b/lint/persist.py
@@ -7,6 +7,26 @@ from .util import printf
 from .settings import Settings
 
 
+if False:
+    from typing import DefaultDict, Dict, List, Type, Optional
+    from mypy_extensions import TypedDict
+    import sublime
+    import subprocess
+    from .linter import Linter
+
+    LintError = TypedDict('LintError', {
+        'line': int,
+        'start': int,
+        'end': int,
+        'region': sublime.Region,
+        'linter': str,
+        'error_type': str,
+        'code': Optional[str],
+        'msg': str,
+        'panel_line': int
+    })
+
+
 api_ready = False
 kill_switch = True
 
@@ -14,25 +34,27 @@ settings = Settings()
 
 # A mapping between buffer ids and errors,
 # Dict[buffer_id, [error]]
-errors = defaultdict(list)
+errors = defaultdict(list)  # type: DefaultDict[sublime.BufferId, List[LintError]]
 
 # A mapping between linter class names and linter classes
-linter_classes = {}
+linter_classes = {}  # type: Dict[str, Type[Linter]]
 
 # A mapping between buffer ids and a list of linter instances
-view_linters = {}
+view_linters = {}  # type: Dict[sublime.BufferId, List[Linter]]
 
 # Dict[buffer_id, [Popen]]
-active_procs = defaultdict(list)
+active_procs = defaultdict(list)  # type: DefaultDict[sublime.BufferId, List[subprocess.Popen]]
 active_procs_lock = threading.Lock()
 
 
 def debug_mode():
+    # type: () -> bool
     """Return whether the "debug" setting is True."""
     return settings.get('debug', False)
 
 
 def debug(*args):
+    # type: (...) -> None
     """Print args to the console if the "debug" setting is True."""
     if debug_mode():
         printf(*args)

--- a/panel/panel.sublime-settings
+++ b/panel/panel.sublime-settings
@@ -7,7 +7,7 @@
     "is_widget": true,
     "line_numbers": false,
     "rulers": false,
-    "scroll_past_end": false,
+    "scroll_past_end": true,
     "spell_check": false,
     "translate_tabs_to_spaces": false,
     "word_wrap": false,

--- a/panel_view.py
+++ b/panel_view.py
@@ -450,11 +450,6 @@ def update_panel_selection(active_view, cursor, **kwargs):
 
     mark_visible_viewport(panel, active_view, all_errors)
 
-    if not all_errors:
-        draw_position_marker(panel, None)
-        mark_lines(panel, None)
-        return
-
     row, _ = active_view.rowcol(cursor)
     errors_with_position = (
         (
@@ -504,8 +499,12 @@ def update_panel_selection(active_view, cursor, **kwargs):
                 if error['region'].begin() > cursor
             )
         except StopIteration:
-            last_error = all_errors[-1]
-            panel_line = last_error['panel_line'] + 1
+            try:
+                last_error = all_errors[-1]
+            except IndexError:
+                panel_line = None
+            else:
+                panel_line = last_error['panel_line'] + 1
         else:
             panel_line = next_error['panel_line']
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -5,6 +5,20 @@ import sublime_plugin
 
 from .lint import events, util, persist
 
+
+if False:
+    from typing import Any, Dict, List, Tuple, Iterable, Optional, Set
+    from mypy_extensions import TypedDict
+
+    State_ = TypedDict('State_', {
+        'active_view': Optional[sublime.View],
+        'cursor': int,
+        'just_saved_buffers': Set[sublime.BufferId],
+        'panel_opened_automatically': Set[sublime.WindowId]
+    })
+    LintError = Dict[str, Any]
+
+
 PANEL_NAME = "SublimeLinter"
 OUTPUT_PANEL = "output." + PANEL_NAME
 
@@ -13,7 +27,7 @@ State = {
     'cursor': -1,
     'just_saved_buffers': set(),
     'panel_opened_automatically': set()
-}
+}  # type: State_
 
 
 def plugin_loaded():
@@ -409,11 +423,6 @@ def fill_panel(window):
 
     if State['active_view'].window() == window:
         update_panel_selection(**State)
-
-
-if False:
-    from typing import Any, Dict, List, Tuple, Iterable, Optional
-    LintError = Dict[str, Any]
 
 
 def update_panel_selection(active_view, cursor, **kwargs):

--- a/panel_view.py
+++ b/panel_view.py
@@ -10,7 +10,7 @@ OUTPUT_PANEL = "output." + PANEL_NAME
 
 State = {
     'active_view': None,
-    'current_pos': -1,
+    'cursor': -1,
     'just_saved_buffers': set(),
     'panel_opened_automatically': set()
 }
@@ -68,7 +68,7 @@ class UpdateState(sublime_plugin.EventListener):
 
         State.update({
             'active_view': active_view,
-            'current_pos': get_current_pos(active_view)
+            'cursor': get_current_pos(active_view)
         })
         ensure_panel(window)
         if panel_is_active(window):
@@ -83,10 +83,10 @@ class UpdateState(sublime_plugin.EventListener):
         if view.buffer_id() != active_view.buffer_id():
             return
 
-        current_pos = get_current_pos(active_view)
-        if current_pos != State['current_pos']:
+        cursor = get_current_pos(active_view)
+        if cursor != State['cursor']:
             State.update({
-                'current_pos': current_pos
+                'cursor': cursor
             })
             if panel_is_active(active_view.window()):
                 update_panel_selection(**State)
@@ -411,7 +411,7 @@ def fill_panel(window):
         update_panel_selection(**State)
 
 
-def update_panel_selection(active_view, current_pos, **kwargs):
+def update_panel_selection(active_view, cursor, **kwargs):
     """Alter panel selection according to errors belonging to current position.
 
     If current position is between two errors, place empty panel selection on start of next error's panel line.
@@ -422,7 +422,6 @@ def update_panel_selection(active_view, current_pos, **kwargs):
     if not panel:
         return
 
-    cursor = current_pos
     if cursor == -1:
         return
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -451,7 +451,7 @@ def update_panel_selection(active_view, cursor, **kwargs):
     mark_visible_viewport(panel, active_view, all_errors)
 
     if not all_errors:
-        clear_position_marker(panel)
+        draw_position_marker(panel, None)
         mark_lines(panel, None)
         return
 
@@ -490,12 +490,11 @@ def update_panel_selection(active_view, cursor, **kwargs):
             for e in all_errors
             if nearest_error['region'].contains(e['region'])
         ]
-
         start = nearest_errors[0]['panel_line']
         end = nearest_errors[-1]['panel_line']
-        mark_lines(panel, (start, end))
 
-        clear_position_marker(panel)
+        mark_lines(panel, (start, end))
+        draw_position_marker(panel, None)
 
     else:
         try:
@@ -510,8 +509,8 @@ def update_panel_selection(active_view, cursor, **kwargs):
         else:
             panel_line = next_error['panel_line']
 
-        draw_position_marker(panel, panel_line)
         mark_lines(panel, None)
+        draw_position_marker(panel, panel_line)
 
 
 def mark_visible_viewport(panel, view, errors):
@@ -580,7 +579,12 @@ class _sublime_linter_update_selection(sublime_plugin.TextCommand):
             self.view.set_viewport_position((x1, y2))
 
 
-def draw_position_marker(panel, line):  # type: (sublime.View, int) -> None
+def draw_position_marker(panel, line):
+    # type: (sublime.View, Optional[int]) -> None
+    if line is None:
+        panel.erase_regions('SL.PanelMarker')
+        return
+
     line_start = panel.text_point(line - 1, 0)
     region = sublime.Region(line_start, line_start)
     # scope = 'region.redish markup.deleted.sublime_linter markup.error.sublime_linter'
@@ -588,7 +592,3 @@ def draw_position_marker(panel, line):  # type: (sublime.View, int) -> None
     flags = (sublime.DRAW_SOLID_UNDERLINE | sublime.DRAW_NO_FILL |
              sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE)
     panel.add_regions('SL.PanelMarker', [region], scope=scope, flags=flags)
-
-
-def clear_position_marker(panel):
-    panel.erase_regions('SL.PanelMarker')

--- a/panel_view.py
+++ b/panel_view.py
@@ -489,11 +489,6 @@ def update_panel_selection(active_view, cursor, **kwargs):
             start = panel.text_point(nearest_errors[0]['panel_line'], 0)
             end = panel.text_point(nearest_errors[-1]['panel_line'], 0)
             region = panel.line(sublime.Region(start, end))
-            # regions = panel.lines(sublime.Region(start, end))
-            # regions = [sublime.Region(r.a, r.a + 1) for r in regions]
-
-            # panel.sel().clear()
-            # panel.sel().add_all(regions)
 
             clear_position_marker(panel)
             update_selection(panel, region)

--- a/panel_view.py
+++ b/panel_view.py
@@ -382,12 +382,11 @@ def fill_panel(window):
         return
 
     errors_by_bid = get_window_errors(window, persist.errors)
-    path_dict, base_dir = create_path_dict(window, errors_by_bid.keys())
+    fpath_by_bid, base_dir = create_path_dict(window, errors_by_bid.keys())
 
     settings = panel.settings()
     settings.set("result_base_dir", base_dir)
 
-    to_render = []
     widths = dict(
         zip(
             ('line', 'col', 'error_type', 'linter_name', 'code'),
@@ -406,13 +405,15 @@ def fill_panel(window):
             )
         )
     )
-    for bid, buf_errors in errors_by_bid.items():
-        # append header
-        to_render.append(format_header(path_dict[bid]))
 
-        # append lines
+    to_render = []
+    for fpath, errors in sorted(
+        (fpath_by_bid[bid], errors) for bid, errors in errors_by_bid.items()
+    ):
+        to_render.append(format_header(fpath))
+
         base_lineno = len(to_render)
-        for i, item in enumerate(buf_errors):
+        for i, item in enumerate(errors):
             to_render.append(format_row(item, widths))
             item["panel_line"] = base_lineno + i
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -434,7 +434,13 @@ def update_panel_selection(active_view, cursor, **kwargs):
     if not persist.errors[bid]:
         return
 
-    all_errors = sorted(persist.errors[bid], key=lambda e: e['panel_line'])
+    try:
+        # Rarely, and if so only on hot-reload, `update_panel_selection` runs
+        # before `fill_panel`, thus 'panel_line' has not been set.
+        all_errors = sorted(persist.errors[bid], key=lambda e: e['panel_line'])
+    except KeyError:
+        all_errors = []
+
     mark_visible_viewport(panel, active_view, all_errors)
 
     row, _ = active_view.rowcol(cursor)

--- a/panel_view.py
+++ b/panel_view.py
@@ -518,6 +518,8 @@ if False:
 def mark_visible_viewport(panel, view, errors):
     # type: (sublime.View, sublime.View, List[Dict[str, Any]]) -> None
     KEY = 'SL.Panel.ViewportMarker'
+    KEY2 = 'SL.Panel.ViewportMarker2'
+
     viewport = view.visible_region()
 
     visible_errors = [e for e in errors if viewport.contains(e['region'])]
@@ -534,10 +536,18 @@ def mark_visible_viewport(panel, view, errors):
         scope = 'region.bluish'
         flags = (sublime.DRAW_SOLID_UNDERLINE | sublime.DRAW_NO_FILL |
                  sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE)
-        print()
         panel.add_regions(KEY, regions, scope=scope, flags=flags)
+
+        scope = 'comment'
+        scope = 'region.bluish'
+        flags = sublime.DRAW_NO_OUTLINE
+        head_line = panel.text_point(head['panel_line'], 0)
+        end_line = panel.text_point(end['panel_line'] + 1, 0)
+        regions = [sublime.Region(r.a, r.a + 1) for r in panel.lines(sublime.Region(head_line, end_line))]
+        panel.add_regions(KEY2, regions, scope=scope, flags=flags)
     else:
         panel.erase_regions(KEY)
+        panel.erase_regions(KEY2)
 
 
 def update_selection(panel, region=None):

--- a/panel_view.py
+++ b/panel_view.py
@@ -532,14 +532,12 @@ def mark_visible_viewport(panel, view, errors):
             sublime.Region(head_line, head_line),
             sublime.Region(end_line, end_line)
         ]
-        # scope = 'foo_means_forground'  # LOL
-        scope = 'region.bluish'
+        scope = 'region.bluish.visible_viewport.sublime_linter'
         flags = (sublime.DRAW_SOLID_UNDERLINE | sublime.DRAW_NO_FILL |
                  sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE)
         panel.add_regions(KEY, regions, scope=scope, flags=flags)
 
-        scope = 'comment'
-        scope = 'region.bluish'
+        scope = 'region.bluish.visible_viewport.sublime_linter'
         flags = sublime.DRAW_NO_OUTLINE
         head_line = panel.text_point(head['panel_line'], 0)
         end_line = panel.text_point(end['panel_line'] + 1, 0)

--- a/panel_view.py
+++ b/panel_view.py
@@ -447,7 +447,7 @@ def update_panel_selection(active_view, cursor, **kwargs):
         update_selection(panel, region)
 
     else:
-        SNAP = (5, 0)  # (lines, characters)
+        SNAP = (3, 0)  # (lines, characters)
 
         row, _ = active_view.rowcol(cursor)
         next_error = next(

--- a/panel_view.py
+++ b/panel_view.py
@@ -206,27 +206,19 @@ class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
 
 class SublimeLinterUpdatePanelCommand(sublime_plugin.TextCommand):
     def run(self, edit, text="", clear_sel=False):
-        """Replace a view's text entirely and attempt to restore previous selection."""
+        """Replace a view's text entirely and try to hold the viewport stable."""
         view = self.view
-
-        old_sel = [(view.rowcol(s.a), view.rowcol(s.b)) for s in view.sel()]
         x, _ = view.viewport_position()
 
         view.set_read_only(False)
         view.replace(edit, sublime.Region(0, view.size()), text)
         view.set_read_only(True)
 
-        view.sel().clear()
-        for a, b in old_sel:
-            view.sel().add(sublime.Region(view.text_point(*a), view.text_point(*b)))
-
         # We cannot measure the `viewport_position` until right after this
         # command actually finished. So we defer to the next tick/micro-task
         # using `set_timeout`.
         sublime.set_timeout(
-            lambda: view.run_command(
-                '_sublime_linter_pin_x_axis', {'x': x}
-            )
+            lambda: view.run_command('_sublime_linter_pin_x_axis', {'x': x})
         )
 
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -486,28 +486,26 @@ def update_panel_selection(active_view, cursor, **kwargs):
         scroll_into_view(panel, (start, end), all_errors)
 
     else:
-        try:
-            next_error = next(
-                error
-                for error in all_errors
-                if error['region'].begin() > cursor
-            )
-        except StopIteration:
-            try:
-                last_error = all_errors[-1]
-            except IndexError:
-                panel_line = None
-                wanted = None
-            else:
-                panel_line = last_error['panel_line'] + 1
-                wanted = (panel_line, panel_line)
-        else:
-            panel_line = next_error['panel_line']
-            wanted = (panel_line, panel_line)
-
         mark_lines(panel, None)
-        draw_position_marker(panel, panel_line)
-        scroll_into_view(panel, wanted, all_errors)
+
+        if not all_errors:
+            draw_position_marker(panel, None)
+            scroll_into_view(panel, None, all_errors)
+        else:
+            try:
+                next_error = next(
+                    error
+                    for error in all_errors
+                    if error['region'].begin() > cursor
+                )
+            except StopIteration:
+                last_error = all_errors[-1]
+                panel_line = last_error['panel_line'] + 1
+            else:
+                panel_line = next_error['panel_line']
+
+            draw_position_marker(panel, panel_line)
+            scroll_into_view(panel, (panel_line, panel_line), all_errors)
 
 
 INNER_MARGIN = 2  # [lines]

--- a/panel_view.py
+++ b/panel_view.py
@@ -268,20 +268,18 @@ def draw_on_main_thread(*args, **kwargs):
     sublime.set_timeout(lambda: draw(*args, **kwargs))
 
 
-def get_window_errors(window, all_errors):
-    bid_error_pairs = (
-        (bid, all_errors[bid]) for bid in buffer_ids_per_window(window)
-    )
+def get_window_errors(window, errors_by_bid):
     return {
-        bid: sort_errors(errors)
-        for bid, errors in bid_error_pairs
+        bid: sorted(
+            errors,
+            key=lambda e: (e["line"], e["start"], e["end"], e["linter"])
+        )
+        for bid, errors in (
+            (bid, errors_by_bid.get(bid))
+            for bid in buffer_ids_per_window(window)
+        )
         if errors
     }
-
-
-def sort_errors(errors):
-    return sorted(
-        errors, key=lambda e: (e["line"], e["start"], e["end"], e["linter"]))
 
 
 def buffer_ids_per_window(window):

--- a/panel_view.py
+++ b/panel_view.py
@@ -650,7 +650,7 @@ def mark_visible_viewport(panel, view, errors):
     ... indicating the current viewport into that file or error(s) list.
     """
     KEY = 'SL.Panel.ViewportMarker'
-    KEY2 = 'SL.Panel.ViewportMarker2'
+    # KEY2 = 'SL.Panel.ViewportMarker2'
 
     if len(errors) > CONFUSION_THRESHOLD:
         viewport = view.visible_region()
@@ -669,13 +669,13 @@ def mark_visible_viewport(panel, view, errors):
                      sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE)
             panel.add_regions(KEY, regions, scope=scope, flags=flags)
 
-            scope = 'region.bluish.visible_viewport.sublime_linter'
-            flags = sublime.DRAW_NO_OUTLINE
-            head_line = panel.text_point(head['panel_line'], 0)
-            end_line = panel.text_point(end['panel_line'] + 1, 0)
-            regions = [sublime.Region(r.a, r.a + 1) for r in panel.lines(sublime.Region(head_line, end_line))]
-            panel.add_regions(KEY2, regions, scope=scope, flags=flags)
+            # scope = 'region.bluish.visible_viewport.sublime_linter'
+            # flags = sublime.DRAW_NO_OUTLINE
+            # head_line = panel.text_point(head['panel_line'], 0)
+            # end_line = panel.text_point(end['panel_line'] + 1, 0)
+            # regions = [sublime.Region(r.a, r.a + 1) for r in panel.lines(sublime.Region(head_line, end_line))]
+            # panel.add_regions(KEY2, regions, scope=scope, flags=flags)
             return
 
     panel.erase_regions(KEY)
-    panel.erase_regions(KEY2)
+    # panel.erase_regions(KEY2)

--- a/panel_view.py
+++ b/panel_view.py
@@ -613,25 +613,8 @@ def mark_lines(panel, lines):
     end = panel.text_point(end, 0)
     region = panel.line(sublime.Region(start, end))
 
-    panel.run_command(
-        '_sublime_linter_update_selection', {'a': region.a, 'b': region.b})
-
-
-class _sublime_linter_update_selection(sublime_plugin.TextCommand):
-    def run(self, edit, a, b):
-        x1, y1 = self.view.viewport_position()
-
-        region = sublime.Region(a, b)
-        self.view.sel().clear()
-        self.view.sel().add(region)
-
-        # `show_at_center` will scroll the `b` part into the viewport. If
-        # we have long lines that means we scroll on the x-axis as well.
-        # But we don't want that, so we maybe halfway undo and pin the x-axis
-        # to the previous value.
-        x2, y2 = self.view.viewport_position()
-        if x1 != x2:
-            self.view.set_viewport_position((x1, y2))
+    panel.sel().clear()
+    panel.sel().add(region)
 
 
 def scroll_to_line(view, line, animate):

--- a/panel_view.py
+++ b/panel_view.py
@@ -617,6 +617,10 @@ def mark_lines(panel, lines):
     panel.sel().add(region)
 
 
+CURSOR_MARKER_KEY = 'SL.PanelMarker'
+CURSOR_MARKER_SCOPE = 'region.yellowish.panel_cursor.sublime_linter'
+
+
 def draw_position_marker(panel, line):
     # type: (sublime.View, Optional[int]) -> None
     """Draw a visual cursor 'below' given line.
@@ -628,19 +632,17 @@ def draw_position_marker(panel, line):
     Basically a visual hack.
     """
     if line is None:
-        panel.erase_regions('SL.PanelMarker')
+        panel.erase_regions(CURSOR_MARKER_KEY)
         return
 
     line_start = panel.text_point(line - 1, 0)
     region = sublime.Region(line_start, line_start)
-    # scope = 'region.redish markup.deleted.sublime_linter markup.error.sublime_linter'
-    scope = 'region.yellowish'
-    flags = (sublime.DRAW_SOLID_UNDERLINE | sublime.DRAW_NO_FILL |
-             sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE)
-    panel.add_regions('SL.PanelMarker', [region], scope=scope, flags=flags)
+    draw_region_dangle(panel, CURSOR_MARKER_KEY, CURSOR_MARKER_SCOPE, [region])
 
 
 CONFUSION_THRESHOLD = 5
+VIEWPORT_MARKER_KEY = 'SL.Panel.ViewportMarker'
+VIEWPORT_MARKER_SCOPE = 'region.bluish.visible_viewport.sublime_linter'
 
 
 def mark_visible_viewport(panel, view, errors):
@@ -649,7 +651,6 @@ def mark_visible_viewport(panel, view, errors):
 
     ... indicating the current viewport into that file or error(s) list.
     """
-    KEY = 'SL.Panel.ViewportMarker'
     # KEY2 = 'SL.Panel.ViewportMarker2'
 
     if len(errors) > CONFUSION_THRESHOLD:
@@ -664,10 +665,8 @@ def mark_visible_viewport(panel, view, errors):
                 sublime.Region(head_line, head_line),
                 sublime.Region(end_line, end_line)
             ]
-            scope = 'region.bluish.visible_viewport.sublime_linter'
-            flags = (sublime.DRAW_SOLID_UNDERLINE | sublime.DRAW_NO_FILL |
-                     sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE)
-            panel.add_regions(KEY, regions, scope=scope, flags=flags)
+            draw_region_dangle(
+                panel, VIEWPORT_MARKER_KEY, VIEWPORT_MARKER_SCOPE, regions)
 
             # scope = 'region.bluish.visible_viewport.sublime_linter'
             # flags = sublime.DRAW_NO_OUTLINE
@@ -677,5 +676,15 @@ def mark_visible_viewport(panel, view, errors):
             # panel.add_regions(KEY2, regions, scope=scope, flags=flags)
             return
 
-    panel.erase_regions(KEY)
+    panel.erase_regions(VIEWPORT_MARKER_KEY)
     # panel.erase_regions(KEY2)
+
+
+DANGLE_FLAGS = (
+    sublime.DRAW_SOLID_UNDERLINE | sublime.DRAW_NO_FILL |
+    sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE)
+
+
+def draw_region_dangle(view, key, scope, regions):
+    # type: (sublime.View, str, str, List[sublime.Region]) -> None
+    view.add_regions(key, regions, scope=scope, flags=DANGLE_FLAGS)

--- a/panel_view.py
+++ b/panel_view.py
@@ -540,7 +540,7 @@ def scroll_into_view(panel, wanted_lines, errors):
     possible shows the start of this file section (the filename) at the top
     of the viewport. Otherwise tries to not 'overscroll' so that errors from a
     possible next file are essentially hidden. Inbetween tries to scroll as
-    much as possible.
+    little as possible.
     """
     if not errors or not wanted_lines:
         return

--- a/panel_view.py
+++ b/panel_view.py
@@ -9,6 +9,7 @@ from .lint import events, util, persist
 if False:
     from typing import Any, Dict, List, Tuple, Iterable, Optional, Set
     from mypy_extensions import TypedDict
+    from .lint.persist import LintError
 
     State_ = TypedDict('State_', {
         'active_view': Optional[sublime.View],
@@ -16,7 +17,6 @@ if False:
         'just_saved_buffers': Set[sublime.BufferId],
         'panel_opened_automatically': Set[sublime.WindowId]
     })
-    LintError = Dict[str, Any]
 
 
 PANEL_NAME = "SublimeLinter"
@@ -553,7 +553,7 @@ def scroll_into_view(panel, wanted_lines, errors):
     # to lines. See below.
     _, vy = panel.viewport_position()
     vtop = panel.rowcol(panel.layout_to_text((0.0, vy)))[0]
-    vheight = panel.viewport_extent()[1] // panel.line_height()
+    vheight = int(panel.viewport_extent()[1] // panel.line_height())
     vbottom = vtop + vheight
 
     # Before the first error comes the filename
@@ -568,7 +568,7 @@ def scroll_into_view(panel, wanted_lines, errors):
 
     wtop, wbottom = wanted_lines
     out_of_bounds = False
-    jump_position = vheight // JUMP_COEFFICIENT
+    jump_position = int(vheight // JUMP_COEFFICIENT)
 
     if fbottom < vbottom:
         out_of_bounds = True
@@ -644,7 +644,7 @@ CONFUSION_THRESHOLD = 5
 
 
 def mark_visible_viewport(panel, view, errors):
-    # type: (sublime.View, sublime.View, List[Dict[str, Any]]) -> None
+    # type: (sublime.View, sublime.View, List[LintError]) -> None
     """Compute and draw a fancy scrollbar like region on the left...
 
     ... indicating the current viewport into that file or error(s) list.

--- a/panel_view.py
+++ b/panel_view.py
@@ -658,6 +658,8 @@ _LAST = None  # type: Optional[Tuple[sublime.BufferId, sublime.Region]]
 def until_stable_viewport(view, sink):
     # type: (sublime.View, Callable[[], None]) -> None
     global _LAST
+    if view != State['active_view']:
+        return
 
     CUR = (view.buffer_id(), view.visible_region())
     if CUR != _LAST:

--- a/panel_view.py
+++ b/panel_view.py
@@ -646,10 +646,12 @@ CONFUSION_THRESHOLD = 5
 VIEWPORT_MARKER_KEY = 'SL.Panel.ViewportMarker'
 VIEWPORT_MARKER_SCOPE = 'region.bluish.visible_viewport.sublime_linter'
 VIEWPORT_BACKGROUND_KEY = 'SL.Panel.ViewportBackground'
-# VIEWPORT_BACKGROUND_SCOPE = 'region.bluish.visible_viewport.sublime_linter'
-VIEWPORT_BACKGROUND_SCOPE = ''
 
 _RUNNING = False
+
+
+def get_viewport_background_scope():
+    return persist.settings.get('xperiments', {}).get('viewport_background_scope')
 
 
 def start_viewport_poller():
@@ -731,7 +733,8 @@ def render_visible_viewport(panel, view):
             draw_region_dangle(
                 panel, VIEWPORT_MARKER_KEY, VIEWPORT_MARKER_SCOPE, regions)
 
-            if VIEWPORT_BACKGROUND_SCOPE:
+            viewport_background_scope = get_viewport_background_scope()
+            if viewport_background_scope:
                 head_line = panel.text_point(head['panel_line'], 0)
                 end_line = panel.text_point(end['panel_line'] + 1, 0)
                 regions = [
@@ -741,7 +744,7 @@ def render_visible_viewport(panel, view):
                 flags = sublime.DRAW_NO_OUTLINE
                 panel.add_regions(
                     VIEWPORT_BACKGROUND_KEY, regions,
-                    scope=VIEWPORT_BACKGROUND_SCOPE, flags=flags)
+                    scope=viewport_background_scope, flags=flags)
             return
 
     panel.erase_regions(VIEWPORT_MARKER_KEY)

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -178,6 +178,9 @@
                 },
                 "additionalProperties":false
             }
+        },
+        "xperiments":{
+            "additionalProperties": true
         }
     },
     "additionalProperties": false


### PR DESCRIPTION
Current state: In the error panel we draw a tiny mark (as cursor) if we're somewhere in the code, and if we're on an error, we highlight the whole line. 

This is not good enough IMO. If you have a lot of information in the panel (e.g. you use mypy and really have to read that stuff) it is too hard to find the error you're actually staring at bc clearly most of the time your cursor is only 'nearby' an error and not directly on it. 

I propose that we highlight the nearest error. We don't highlight anything (t.i. we still have the tiny marker) if we're just somewhere in the code. The snap distance is 5 lines. (See the `SNAP` constant in the code.)



Fixes #1554 
Fixes #1549 
Fixes #1548 