### PR TITLE
Accept non-strings for `code` and fix line format in the error panel

### DIFF
--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -76,7 +76,7 @@ contexts:
 
   expect-linter-type:
     - include: pop-at-end
-    - match: ([^\s:]+)(?:(:)(\S+))?
+    - match: ([^\s:]+)\s*(?:(:)(\S+))?
       captures:
         0: meta.linter-code.sublime_linter
         1: entity.name.label.linter-name.sublime_linter

--- a/panel/syntax_test_panel
+++ b/panel/syntax_test_panel
@@ -3,6 +3,8 @@
 highlight_view.py:
 # <- entity.name.filename.sublime_linter
 #^^^^^^^^^^^^^^^^ entity.name.filename.sublime_linter
+# <- meta.error_panel.fileline.sublime_linter
+#^^^^^^^^^^^^^^^^^ meta.error_panel.fileline.sublime_linter
 
 
    667:14   warning       flake8:E211         whitespace before '('
@@ -37,6 +39,12 @@ highlight_view.py:
 #                         ^^^^^^ entity.name.label.linter-name.sublime_linter
 #                               ^ punctuation.separator.sublime_linter
 #                                ^^^^ entity.name.class.error-code.sublime_linter
+
+   669:1    error         flake8  :E113         unexpected indentation
+#                         ^^^^^^^^^^^^^ meta.linter-code.sublime_linter
+#                         ^^^^^^ entity.name.label.linter-name.sublime_linter
+#                                 ^ punctuation.separator.sublime_linter
+#                                  ^^^^ entity.name.class.error-code.sublime_linter
 
    669:1    error         flake8              unexpected indentation
 #                         ^^^^^^ meta.linter-code.sublime_linter

--- a/panel_view.py
+++ b/panel_view.py
@@ -343,22 +343,21 @@ def run_update_panel_cmd(panel, text=None):
     panel.run_command(cmd, {'text': text, 'clear_sel': clear_sel})
 
 
-def format_row(
-    item, error_type_width=7, linter_name_width=12, line_width=5,
-    col_width=4, code_width=12
-):
+def format_row(item, widths):
+    code_width = widths['code']
+    code_tmpl = ":{{code:<{}}}".format(code_width)
+    tmpl = (
+        " {{LINE:>{line}}}:{{START:<{col}}}  {{error_type:{error_type}}}  "
+        "{{linter:<{linter_name}}}{{CODE}}  {{msg}}"
+        .format(**widths)
+    )
+
     line = item["line"] + 1
     start = item["start"] + 1
-    code_tmpl = ":{{code:<{}}}".format(code_width)
     code = (
         code_tmpl.format(**item)
         if item['code']
         else ' ' * (code_width + (1 if code_width else 0))  # + 1 for the ':'
-    )
-    tmpl = (
-        " {{LINE:>{}}}:{{START:<{}}}  {{error_type:{}}}  "
-        "{{linter:<{}}}{{CODE}}  {{msg}}"
-        .format(line_width, col_width, error_type_width, linter_name_width)
     )
     return tmpl.format(LINE=line, START=start, CODE=code, **item)
 
@@ -380,7 +379,7 @@ def fill_panel(window):
     to_render = []
     widths = dict(
         zip(
-            ('line_width', 'col_width', 'error_type_width', 'linter_name_width', 'code_width'),
+            ('line', 'col', 'error_type', 'linter_name', 'code'),
             map(
                 max,
                 zip(*[
@@ -403,7 +402,7 @@ def fill_panel(window):
         # append lines
         base_lineno = len(to_render)
         for i, item in enumerate(buf_errors):
-            to_render.append(format_row(item, **widths))
+            to_render.append(format_row(item, widths))
             item["panel_line"] = base_lineno + i
 
         # insert empty line between views sections

--- a/panel_view.py
+++ b/panel_view.py
@@ -389,7 +389,7 @@ def fill_panel(window):
                         len(str(error['start'])),
                         len(error['error_type']),
                         len(error['linter']),
-                        len(error['code']),
+                        len(str(error['code'])),
                     )
                     for error in chain(*errors_by_bid.values())
                 ])

--- a/panel_view.py
+++ b/panel_view.py
@@ -349,7 +349,7 @@ def format_row(
 ):
     line = item["line"] + 1
     start = item["start"] + 1
-    code_tmpl = ":{{code:{}}}".format(code_width)
+    code_tmpl = ":{{code:<{}}}".format(code_width)
     code = (
         code_tmpl.format(**item)
         if item['code']


### PR DESCRIPTION
Fixes #1550 

As a hotfix accept non-strings as value for `code`. After fixing flow probably switch back. Currently flow sends a literal `True` as `code` which doesn't make sense and also looks a bit funny in the error panel. A bit sad that nobody ever reported or fixed that.

Also: Fix small glitches introduced by the new column layout. 

- Ensure code is left-aligned
- Ensure code is colored correctly for short linter names.

Add tests.