### PR TITLE
Ensure independent, mutable linter instances in backend

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -397,14 +397,14 @@ class LinterMeta(type):
             'npm_name', 'composer_name'
         ):
             if key in attrs:
-                logger.info(
-                    "{}: Defining 'cls.{}' has no effect anymore. You can "
-                    "safely remove these settings.".format(name, key))
+                logger.warning(
+                    "{}: Defining 'cls.{}' has no effect. Please cleanup and "
+                    "remove these settings.".format(name, key))
 
         for key in ('build_cmd', 'insert_args'):
             if key in attrs:
                 logger.warning(
-                    "{}: Do not implement 'cls.{}()'. SublimeLinter will "
+                    "{}: Do not implement '{}'. SublimeLinter will "
                     "change here in the near future.".format(name, key))
 
         for key in ('can_lint', 'can_lint_syntax'):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -412,6 +412,14 @@ class LinterMeta(type):
                 logger.warning(
                     "{}: Implementing 'cls.{}' has no effect anymore. You "
                     "can safely remove these methods.".format(name, key))
+
+        if 'should_lint' in attrs:
+            logger.warning(
+                "{}: Do *NOT* implement 'should_lint'. SublimeLinter will "
+                "have a breaking change here in the near future.  "
+                "Note: The 'self' you see in there is probably not the "
+                "same 'self' you see in other methods. Do *not* mutate 'self'!"
+                .format(name))
         # END DEPRECATIONS
 
         cmd = attrs.get('cmd')
@@ -932,8 +940,9 @@ class Linter(metaclass=LinterMeta):
         """
         should_lint takes reason then decides whether the linter should start or not.
 
-        should_lint allows each Linter to programmatically decide whether it should take
-        action on each trigger or not.
+        DO NOT USE except for experiments! WILL CHANGE!
+        Note that `self` here is probably not the same `self` you later
+        see e.g. in `split_match`. Do *NOT* mutate `self`!
         """
         # A 'saved-file-only' linter does not run on unsaved views
         if self.tempfile_suffix == '-' and self.view.is_dirty():

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1142,7 +1142,11 @@ class Linter(metaclass=LinterMeta):
                 vv = VirtualView.from_file(filename)
             except OSError as err:
                 # warn about the error and drop this match
-                logger.warning('Exception: {}'.format(str(err)))
+                logger.warning(
+                    "{} reported errors coming from '{}'. "
+                    "However, reading that file raised:\n  {}."
+                    .format(self.name, filename, str(err))
+                )
                 self.notify_failure()
                 return None
         else:  # main file

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1490,7 +1490,12 @@ def store_proc_while_running(bid, proc):
         yield proc
     finally:
         with persist.active_procs_lock:
-            persist.active_procs[bid].remove(proc)
+            # During hot-reload `active_procs` gets evicted so we must
+            # expect a `ValueError` from time to time
+            try:
+                persist.active_procs[bid].remove(proc)
+            except ValueError:
+                pass
 
 
 RUNNING_TEMPLATE = """{headline}

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,43 @@
+from unittesting import DeferrableTestCase
+
+import sublime
+from SublimeLinter.lint import (
+    Linter,
+    linter as linter_module,
+    backend,
+)
+
+
+class TestCloningLinters(DeferrableTestCase):
+    def create_view(self, window):
+        view = window.new_file()
+        self.addCleanup(self.close_view, view)
+        return view
+
+    def close_view(self, view):
+        view.set_scratch(True)
+        view.close()
+
+    def test_independent_linters_inherit_settings_from_parent(self):
+        view = self.create_view(sublime.active_window())
+        settings = linter_module.LinterSettings({}, {})
+        linter = Linter(view, settings)
+
+        cloneA, cloneB = backend.create_n_independent_linters(linter, 2)
+        self.assertIsNot(cloneA, linter)
+        self.assertIsNot(cloneB, linter)
+
+        linter.settings['foo'] = 'bar'
+        self.assertIn('foo', cloneA.settings)
+        self.assertIn('foo', cloneB.settings)
+
+    def test_independent_linter_do_not_share_their_own_settings(self):
+        view = self.create_view(sublime.active_window())
+        settings = linter_module.LinterSettings({}, {})
+        linter = Linter(view, settings)
+        cloneA, cloneB = backend.create_n_independent_linters(linter, 2)
+
+        cloneA.settings['a'] = 'foo'
+        cloneB.settings['a'] = 'bar'
+        self.assertEqual('foo', cloneA.settings['a'])
+        self.assertEqual('bar', cloneB.settings['a'])


### PR DESCRIPTION
Fixes #1564

People are used to the OOP rule that if they see a `self` they can mutate
at their will. This works okay if the linter selects the whole buffer because
then the linter is used only once. If the linter selects multiple regions
instead we always reused the linter which can lead to subtle bugs.

We therefore clone the linter if the linter selects multiple regions.

We ensure that cloned linters inherit all modifications made to the settings
from the 'parent'. E.g. a linter could modify the settings in `can_lint_view`,
and these changes must be visible to the cloned linters.

All changes after the cloning are local.