### PR TITLE
 Make `LintMatch.match` optional

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1035,7 +1035,7 @@ class Linter(metaclass=LinterMeta):
                 self.name, textwrap.indent(output.strip(), '  ')))
 
         for m in self.find_errors(output):
-            if not m or not m[0]:
+            if not m:
                 continue
 
             if not isinstance(m, LintMatch):  # ensure right type

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -1045,24 +1045,6 @@ class TestSplitMatchContract(_BaseTestCase):
 
         self.assertResult([], result)
 
-    @p.expand([('empty_string', ''), ('none', None), ('false', False)])
-    def test_do_not_pass_if_1st_item_is_falsy(self, _, FALSY):
-        linter = self.create_linter()
-
-        INPUT = "0123456789"
-        OUTPUT = "stdin:1:1 ERROR: The message"
-        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
-
-        def split_match(match):
-            m = Linter.split_match(linter, match)
-            match_, line, col, error, warning, message, near = m
-            return FALSY, line, col, error, warning, message, near
-
-        with expect(linter, times=1).split_match(...).thenAnswer(split_match):
-            result = linter.lint(INPUT, VIEW_UNCHANGED)
-
-        self.assertEqual(0, len(result))
-
     def test_do_not_pass_if_2nd_item_is_None(self):
         linter = self.create_linter()
 

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -10,6 +10,7 @@ from SublimeLinter.tests.parameterized import parameterized as p
 import sublime
 from SublimeLinter.lint import (
     Linter,
+    LintMatch,
     linter as linter_module,
     backend,
     persist,
@@ -1100,6 +1101,22 @@ class TestSplitMatchContract(_BaseTestCase):
 
         self.assertEqual(1, len(result))
 
+    def test_match_is_optional(self):
+        linter = self.create_linter()
+
+        INPUT = "0123456789"
+        OUTPUT = "stdin:1:1 ERROR: The message"
+        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
+
+        def split_match(match):
+            m = Linter.split_match(linter, match)
+            m.pop('match')
+            return m
+
+        with expect(linter, times=1).split_match(...).thenAnswer(split_match):
+            result = linter.lint(INPUT, VIEW_UNCHANGED)
+
+        self.assertEqual(1, len(result))
 
 def drop_keys(keys, array, strict=False):
     for item in array:

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -1118,6 +1118,22 @@ class TestSplitMatchContract(_BaseTestCase):
 
         self.assertEqual(1, len(result))
 
+    def test_only_line_and_message_are_mandatory(self):
+        linter = self.create_linter()
+
+        INPUT = "0123456789"
+        OUTPUT = "stdin:1:1 ERROR: The message"
+        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
+
+        def split_match(match):
+            return LintMatch(line=1, message="Hi")
+
+        with expect(linter, times=1).split_match(...).thenAnswer(split_match):
+            result = linter.lint(INPUT, VIEW_UNCHANGED)
+
+        self.assertEqual(1, len(result))
+
+
 def drop_keys(keys, array, strict=False):
     for item in array:
         for k in keys:


### PR DESCRIPTION
Fixes #1562

We do not use `LintMatch.match` internally, and for JSON reporters it is
annoying to pass a truthy value here just to get the error passed.

We implement here easy as **breaking change** because it is unlikely users
explicitly set the first item of our 7-tuple to `None` but have valid values
for the other holes.