### PR TITLE
Highlights can now start as hidden

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -41,7 +41,7 @@
     "highlights.time_to_idle": 1.5,
 
     // Set to true to start the highlights hidden. Use the command
-    // "sublime_linter_toggle_highlights" to toggle the highlights
+    // "SublimeLinter: Toggle Highlights" to toggle the highlights
     "highlights.start_hidden": false,
 
     // Send a "terminate" signal to old lint processes, if their result would

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -40,6 +40,10 @@
     // you save the buffer.
     "highlights.time_to_idle": 1.5,
 
+    // Set to true to start the highlights hidden. Use the command
+    // "sublime_linter_toggle_highlights" to toggle the highlights
+    "highlights.start_hidden": false,
+
     // Send a "terminate" signal to old lint processes, if their result would
     // be thrown away. If false we fire-and-forget processes instead.
     "kill_old_processes": false,

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -54,7 +54,8 @@ State = {
     'active_view': None,
     'current_sel': tuple(),
     'idle_views': set(),
-    'quiet_views': set()
+    'quiet_views': set(),
+    'views': set()
 }
 
 
@@ -105,8 +106,11 @@ def on_lint_result(buffer_id, linter_name, **kwargs):
     for view in views:
         vid = view.id()
 
-        if persist.settings.get('highlights.start_hidden') and vid not in State['quiet_views']:
+        if persist.settings.get('highlights.start_hidden') and vid not in State['quiet_views'] and vid not in State['views']:
             State['quiet_views'].add(vid)
+
+        if vid not in State['views']:
+            State['views'].add(vid)
 
         draw(
             view,

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -103,14 +103,19 @@ def on_lint_result(buffer_id, linter_name, **kwargs):
         view, linter_name, errors_for_the_gutter)
 
     for view in views:
+        vid = view.id()
+
+        if persist.settings.get('highlights.start_hidden') and vid not in State['quiet_views']:
+            State['quiet_views'].add(vid)
+
         draw(
             view,
             linter_name,
             highlight_regions,
             gutter_regions,
             protected_regions,
-            idle=(view.id() in State['idle_views']),
-            quiet=(view.id() in State['quiet_views'])
+            idle=(vid in State['idle_views']),
+            quiet=(vid in State['quiet_views'])
         )
 
 

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -106,7 +106,11 @@ def on_lint_result(buffer_id, linter_name, **kwargs):
     for view in views:
         vid = view.id()
 
-        if persist.settings.get('highlights.start_hidden') and vid not in State['quiet_views'] and vid not in State['views']:
+        if (
+            persist.settings.get('highlights.start_hidden') and
+            vid not in State['quiet_views'] and
+            vid not in State['views']
+        ):
             State['quiet_views'].add(vid)
 
         if vid not in State['views']:

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -127,6 +127,14 @@ def on_lint_result(buffer_id, linter_name, **kwargs):
         )
 
 
+class GarbageController(sublime_plugin.EventListener):
+    def on_pre_close(self, view):
+        vid = view.id()
+        State['idle_views'].discard(vid)
+        State['quiet_views'].discard(vid)
+        State['views'].discard(vid)
+
+
 class UpdateErrorRegions(sublime_plugin.EventListener):
     @util.distinct_until_buffer_changed
     def on_modified_async(self, view):

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -127,7 +127,7 @@ def on_lint_result(buffer_id, linter_name, **kwargs):
         )
 
 
-class GarbageController(sublime_plugin.EventListener):
+class ViewListCleanupController(sublime_plugin.EventListener):
     def on_pre_close(self, view):
         vid = view.id()
         State['idle_views'].discard(vid)

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -24,6 +24,9 @@
         "highlights.demote_scope": {
             "type":"string"
         },
+        "highlights.start_hidden":{
+            "type":"boolean"
+        },
         "lint_mode":{
             "type":"string",
             "enum":["background", "load_save", "manual", "save"]


### PR DESCRIPTION
Fixes SublimeLinter/SublimeLinter#1323

Changes:
- Adds a "highlights.start_hidden" setting (boolean)
- When lint results come in, if the "highlights.start_hidden" is true, the views are added to the "quiet views state"