### PR TITLE
Move common manifest-related features to a standalone mixin

### DIFF
--- a/lint/base_linter/composer_linter.py
+++ b/lint/base_linter/composer_linter.py
@@ -1,24 +1,22 @@
 """This module exports the ComposerLinter subclass of Linter."""
 
-import codecs
-import json
-import hashlib
 import logging
-import os
-import shutil
 
-from .. import linter, util
+from ..linter import Linter
+
+from .manifest_linter_mixin import ManifestLinterMixin
 
 
 logger = logging.getLogger(__name__)
 
 
-class ComposerLinter(linter.Linter):
+class ComposerLinter(ManifestLinterMixin, Linter):
     """
     This Linter subclass provides composer-specific functionality.
 
     Linters installed with composer should inherit from this class.
-    By doing so, they automatically get the following features:
+    By doing so, they not only automatically get the features in the
+    ManifestLinterMixin, but also the following features:
 
     """
 
@@ -26,139 +24,4 @@ class ComposerLinter(linter.Linter):
         """Initialize a new ComposerLinter instance."""
         super().__init__(view, settings)
 
-        self.manifest_path = self.get_manifest_path()
-
-        if self.manifest_path:
-            self.read_manifest(os.path.getmtime(self.manifest_path))
-
-    def context_sensitive_executable_path(self, cmd):
-        """
-        Attempt to locate the composer package specified in cmd.
-
-        Searches the local vendor/bin folder first before
-        looking in the global system .composer/vendor/bin folder.
-
-        Return a tuple of (have_path, path).
-        """
-        # The default implementation will look for a user defined `executable`
-        # setting.
-        success, executable = super().context_sensitive_executable_path(cmd)
-        if success:
-            return success, executable
-
-        if self.manifest_path:
-            local_cmd = self.find_local_cmd_path(cmd[0])
-            if local_cmd:
-                return True, local_cmd
-
-        global_cmd = util.which(cmd[0])
-        if global_cmd:
-            return True, global_cmd
-        else:
-            logger.warning('{} cannot locate \'{}\'\n'
-                           'Please refer to the readme of this plugin and our troubleshooting guide: '
-                           'http://www.sublimelinter.com/en/stable/troubleshooting.html'.format(self.name, cmd[0]))
-            return True, None
-
-    def get_manifest_path(self):
-        """Get the path to the composer.json file for the current file."""
-        filename = self.view.file_name()
-        cwd = (
-            os.path.dirname(filename) if filename else
-            linter.guess_project_root_of_view(self.view)
-        )
-        return self.rev_parse_manifest_path(cwd) if cwd else None
-
-    def rev_parse_manifest_path(self, cwd):
-        """
-        Search parent directories for composer.json.
-
-        Starting at the current working directory. Go up one directory
-        at a time checking if that directory contains a composer.json
-        file. If it does, return that directory.
-        """
-        manifest_path = os.path.normpath(os.path.join(cwd, 'composer.json'))
-        bin_path = os.path.normpath(os.path.join(cwd, 'vendor/bin/'))
-
-        if os.path.isfile(manifest_path) and os.path.isdir(bin_path):
-            return manifest_path
-
-        parent = os.path.dirname(cwd)
-
-        if parent == '/' or parent == cwd:
-            return None
-
-        return self.rev_parse_manifest_path(parent)
-
-    def find_local_cmd_path(self, cmd):
-        """
-        Find a local binary in vendor/bin.
-
-        Given composer.json filepath and a local binary to find,
-        look in vendor/bin for that binary.
-        """
-        cwd = os.path.dirname(self.manifest_path)
-
-        binary = self.get_pkg_bin_cmd(cmd)
-
-        if binary:
-            return os.path.normpath(os.path.join(cwd, binary))
-
-        return self.find_ancestor_cmd_path(cmd, cwd)
-
-    def find_ancestor_cmd_path(self, cmd, cwd):
-        """Recursively check for command binary in ancestors' vendor/bin directories."""
-        vendor_bin = os.path.normpath(os.path.join(cwd, 'vendor/bin/'))
-
-        binary = shutil.which(cmd, path=vendor_bin)
-        if binary:
-            return binary
-
-        parent = os.path.dirname(cwd)
-
-        if parent == '/' or parent == cwd:
-            return None
-
-        return self.find_ancestor_cmd_path(cmd, parent)
-
-    def get_pkg_bin_cmd(self, cmd):
-        """
-        Check is binary path is defined in composer.json bin property.
-
-        Loading a linter to check its own source code is a special case.
-        For example, the local phpcs binary when linting phpcs is
-        installed at ./scripts/phpcs and not ./vendor/bin/phpcs
-
-        This function checks the composer.json `bin` property keys to
-        see if the cmd we're looking for is defined for the current
-        project.
-        """
-        pkg = self.get_manifest()
-
-        if 'bin' in pkg:
-            for executable in pkg['bin']:
-                if cmd in executable:
-                    return executable
-
-        return None
-
-    def get_manifest(self):
-        """Load manifest file (composer.json)."""
-        current_manifest_mtime = os.path.getmtime(self.manifest_path)
-
-        if (current_manifest_mtime != self.cached_manifest_mtime and
-                self.hash_manifest() != self.cached_manifest_hash):
-            self.read_manifest(current_manifest_mtime)
-
-        return self.cached_manifest
-
-    def read_manifest(self, current_manifest_mtime):
-        """Read manifest and cache mtime, hash and json content."""
-        self.cached_manifest_mtime = current_manifest_mtime
-        self.cached_manifest_hash = self.hash_manifest()
-        self.cached_manifest = json.load(codecs.open(self.manifest_path, 'r', 'utf-8'))
-
-    def hash_manifest(self):
-        """Calculate the hash of the manifest file."""
-        f = codecs.open(self.manifest_path, 'r', 'utf-8')
-        return hashlib.sha1(f.read().encode('utf-8')).hexdigest()
+        self.manifest_init(logger, manifest='composer.json', bin_path='vendor/bin/')

--- a/lint/base_linter/manifest_linter_mixin.py
+++ b/lint/base_linter/manifest_linter_mixin.py
@@ -1,0 +1,181 @@
+"""This module exports the ManifestLinterMixin of Linter."""
+
+import codecs
+import json
+import hashlib
+import os
+import shutil
+
+from .. import linter, util
+
+
+class ManifestLinterMixin:
+    """
+    This Linter mixin provides functionality to linters that have
+    manifests.
+
+    Linters with manifests should inherit from this mixin.
+    By doing so, they automatically get the following features:
+
+    """
+    logger = None
+    manifest_file = None
+    bin_path = None
+    executable_checks = set()
+
+    def manifest_init(self, logger, manifest, bin_path):
+        if manifest == None or bin_path == None:
+            return
+
+        self.logger = logger
+        self.manifest_file = manifest
+        self.bin_path = bin_path
+
+        self.manifest_path = self.get_manifest_path()
+
+        if self.manifest_path:
+            self.read_manifest(os.path.getmtime(self.manifest_path))
+
+    def manifest_register_executable_check(self, check):
+        self.executable_checks.add(check)
+
+    def context_sensitive_executable_path(self, cmd):
+        """
+        Attempt to locate the manifest module specified in cmd.
+
+        Searches the local bin folder first before
+        looking in the global system's bin folder.
+
+        Return a tuple of (have_path, path).
+        """
+        # The default implementation will look for a user defined `executable`
+        # setting.
+        success, executable = super().context_sensitive_executable_path(cmd)
+
+        if success:
+            return success, executable
+
+        if self.manifest_path:
+            local_cmd = self.find_local_cmd_path(cmd[0])
+            if local_cmd:
+                return True, local_cmd
+
+        for check in self.executable_checks:
+            success, executable = check(cmd)
+
+            if success:
+                return success, executable
+
+        global_cmd = util.which(cmd[0])
+
+        if global_cmd:
+            return True, global_cmd
+        else:
+            self.logger.warning('{} cannot locate \'{}\'\n'
+                                'Please refer to the readme of this plugin and our troubleshooting guide: '
+                                'http://www.sublimelinter.com/en/stable/troubleshooting.html'
+                                .format(self.name, cmd[0]))
+            return True, None
+
+    def get_manifest_path(self):
+        """Get the path to the manifest file for the current file."""
+        filename = self.view.file_name()
+        cwd = (
+            os.path.dirname(filename) if filename else
+            linter.guess_project_root_of_view(self.view)
+        )
+        return self.rev_parse_manifest_path(cwd) if cwd else None
+
+    def rev_parse_manifest_path(self, cwd):
+        """
+        Search parent directories for the manifest file.
+
+        Starting at the current working directory. Go up one directory
+        at a time checking if that directory contains a manifest file.
+        If it does, return that directory.
+        """
+        manifest_path = os.path.normpath(os.path.join(cwd, self.manifest_file))
+        bin_path = os.path.normpath(os.path.join(cwd, self.bin_path))
+
+        if os.path.isfile(manifest_path) and os.path.isdir(bin_path):
+            return manifest_path
+
+        parent = os.path.dirname(cwd)
+
+        if parent == '/' or parent == cwd:
+            return None
+
+        return self.rev_parse_manifest_path(parent)
+
+    def find_local_cmd_path(self, cmd):
+        """
+        Find a local binary in bin.
+
+        Given the manifest filepath and a local binary to find,
+        look in the bin for that binary.
+        """
+        cwd = os.path.dirname(self.manifest_path)
+
+        binary = self.get_pkg_bin_cmd(cmd)
+
+        if binary:
+            return os.path.normpath(os.path.join(cwd, binary))
+
+        return self.find_ancestor_cmd_path(cmd, cwd)
+
+    def find_ancestor_cmd_path(self, cmd, cwd):
+        """Recursively check for command binary in ancestors' bin directories."""
+        bin_path = os.path.normpath(os.path.join(cwd, self.bin_path))
+
+        binary = shutil.which(cmd, path=bin_path)
+        if binary:
+            return binary
+
+        parent = os.path.dirname(cwd)
+
+        if parent == '/' or parent == cwd:
+            return None
+
+        return self.find_ancestor_cmd_path(cmd, parent)
+
+    def get_pkg_bin_cmd(self, cmd):
+        """
+        Check is binary path is defined in the manifest bin property.
+
+        Loading a linter to check its own source code is a special case.
+        For example, the local phpcs binary when linting phpcs is
+        installed at ./scripts/phpcs and not ./vendor/bin/phpcs
+
+        This function checks the manifest file `bin` property keys to
+        see if the cmd we're looking for is defined for the current
+        project.
+        """
+        pkg = self.get_manifest()
+
+        if 'bin' in pkg:
+            for executable in pkg['bin']:
+                if cmd in executable:
+                    return executable
+
+        return None
+
+    def get_manifest(self):
+        """Load manifest file."""
+        current_manifest_mtime = os.path.getmtime(self.manifest_path)
+
+        if (current_manifest_mtime != self.cached_manifest_mtime and
+                self.hash_manifest() != self.cached_manifest_hash):
+            self.read_manifest(current_manifest_mtime)
+
+        return self.cached_manifest
+
+    def read_manifest(self, current_manifest_mtime):
+        """Read manifest and cache mtime, hash and json content."""
+        self.cached_manifest_mtime = current_manifest_mtime
+        self.cached_manifest_hash = self.hash_manifest()
+        self.cached_manifest = json.load(codecs.open(self.manifest_path, 'r', 'utf-8'))
+
+    def hash_manifest(self):
+        """Calculate the hash of the manifest file."""
+        f = codecs.open(self.manifest_path, 'r', 'utf-8')
+        return hashlib.sha1(f.read().encode('utf-8')).hexdigest()

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -1,24 +1,22 @@
 """This module exports the NodeLinter subclass of Linter."""
 
-import codecs
-import json
-import hashlib
 import logging
-import os
-import shutil
 
-from .. import linter, util
+from ..linter import Linter
+
+from .manifest_linter_mixin import ManifestLinterMixin
 
 
 logger = logging.getLogger(__name__)
 
 
-class NodeLinter(linter.Linter):
+class NodeLinter(ManifestLinterMixin, Linter):
     """
     This Linter subclass provides NodeJS-specific functionality.
 
     Linters installed with npm should inherit from this class.
-    By doing so, they automatically get the following features:
+    By doing so, they not only automatically get the features in
+    the ManifestLinterMixin, but also the following features:
 
     """
 
@@ -26,30 +24,11 @@ class NodeLinter(linter.Linter):
         """Initialize a new NodeLinter instance."""
         super().__init__(view, settings)
 
-        self.manifest_path = self.get_manifest_path()
+        self.manifest_register_executable_check(self.executable_disable_if_not_dependency)
 
-        if self.manifest_path:
-            self.read_manifest(os.path.getmtime(self.manifest_path))
+        self.manifest_init(logger, manifest='package.json', bin_path='node_modules/.bin/')
 
-    def context_sensitive_executable_path(self, cmd):
-        """
-        Attempt to locate the npm module specified in cmd.
-
-        Searches the local node_modules/.bin folder first before
-        looking in the global system node_modules folder. return
-        a tuple of (have_path, path).
-        """
-        # The default implementation will look for a user defined `executable`
-        # setting.
-        success, executable = super().context_sensitive_executable_path(cmd)
-        if success:
-            return True, executable
-
-        if self.manifest_path:
-            local_cmd = self.find_local_cmd_path(cmd[0])
-            if local_cmd:
-                return True, local_cmd
-
+    def executable_disable_if_not_dependency(self, cmd):
         if self.get_view_settings().get('disable_if_not_dependency', False):
             logger.info(
                 "Skipping '{}' since it is not installed locally.\n"
@@ -59,108 +38,4 @@ class NodeLinter(linter.Linter):
             self.notify_unassign()
             raise linter.PermanentError('disable_if_not_dependency')
 
-        global_cmd = util.which(cmd[0])
-        if global_cmd:
-            return True, global_cmd
-        else:
-            logger.warning('{} cannot locate \'{}\'\n'
-                           'Please refer to the readme of this plugin and our troubleshooting guide: '
-                           'http://www.sublimelinter.com/en/stable/troubleshooting.html'.format(self.name, cmd[0]))
-            return True, None
-
-    def get_manifest_path(self):
-        """Get the path to the package.json file for the current file."""
-        filename = self.view.file_name()
-        cwd = (
-            os.path.dirname(filename) if filename else
-            linter.guess_project_root_of_view(self.view)
-        )
-        return self.rev_parse_manifest_path(cwd) if cwd else None
-
-    def rev_parse_manifest_path(self, cwd):
-        """
-        Search parent directories for package.json.
-
-        Starting at the current working directory. Go up one directory
-        at a time checking if that directory contains a package.json
-        file. If it does, return that directory.
-        """
-        manifest_path = os.path.join(cwd, 'package.json')
-        bin_path = os.path.normpath(os.path.join(cwd, 'node_modules/.bin/'))
-
-        if os.path.isfile(manifest_path) and os.path.isdir(bin_path):
-            return manifest_path
-
-        parent = os.path.dirname(cwd)
-
-        if parent == '/' or parent == cwd:
-            return None
-
-        return self.rev_parse_manifest_path(parent)
-
-    def find_local_cmd_path(self, cmd):
-        """
-        Find a local binary in node_modules/.bin.
-
-        Given package.json filepath and a local binary to find,
-        look in node_modules/.bin for that binary.
-        """
-        cwd = os.path.dirname(self.manifest_path)
-
-        binary = self.get_pkg_bin_cmd(cmd)
-
-        if binary:
-            return os.path.normpath(os.path.join(cwd, binary))
-
-        return self.find_ancestor_cmd_path(cmd, cwd)
-
-    def find_ancestor_cmd_path(self, cmd, cwd):
-        """Recursively check for command binary in ancestors' node_modules/.bin directories."""
-        node_modules_bin = os.path.normpath(os.path.join(cwd, 'node_modules/.bin/'))
-
-        binary = shutil.which(cmd, path=node_modules_bin)
-        if binary:
-            return binary
-
-        parent = os.path.dirname(cwd)
-
-        if parent == '/' or parent == cwd:
-            return None
-
-        return self.find_ancestor_cmd_path(cmd, parent)
-
-    def get_pkg_bin_cmd(self, cmd):
-        """
-        Check is binary path is defined in package.json bin property.
-
-        Loading a linter to check its own source code is a special case.
-        For example, the local eslint binary when linting eslint is
-        installed at ./bin/eslint.js and not ./node_modules/.bin/eslint
-
-        This function checks the package.json `bin` property keys to
-        see if the cmd we're looking for is defined for the current
-        project.
-        """
-        pkg = self.get_manifest()
-        return pkg['bin'][cmd] if 'bin' in pkg and cmd in pkg['bin'] else None
-
-    def get_manifest(self):
-        """Load manifest file (package.json)."""
-        current_manifest_mtime = os.path.getmtime(self.manifest_path)
-
-        if (current_manifest_mtime != self.cached_manifest_mtime and
-                self.hash_manifest() != self.cached_manifest_hash):
-            self.read_manifest(current_manifest_mtime)
-
-        return self.cached_manifest
-
-    def read_manifest(self, current_manifest_mtime):
-        """Read manifest and cache mtime, hash and json content."""
-        self.cached_manifest_mtime = current_manifest_mtime
-        self.cached_manifest_hash = self.hash_manifest()
-        self.cached_manifest = json.load(codecs.open(self.manifest_path, 'r', 'utf-8'))
-
-    def hash_manifest(self):
-        """Calculate the hash of the manifest file."""
-        f = codecs.open(self.manifest_path, 'r', 'utf-8')
-        return hashlib.sha1(f.read().encode('utf-8')).hexdigest()
+        return False, None


### PR DESCRIPTION
This would enable us to create fancy errors for the failing of reading the manifest files (#1447). I plan on making those errors in this PR, but I just want to make sure I am going in the right direction.

Mind taking a look at this, @kaste or @braver?

(Edit: Also, kaste, you should join Sublime's discord server so we potentially don't have to spam people with notifications)
