### PR TITLE
Various small improvements in linter.py

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -10,7 +10,7 @@ import multiprocessing
 import os
 import threading
 
-from . import style, util, linter as linter_module
+from . import style, linter as linter_module
 
 
 if False:
@@ -25,7 +25,6 @@ if False:
 
 logger = logging.getLogger(__name__)
 
-WILDCARD_SYNTAX = '*'
 MAX_CONCURRENT_TASKS = multiprocessing.cpu_count() or 1
 orchestrator = ThreadPoolExecutor(max_workers=MAX_CONCURRENT_TASKS)
 executor = ThreadPoolExecutor(max_workers=MAX_CONCURRENT_TASKS)
@@ -237,7 +236,6 @@ def finalize_errors(linter, errors, offsets):
 
 def get_lint_regions(linters, view):
     # type: (List[Linter], sublime.View) -> Iterator[Tuple[Linter, List[sublime.Region]]]
-    syntax = util.get_syntax(view)
     for linter in linters:
         settings = linter.get_view_settings()
         selector = settings.get('selector', None)
@@ -249,31 +247,6 @@ def get_lint_regions(linters, view):
                 yield linter, [
                     region for region in view.find_by_selector(selector)
                 ]
-
-            continue
-
-        # Fallback using deprecated `cls.syntax` and `cls.selectors`
-        if (
-            syntax not in linter.selectors and
-            WILDCARD_SYNTAX not in linter.selectors
-        ):
-            yield linter, [sublime.Region(0, view.size())]
-
-        else:
-            yield linter, [
-                region
-                for selector in get_selectors(linter, syntax)
-                for region in view.find_by_selector(selector)
-            ]
-
-
-def get_selectors(linter, wanted_syntax):
-    # type: (Linter, str) -> Iterator[str]
-    for syntax in [wanted_syntax, WILDCARD_SYNTAX]:
-        try:
-            yield linter.selectors[syntax]
-        except KeyError:
-            pass
 
 
 def run_concurrently(tasks, executor):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -715,16 +715,6 @@ class Linter(metaclass=LinterMeta):
         else:
             cmd = list(cmd)
 
-        # For backwards compatibility: SL3 allowed a '@python' suffix which,
-        # when set, triggered special handling. SL4 doesn't need this marker,
-        # bc all the special handling is just done in the subclass.
-        which = cmd[0]
-        if '@python' in which:
-            logger.warning(
-                "The '@python' in '{}' has been deprecated and no effect "
-                "anymore. You can safely remove it.".format(which))
-            cmd[0] = which[:which.find('@python')]
-
         return self.build_cmd(cmd)
 
     def build_cmd(self, cmd):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -479,10 +479,16 @@ class LinterMeta(type):
             )
             cls.disabled = True
         elif 'selector' not in cls.defaults:
-            logger.error(
-                "{} disabled. 'selector' is mandatory in 'cls.defaults'.\n See "
-                "http://www.sublimelinter.com/en/stable/linter_settings.html#selector  "
-                .format(name))
+            if 'defaults' not in attrs:
+                logger.error(
+                    "{} disabled. 'cls.defaults' is mandatory and MUST be a dict."
+                    .format(name)
+                )
+            else:
+                logger.error(
+                    "{} disabled. 'selector' is mandatory in 'cls.defaults'.\n See "
+                    "http://www.sublimelinter.com/en/stable/linter_settings.html#selector  "
+                    .format(name))
             cls.disabled = True
         # END VALIDATION
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -487,7 +487,7 @@ class LinterMeta(type):
             else:
                 logger.error(
                     "{} disabled. 'selector' is mandatory in 'cls.defaults'.\n See "
-                    "http://www.sublimelinter.com/en/stable/linter_settings.html#selector  "
+                    "http://www.sublimelinter.com/en/stable/linter_settings.html#selector"
                     .format(name))
             cls.disabled = True
         # END VALIDATION

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -45,7 +45,7 @@ _ACCEPTABLE_REASONS_MAP = {
     "save": ("on_user_request", "on_save"),
     "load_save": ("on_user_request", "on_save", "on_load"),
     "background": ("on_user_request", "on_save", "on_load", None),
-}
+}  # type: Dict[str, Tuple[Union[str, None], ...]]
 
 BASE_LINT_ENVIRONMENT = ChainMap(UTF8_ENV_VARS, os.environ)
 
@@ -280,7 +280,8 @@ def get_raw_linter_settings(linter, view):
         project_settings = {}
 
     view_settings = ViewSettings(
-        view, 'SublimeLinter.linters.{}.'.format(linter.name))
+        view, 'SublimeLinter.linters.{}.'.format(linter.name)
+    )  # type: Mapping[str, Any]  # type: ignore
 
     return ChainMap({}, view_settings, project_settings, user_settings, defaults)
 
@@ -936,6 +937,7 @@ class Linter(metaclass=LinterMeta):
         return False
 
     def should_lint(self, reason=None):
+        # type: (Optional[str]) -> bool
         """
         should_lint takes reason then decides whether the linter should start or not.
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -532,10 +532,6 @@ class Linter(metaclass=LinterMeta):
     #
     name = ''
 
-    # The syntax that the linter handles. May be a string or
-    # list/tuple of strings. Names should be all lowercase.
-    syntax = ''
-
     # A string, list, tuple or callable that returns a string, list or tuple, containing the
     # command line (with arguments) used to lint.
     cmd = ''
@@ -589,16 +585,6 @@ class Linter(metaclass=LinterMeta):
 
     # Tab width
     tab_width = 1
-
-    # If a linter can be used with embedded code, you need to tell SublimeLinter
-    # which portions of the source code contain the embedded code by specifying
-    # the embedded scope selectors. This attribute maps syntax names
-    # to embedded scope selectors.
-    #
-    # For example, the HTML syntax uses the scope `source.js.embedded.html`
-    # for embedded JavaScript. To allow a JavaScript linter to lint that embedded
-    # JavaScript, you would set this attribute to {'html': 'source.js.embedded.html'}.
-    selectors = {}
 
     # If a linter reports a column position, SublimeLinter highlights the nearest
     # word at that point. You can customize the regex used to highlight words
@@ -941,24 +927,7 @@ class Linter(metaclass=LinterMeta):
                 view.score_selector(0, selector) or
                 view.find_by_selector(selector)
             )
-
-        # Fallback using deprecated `cls.syntax`
-        syntax = util.get_syntax(view).lower()
-
-        if not syntax:
-            return False
-
-        if cls.syntax == '*':
-            return True
-
-        if hasattr(cls.syntax, 'match'):
-            return cls.syntax.match(syntax) is not None
-
-        syntaxes = (
-            [cls.syntax] if isinstance(cls.syntax, str)
-            else list(cls.syntax)
-        )
-        return syntax in syntaxes
+        return False
 
     def should_lint(self, reason=None):
         """

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -975,14 +975,14 @@ class Linter(metaclass=LinterMeta):
         # `cmd = None` is a special API signal, that the plugin author
         # implemented its own `run`
         if self.cmd is None:
-            output = self.run(None, code)     # type: str
+            output = self.run(None, code)  # type: Union[str, util.popen_output]
         else:
             cmd = self.get_cmd()
             if not cmd:  # We couldn't find an executable
                 self.notify_failure()
                 return []
 
-            output = self.run(cmd, code)  # type: util.popen_output
+            output = self.run(cmd, code)
 
         if view_has_changed():
             raise TransientError('View not consistent.')
@@ -991,6 +991,7 @@ class Linter(metaclass=LinterMeta):
         return self.filter_errors(self.parse_output(output, virtual_view))
 
     def filter_errors(self, errors):
+        # type: (Iterable[LintError]) -> List[LintError]
         filter_patterns = self.get_view_settings().get('filter_errors') or []
         if isinstance(filter_patterns, str):
             filter_patterns = [filter_patterns]
@@ -1021,27 +1022,29 @@ class Linter(metaclass=LinterMeta):
         ]
 
     def parse_output(self, proc, virtual_view):
+        # type: (Union[str, util.popen_output], VirtualView) -> Iterable[LintError]
         # Note: We support type str for `proc`. E.g. the user might have
         # implemented `run`.
-        try:
-            output, stderr = proc.stdout, proc.stderr
-        except AttributeError:
-            output = proc
-        else:
-            # Try to handle `on_stderr`, but only for STREAM_BOTH linters
+        if isinstance(proc, util.popen_output):
+            # Split output, but only for STREAM_BOTH linters, and if
+            # `on_stderr` is defined.
             if (
-                output is not None and
-                stderr is not None and
+                proc.stdout is not None and
+                proc.stderr is not None and
                 callable(self.on_stderr)
             ):
+                output, stderr = proc.stdout, proc.stderr
                 if stderr.strip():
                     self.on_stderr(stderr)
             else:
                 output = proc.combined_output
+        else:
+            output = proc
 
         return self.parse_output_via_regex(output, virtual_view)
 
     def parse_output_via_regex(self, output, virtual_view):
+        # type: (str, VirtualView) -> Iterable[LintError]
         if not output:
             logger.info('{}: no output'.format(self.name))
             return
@@ -1150,6 +1153,7 @@ class Linter(metaclass=LinterMeta):
         return error
 
     def process_match(self, m, vv):
+        # type: (LintMatch, VirtualView) -> Optional[LintError]
         error_type = m.error_type or self.get_error_type(m.error, m.warning)
         code = m.code or m.error or m.warning or ''
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -435,13 +435,13 @@ class LinterMeta(type):
         if isinstance(cmd, str):
             setattr(cls, 'cmd', shlex.split(cmd))
 
+        if attrs.get('multiline', False):
+            cls.re_flags |= re.MULTILINE
+
         for regex in ('regex', 'word_re'):
-            attr = getattr(cls, regex)
+            attr = attrs.get(regex)
 
             if isinstance(attr, str):
-                if regex == 'regex' and cls.multiline:
-                    setattr(cls, 're_flags', cls.re_flags | re.MULTILINE)
-
                 try:
                     setattr(cls, regex, re.compile(attr, cls.re_flags))
                 except re.error as err:
@@ -450,6 +450,9 @@ class LinterMeta(type):
                         .format(name, regex, str(err))
                     )
                     cls.disabled = True
+                else:
+                    if regex == 'regex' and cls.regex.flags & re.M == re.M:
+                        cls.multiline = True
 
         # If this class has its own defaults, create an args_map.
         defaults = attrs.get('defaults', None)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -446,7 +446,7 @@ class LinterMeta(type):
                     setattr(cls, regex, re.compile(attr, cls.re_flags))
                 except re.error as err:
                     logger.error(
-                        '{} disabled, error compiling {}: {}'
+                        '{} disabled, error compiling {}: {}.'
                         .format(name, regex, str(err))
                     )
                     cls.disabled = True

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1014,7 +1014,7 @@ class Linter(metaclass=LinterMeta):
         return [
             error
             for error in errors
-            if error is not None and not any(
+            if not any(
                 pattern.search(': '.join([error['error_type'], error['code'], error['msg']]))
                 for pattern in filters
             )
@@ -1059,7 +1059,9 @@ class Linter(metaclass=LinterMeta):
                 m = LintMatch(*m)
 
             if m.message and m.line is not None:
-                yield self.process_match(m, virtual_view)
+                error = self.process_match(m, virtual_view)
+                if error:
+                    yield error
 
     def find_errors(self, output):
         # type: (str) -> Iterable[LintMatch]

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -390,11 +390,13 @@ class LinterMeta(type):
         # BEGIN DEPRECATIONS
         for key in ('syntax', 'selectors'):
             if key in attrs:
-                logger.warning(
-                    "{}: Defining 'cls.{}' has been deprecated. Use "
-                    "http://www.sublimelinter.com/en/stable/linter_settings.html#selector"
+                logger.error(
+                    "{}: Defining 'cls.{}' has no effect anymore. Use "
+                    "http://www.sublimelinter.com/en/stable/linter_settings.html#selector "
+                    "instead."
                     .format(name, key)
                 )
+                cls.disabled = True
 
         for key in (
             'version_args', 'version_re', 'version_requirement',

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -8,7 +8,7 @@ from .settings import Settings
 
 
 if False:
-    from typing import DefaultDict, Dict, List, Tuple, Type, Optional
+    from typing import DefaultDict, Dict, List, Tuple, Type
     from mypy_extensions import TypedDict
     import sublime
     import subprocess
@@ -21,7 +21,7 @@ if False:
         'region': sublime.Region,
         'linter': str,
         'error_type': str,
-        'code': Optional[str],
+        'code': str,
         'msg': str,
         'filename': str,
         'uid': str,

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -27,7 +27,7 @@ if False:
         'uid': str,
         'priority': int,
         'panel_line': Tuple[int, int]
-    })
+    }, total=False)
 
 
 api_ready = False

--- a/lint/util.py
+++ b/lint/util.py
@@ -10,6 +10,10 @@ import sublime
 import subprocess
 
 
+if False:
+    from typing import Optional
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -263,6 +267,9 @@ class popen_output(str):
     Small compatibility layer: It is both the decoded output
     as str and partially the Popen object.
     """
+    stdout = ''  # type: Optional[str]
+    stderr = ''  # type: Optional[str]
+    combined_output = ''
 
     def __new__(cls, proc, stdout, stderr):
         if stdout is not None:
@@ -272,7 +279,7 @@ class popen_output(str):
 
         combined_output = ''.join(filter(None, [stdout, stderr]))
 
-        rv = super().__new__(cls, combined_output)
+        rv = super().__new__(cls, combined_output)  # type: ignore
         rv.combined_output = combined_output
         rv.stdout = stdout
         rv.stderr = stderr

--- a/lint/util.py
+++ b/lint/util.py
@@ -267,6 +267,7 @@ class popen_output(str):
     Small compatibility layer: It is both the decoded output
     as str and partially the Popen object.
     """
+
     stdout = ''  # type: Optional[str]
     stderr = ''  # type: Optional[str]
     combined_output = ''

--- a/tests/test_command_generation.py
+++ b/tests/test_command_generation.py
@@ -40,7 +40,7 @@ class _BaseTestCase(DeferrableTestCase):
     def setUp(self):
         when(util).which('fake_linter_1').thenReturn('fake_linter_1')
         # it's just faster if we mock this out
-        when(linter_module.LinterMeta).register_linter(...).thenReturn(None)
+        when(linter_module).register_linter(...).thenReturn(None)
 
     def tearDown(self):
         unstub()

--- a/tests/test_filter_results.py
+++ b/tests/test_filter_results.py
@@ -38,7 +38,7 @@ class _BaseTestCase(DeferrableTestCase):
     def setUp(self):
         when(util).which('fake_linter_1').thenReturn('fake_linter_1')
         # it's just faster if we mock this out
-        when(linter_module.LinterMeta).register_linter(...).thenReturn(None)
+        when(linter_module).register_linter(...).thenReturn(None)
 
     def tearDown(self):
         unstub()

--- a/tests/test_linter_validity.py
+++ b/tests/test_linter_validity.py
@@ -20,7 +20,7 @@ from SublimeLinter.tests.mockito import (
 
 class TestLinterValidity(DeferrableTestCase):
     def setUp(self):
-        when(linter_module.LinterMeta).register_linter(...).thenReturn(None)
+        when(linter_module).register_linter(...).thenReturn(None)
 
     def tearDown(self):
         unstub()
@@ -93,7 +93,7 @@ class TestLinterValidity(DeferrableTestCase):
 
 class TestRegexCompiling(DeferrableTestCase):
     def setUp(self):
-        when(linter_module.LinterMeta).register_linter(...).thenReturn(None)
+        when(linter_module).register_linter(...).thenReturn(None)
 
     def tearDown(self):
         unstub()

--- a/tests/test_linter_validity.py
+++ b/tests/test_linter_validity.py
@@ -156,3 +156,17 @@ class TestRegexCompiling(DeferrableTestCase):
         linter = def_linter()
 
         self.assertTrue(linter.disabled)
+
+    def test_valid_and_registered_without_defining_regex(self):
+        def def_linter():
+            class Fake(Linter):
+                cmd = 'foo'
+                defaults = {'selector': ''}
+
+            return Fake
+
+        when(linter_module).register_linter('fake', ...).thenReturn(None)
+        linter = def_linter()
+
+        self.assertFalse(linter.disabled)
+        verify(linter_module).register_linter('fake', linter)

--- a/tests/test_linter_validity.py
+++ b/tests/test_linter_validity.py
@@ -56,6 +56,9 @@ class TestLinterValidity(DeferrableTestCase):
         linter = def_linter()
 
         self.assertTrue(linter.disabled)
+        verify(linter_module.logger).error(
+            contains("'cmd' must be specified.")
+        )
 
     def test_no_defaults_fails(self):
         def def_linter():
@@ -68,6 +71,9 @@ class TestLinterValidity(DeferrableTestCase):
         linter = def_linter()
 
         self.assertTrue(linter.disabled)
+        verify(linter_module.logger).error(
+            contains("'cls.defaults' is mandatory")
+        )
 
     @p.expand([
         (None, ),
@@ -76,7 +82,6 @@ class TestLinterValidity(DeferrableTestCase):
         ('foo',),
         ([], ),
         (lambda x: x,),
-        ({},),
     ])
     def test_wrong_defaults_fails(self, VAL):
         def def_linter():
@@ -90,6 +95,25 @@ class TestLinterValidity(DeferrableTestCase):
         linter = def_linter()
 
         self.assertTrue(linter.disabled)
+        verify(linter_module.logger).error(
+            contains("'cls.defaults' is mandatory and MUST be a dict.")
+        )
+
+    def test_selector_is_mandatory(self):
+        def def_linter():
+            class Fake(Linter):
+                cmd = 'foo'
+                defaults = {}
+
+            return Fake
+
+        when(linter_module.logger).error(...).thenReturn(None)
+        linter = def_linter()
+
+        self.assertTrue(linter.disabled)
+        verify(linter_module.logger).error(
+            contains("'selector' is mandatory")
+        )
 
 class TestRegexCompiling(DeferrableTestCase):
     def setUp(self):
@@ -156,6 +180,9 @@ class TestRegexCompiling(DeferrableTestCase):
         linter = def_linter()
 
         self.assertTrue(linter.disabled)
+        verify(linter_module.logger).error(
+            contains("error compiling regex: unbalanced parenthesis.")
+        )
 
     def test_valid_and_registered_without_defining_regex(self):
         def def_linter():

--- a/tests/test_linter_validity.py
+++ b/tests/test_linter_validity.py
@@ -11,10 +11,7 @@ from SublimeLinter.tests.mockito import (
     when,
     verify,
     contains,
-    verifyNoUnwantedInteractions,
-    expect,
     unstub,
-    mock
 )
 
 
@@ -35,7 +32,6 @@ class TestLinterValidity(DeferrableTestCase):
                 locals()[KEY] = 'foo'
 
             return Fake
-
 
         when(linter_module.logger).error(...).thenReturn(None)
         linter = def_linter()
@@ -114,6 +110,7 @@ class TestLinterValidity(DeferrableTestCase):
         verify(linter_module.logger).error(
             contains("'selector' is mandatory")
         )
+
 
 class TestRegexCompiling(DeferrableTestCase):
     def setUp(self):

--- a/tests/test_linter_validity.py
+++ b/tests/test_linter_validity.py
@@ -1,0 +1,91 @@
+import sublime
+from SublimeLinter.lint import (
+    Linter,
+    linter as linter_module,
+    util,
+)
+
+from unittesting import DeferrableTestCase
+from SublimeLinter.tests.parameterized import parameterized as p
+from SublimeLinter.tests.mockito import (
+    when,
+    verify,
+    contains,
+    verifyNoUnwantedInteractions,
+    expect,
+    unstub,
+    mock
+)
+
+
+class TestLinterValidity(DeferrableTestCase):
+    def tearDown(self):
+        unstub()
+
+    @p.expand([
+        ('syntax',),
+        ('selectors',)
+    ])
+    def test_defining_x_errs(self, KEY):
+        def def_linter():
+            class Fake(Linter):
+                locals()[KEY] = 'foo'
+
+            return Fake
+
+
+        when(linter_module.logger).error(...).thenReturn(None)
+        linter = def_linter()
+
+        self.assertTrue(linter.disabled)
+        verify(linter_module.logger).error(
+            contains("Defining 'cls.{}' has no effect anymore.".format(KEY))
+        )
+
+    def test_no_cmd_fails(self):
+        def def_linter():
+            class Fake(Linter):
+                ...
+
+            return Fake
+
+        when(linter_module.logger).error(...).thenReturn(None)
+        linter = def_linter()
+
+        self.assertTrue(linter.disabled)
+
+    def test_no_defaults_fails(self):
+        def def_linter():
+            class Fake(Linter):
+                cmd = 'foo'
+
+            return Fake
+
+        when(linter_module.logger).error(...).thenReturn(None)
+        linter = def_linter()
+
+        self.assertTrue(linter.disabled)
+
+    @p.expand([
+        (None, ),
+        (True, ),
+        (False, ),
+        ('foo',),
+        ([], ),
+        (lambda x: x,),
+        ({},),
+    ])
+    def test_wrong_defaults_fails(self, VAL):
+        def def_linter():
+            class Fake(Linter):
+                cmd = 'foo'
+                defaults = VAL
+
+            return Fake
+
+        when(linter_module.logger).error(...).thenReturn(None)
+        linter = def_linter()
+
+        self.assertTrue(linter.disabled)
+
+

--- a/tests/test_node_linter.py
+++ b/tests/test_node_linter.py
@@ -40,7 +40,7 @@ class TestNodeLinters(DeferrableTestCase):
         s.set("close_windows_when_empty", False)
 
         # it's just faster if we mock this out
-        when(linter_module.LinterMeta).register_linter(...).thenReturn(None)
+        when(linter_module).register_linter(...).thenReturn(None)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_user_args_dsl.py
+++ b/tests/test_user_args_dsl.py
@@ -31,7 +31,7 @@ class _BaseTestCase(DeferrableTestCase):
         when(util).which('fake_linter_1').thenReturn('fake_linter_1')
 
         # it's just faster if we mock this out
-        when(linter_module.LinterMeta).register_linter(...).thenReturn(None)
+        when(linter_module).register_linter(...).thenReturn(None)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
- Remove deprecated `cls.selectors` and `cls.syntax` handling. Rel #1583 
- Remove '@python' special handling

- FEAT: Automatically set 'cls.multiline=True' if the pattern sets the flag. 

Fixes #1497 
Fixes #1578 
Fixes #1585 