### PR TITLE
Efficient use of `ThreadPoolExecutor`

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -15,7 +15,8 @@ from .const import WARNING, ERROR
 
 MYPY = False
 if MYPY:
-    from typing import Any, Dict, List, Match, Optional, Tuple, Union
+    from typing import Any, Callable, Dict, List, Match, Optional, Tuple, Union
+    from .persist import LintError
 
 
 logger = logging.getLogger(__name__)
@@ -525,7 +526,6 @@ class Linter(metaclass=LinterMeta):
     #
     # Public attributes
     #
-
     name = ''
 
     # The syntax that the linter handles. May be a string or
@@ -979,6 +979,7 @@ class Linter(metaclass=LinterMeta):
         return reason in _ACCEPTABLE_REASONS_MAP[lint_mode]
 
     def lint(self, code, view_has_changed):
+        # type: (str, Callable[[], bool]) -> List[LintError]
         """Perform the lint, retrieve the results, and add marks to the view.
 
         The flow of control is as follows:

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -23,6 +23,9 @@ if False:
         'error_type': str,
         'code': Optional[str],
         'msg': str,
+        'filename': str,
+        'uid': str,
+        'priority': int,
         'panel_line': Tuple[int, int]
     })
 


### PR DESCRIPTION
The prior implementation did not reuse the `executor` which is a waste. To
actually limit the number of threads, we additionally had to use a
`BoundedSemaphore`.

We replace this system with two global executors. We need *two* executors
because we still have a nested structure here. The orchestrator does the
fan-out, fan-in dance for each linter in case the linter has multiple regions
to lint. The executor just runs the long lint tasks.