### PR TITLE
Fix Sublime's `expand_variables` for UNC paths

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -349,6 +349,9 @@ def substitute_variables(variables, value):
     # `${varname}` syntax and supports placeholders (`${varname:placeholder}`).
 
     if isinstance(value, str):
+        # Workaround https://github.com/SublimeTextIssues/Core/issues/1878
+        # (E.g. UNC paths on Windows start with double slashes.)
+        value = value.replace(r'\\', r'\\\\')
         value = sublime.expand_variables(value, variables)
         return os.path.expanduser(value)
     elif isinstance(value, Mapping):


### PR DESCRIPTION
Fixes https://github.com/SublimeLinter/SublimeLinter-eslint/issues/276

Explainer and origin: https://github.com/SublimeTextIssues/Core/issues/1878

Sublime's `expand_variables` handles `\\` (two slashes) and reduces them to one. We fix by adding more slashes before substituting.
