### PR TITLE
Escape '$' chars in arg values while computing the `cmd`

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -865,13 +865,19 @@ class Linter(metaclass=LinterMeta):
 
             joiner = arg_info['joiner']
             for value in values:
+                # We call `substitute_variables` in `finalize_cmd` on the whole
+                # command. Since all settings are already transparently
+                # 'expanded' we need to make sure to escape remaining '$' chars
+                # in the arg value here which otherwise denote variables within
+                # Sublime.
+                final_value = str(value).replace('$', r'\$')
                 if prefix == '@':
-                    args.append(str(value))
+                    args.append(final_value)
                 elif joiner == '=':
-                    args.append('{}={}'.format(arg, value))
+                    args.append('{}={}'.format(arg, final_value))
                 else:  # joiner == ':' or ''
                     args.append(arg)
-                    args.append(str(value))
+                    args.append(final_value)
 
         return args
 

--- a/tests/test_command_generation.py
+++ b/tests/test_command_generation.py
@@ -308,16 +308,19 @@ class TestWorkingDirSetting(_BaseTestCase):
 
 
 class TestContextSensitiveExecutablePathContract(_BaseTestCase):
-    def test_returns_true_and_a_path_indicates_success(self):
+    @p.expand([
+        ('/foo/foz.exe', ),
+        ('\\\\HOST\\foo\\foz.exe'),
+    ])
+    def test_returns_true_and_a_path_indicates_success(self, EXECUTABLE):
         class FakeLinter(Linter):
             cmd = ('fake_linter_1',)
             defaults = {'selector': None}
 
-        executable = '/foo/foz.exe'
         linter = FakeLinter(self.view, {})
-        when(linter).context_sensitive_executable_path(...).thenReturn((True, executable))
+        when(linter).context_sensitive_executable_path(...).thenReturn((True, EXECUTABLE))
 
-        result = [executable]
+        result = [EXECUTABLE]
         with expect(linter)._communicate(result, ...):
             linter.lint(INPUT, VIEW_UNCHANGED)
 


### PR DESCRIPTION
Double slashes (`\\`) and of course `$` signs are special characters for
Sublime's expand-variables-system. Here we escape '$' signs before putting
them on the `cmd` since we expand variables on the whole `cmd` again
(currently implemented in `finalize_cmd`).

We don't patch `substitute_variables` but on the fly while creating the `cmd`.
Otherwise, e.g. `executable` had such a special char, all user code operating
on settings would have to deal with these escape sequences. E.g. a simple

```
os.path.exists(self.settings['executable'])
```

would not be safe anymore. Thus, after all, the var substitution machinery
would'nt be transparent anymore.

Fixes #1599