### PR TITLE
Hard-wrap tooltip contents

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -696,7 +696,8 @@ def open_tooltip(view, point, line_report=False):
     view.show_popup(
         TOOLTIP_TEMPLATE.format(stylesheet=TOOLTIP_STYLES, content=tooltip_message),
         flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
-        location=point
+        location=point,
+        max_width=1000
     )
 
 

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -692,13 +692,11 @@ def open_tooltip(view, point, line_report=False):
     if not errors:
         return
 
-    max_chars = 80
-    tooltip_message = join_msgs(errors, show_count=line_report, width=max_chars)
+    tooltip_message = join_msgs(errors, show_count=line_report, width=80)
     view.show_popup(
         TOOLTIP_TEMPLATE.format(stylesheet=TOOLTIP_STYLES, content=tooltip_message),
         flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
-        location=point,
-        max_width=1000
+        location=point
     )
 
 

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -692,14 +692,13 @@ def open_tooltip(view, point, line_report=False):
     if not errors:
         return
 
-    max_width = min(1000, view.viewport_extent()[0])
-    max_chars = int(max_width // view.em_width() - 1)
+    max_chars = 80
     tooltip_message = join_msgs(errors, show_count=line_report, width=max_chars)
     view.show_popup(
         TOOLTIP_TEMPLATE.format(stylesheet=TOOLTIP_STYLES, content=tooltip_message),
         flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
         location=point,
-        max_width=max_width
+        max_width=1000
     )
 
 


### PR DESCRIPTION
Fixes #1601
Work-around https://github.com/SublimeTextIssues/Core/issues/2854

Sublime actually wraps long lines automatically but then calculates the height
of the tooltip wrong. We work-around by hard-wrapping all content.