### PR TITLE
Compute line:col visual width using 1-based counting

### DIFF
--- a/panel_view.py
+++ b/panel_view.py
@@ -394,8 +394,8 @@ def fill_panel(window, then=draw_on_main_thread):
                 max,
                 zip(*[
                     (
-                        len(str(error['line'])),
-                        len(str(error['start'])),
+                        len(str(error['line'] + 1)),
+                        len(str(error['start'] + 1)),
                         len(error['error_type']),
                         len(error['linter']),
                         len(str(error['code'])),


### PR DESCRIPTION
Fixes #1618

The error store is based on (0, 0) counting. But only in the panel, we present
the errors using natural (1, 1) line/column counting.

Here the width was computed wrong, e.g. for `start=9` we computed a `1`, but
the user is actually seeing a `10` which is 2 chars.