### PR TITLE
Expect the value of `bin` in a 'package.json' to be `str`

### DIFF
--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -124,7 +124,7 @@ class NodeLinter(linter.Linter):
                 # but must run as a normal script. E.g. `/usr/bin/env node eslint.js`
                 try:
                     script = os.path.normpath(os.path.join(path, manifest['bin'][npm_name]))
-                except KeyError:
+                except (KeyError, TypeError):
                     pass
                 else:
                     if not os.path.exists(os.path.join(path, 'node_modules', '.bin')):

--- a/tests/test_node_linter.py
+++ b/tests/test_node_linter.py
@@ -237,6 +237,24 @@ class TestNodeLinters(DeferrableTestCase):
         verify(node_linter.logger).warning(...)
         verify(linter).notify_failure()
 
+    @p.expand([
+        ({'bin': {'cli': 'fake.js'}},),
+        ({'bin': 'otherthing.js'},),
+    ])
+    def test_ignore_if_bin_does_not_contain_valid_information(self, CONTENT):
+        ROOT_DIR = '/p'
+        PRESENT_PACKAGE_FILE = os.path.join(ROOT_DIR, 'package.json')
+        when(self.view).file_name().thenReturn('/p/a/f.js')
+        exists = os.path.exists
+        when(os.path).exists(...).thenAnswer(exists)
+        when(os.path).exists(PRESENT_PACKAGE_FILE).thenReturn(True)
+        when(node_linter).read_json_file(PRESENT_PACKAGE_FILE).thenReturn(CONTENT)
+        when(util).which(...).thenReturn('fake.exe')
+
+        linter = make_fake_linter(self.view)
+        cmd = linter.get_cmd()
+        self.assertEqual(cmd, ['fake.exe'])
+
     def test_disable_if_not_dependency(self):
         linter = make_fake_linter(self.view)
         linter.settings['disable_if_not_dependency'] = True


### PR DESCRIPTION
Fixes #1621

We assumed that the value of `bin` is a mapping from `str -> str` but it can
be just a plain str as well. See #1621.

For now, it is probably enough to just catch and eat the thrown `TypeError`.