### PR TITLE
Users can copy linter messages from show_popup tooltip

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -657,7 +657,7 @@ TOOLTIP_STYLES = '''
         font-weight: bold;
     }
     .copy {
-        margin-top: 8px;
+        margin-top: 0.5em;
     }
 '''
 

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -692,12 +692,27 @@ def open_tooltip(view, point, line_report=False):
     if not errors:
         return
 
+    def on_navigate(href: str) -> None:
+        if href == "copy":
+            sublime.set_clipboard(join_msgs_raw(errors))
+            sublime.active_window().status_message("SublimeLinter: info copied to clipboard")
+            view.hide_popup()
+
     tooltip_message = join_msgs(errors, show_count=line_report, width=80)
     view.show_popup(
-        TOOLTIP_TEMPLATE.format(stylesheet=TOOLTIP_STYLES, content=tooltip_message),
+        TOOLTIP_TEMPLATE.format(stylesheet=TOOLTIP_STYLES, content=tooltip_message) + "<a href=\"copy\">Copy</a>",
         flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
         location=point,
-        max_width=1000
+        max_width=1000,
+        on_navigate=on_navigate
+    )
+
+
+def join_msgs_raw(errors):
+    # Take an `errors` iterable and reduce it to a string without HTML tags.
+    sorted_errors = sorted(errors, key=lambda r: (r["linter"], r["error_type"]))
+    return "\n\n".join("{}: {}\n{}{}".format(
+        e["linter"], e["error_type"], e["code"] + " - " if e["code"] else "", e["msg"]) for e in sorted_errors
     )
 
 

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -656,12 +656,16 @@ TOOLTIP_STYLES = '''
         color: var(--yellowish);
         font-weight: bold;
     }
+    .copy {
+        margin-top: 8px;
+    }
 '''
 
 TOOLTIP_TEMPLATE = '''
     <body id="sublimelinter-tooltip">
         <style>{stylesheet}</style>
         <div>{content}</div>
+        <div class="copy"><a href="copy">Copy</a></div>
     </body>
 '''
 
@@ -700,7 +704,7 @@ def open_tooltip(view, point, line_report=False):
 
     tooltip_message = join_msgs(errors, show_count=line_report, width=80)
     view.show_popup(
-        TOOLTIP_TEMPLATE.format(stylesheet=TOOLTIP_STYLES, content=tooltip_message) + "<a href=\"copy\">Copy</a>",
+        TOOLTIP_TEMPLATE.format(stylesheet=TOOLTIP_STYLES, content=tooltip_message),
         flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
         location=point,
         max_width=1000,

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -699,7 +699,7 @@ def open_tooltip(view, point, line_report=False):
     def on_navigate(href: str) -> None:
         if href == "copy":
             sublime.set_clipboard(join_msgs_raw(errors))
-            sublime.active_window().status_message("SublimeLinter: info copied to clipboard")
+            view.window().status_message("SublimeLinter: info copied to clipboard")
             view.hide_popup()
 
     tooltip_message = join_msgs(errors, show_count=line_report, width=80)


### PR DESCRIPTION
This is a minor but nice usability win for users. The tooltip created by `show_popup` now includes a link/button labeled **Copy** that lets users copy the linter output to the clipboard.

Output is formatted and has no HTML tags. Here's an example for a line with both `mypy` and `flake8` errors.

<img width="661" alt="Screen Shot 2019-07-08 at 7 01 03 PM 2" src="https://user-images.githubusercontent.com/1524088/60850194-c18d6d80-a1b3-11e9-8d27-d23d733c631d.png">

Actual text copied to clipboard:

<img width="552" alt="Screen Shot 2019-07-08 at 7 01 30 PM" src="https://user-images.githubusercontent.com/1524088/60850208-d2d67a00-a1b3-11e9-8238-482bba69da97.png">

Status message printed on copy to give user feedback:

<img width="300" alt="Screen Shot 2019-07-08 at 7 01 24 PM" src="https://user-images.githubusercontent.com/1524088/60850214-d8cc5b00-a1b3-11e9-857d-9c731d98b4af.png">
