### PR TITLE
Clarify two examples in linter_settings.rst.

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -195,31 +195,34 @@ Example: this changes the appearance of shellcheck warnings:
 .. code-block:: json
 
     {
-        "shellcheck": {
-            "styles": [
-                {
-                    "mark_style": "stippled_underline",
-                    "scope": "region.bluish",
-                    "types": ["warning"]
-                }
-            ]
+        "linters": {
+            "shellcheck": {
+                "styles": [
+                    {
+                        "mark_style": "stippled_underline",
+                        "scope": "region.bluish",
+                        "types": ["warning"]
+                    }
+                ]
+            }
         }
     }
 
 Example: this changes the appearance of whitespace warnings in flake8:
 
 .. code-block:: json
-
     {
-        "flake8": {
-            "styles": [
-                {
-                    "mark_style": "outline",
-                    "scope": "comment",
-                    "icon": "none",
-                    "codes": ["W293", "W291", "W292"]
-                }
-            ]
+        "linters": {
+            "flake8": {
+                "styles": [
+                    {
+                        "mark_style": "outline",
+                        "scope": "comment",
+                        "icon": "none",
+                        "codes": ["W293", "W291", "W292"]
+                    }
+                ]
+            }
         }
     }
 


### PR DESCRIPTION
The examples in the "styles" section now show that the
linter-specific settings need to be nested under the "linters" key,
similar to the example of yamllint in the "selector" section.

This example is now consistent with the example for "selector".