### PR TITLE
Run flake8 weekly

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,6 +1,11 @@
 name: flake8
 
 on:
+  schedule:
+    # flake8 regulary has breaking changes, so we re-check
+    # regulary as well.
+    - cron:  '0 9 * * 1'
+
   push:
     branches:
       - master


### PR DESCRIPTION
flake8 often pushes breaking changes, and we always fail with their strict
rules. Check weekly, nothing is more annoying than a failing PR for a file
you didn't even touch.