### PR TITLE
Set `kill_old_processes` to `True` by default

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -46,7 +46,7 @@
 
     // Send a "terminate" signal to old lint processes, if their result would
     // be thrown away. If false we fire-and-forget processes instead.
-    "kill_old_processes": false,
+    "kill_old_processes": true,
 
     // Lint Mode determines when the linter is run.
     // - background: asynchronously on every change


### PR DESCRIPTION
Fixes #1639