### PR TITLE
Fix: Inner `path` var should not shadow outer

### DIFF
--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -172,9 +172,9 @@ class NodeLinter(linter.Linter):
 
                     # Since we've found a valid 'package.json' as our 'project_root'
                     # exhaust outer loop looking just for installations.
-                    for path in paths:
+                    for path_ in paths:
                         executable = shutil.which(
-                            npm_name, path=os.path.join(path, 'node_modules', '.bin')
+                            npm_name, path=os.path.join(path_, 'node_modules', '.bin')
                         )
                         if executable:
                             return executable


### PR DESCRIPTION
An inner var should not shadow the outer loop var is usually a linter rule. 😁 

Here we also immediately have the error that we compute the 'package-lock.json' path wrong. 