### PR TITLE
WIP: Boost performance

### DIFF
--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -55,6 +55,10 @@ def redraw_file(filename, linter_name, errors, **kwargs):
     else:
         problems.pop(linter_name, None)
 
+    sublime.set_timeout(lambda: redraw_file_(filename, problems))
+
+
+def redraw_file_(filename, problems):
     for view in views_into_file(filename):
         draw(view, problems)
 

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -74,7 +74,7 @@ def plugin_unloaded():
             undraw(view)
 
 
-@events.on(events.LINT_RESULT)
+@events.on('lint_result_changed')
 def on_lint_result(filename, linter_name, **kwargs):
     views = list(all_views_into_file(filename))
     if not views:

--- a/lint/events.py
+++ b/lint/events.py
@@ -21,8 +21,7 @@ def unsubscribe(topic, fn):
         pass
 
 
-def broadcast(topic, message=None):
-    payload = message.copy() or {}
+def broadcast(topic, payload={}):
     for fn in listeners.get(topic, []):
         try:
             fn(**payload)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -158,6 +158,9 @@ class VirtualView:
     def max_lines(self):
         return len(self._newlines) - 2
 
+    def substr(self, region):
+        return self._code[region.begin():region.end()]
+
     # Actual Sublime API would look like:
     # def full_line(self, region)
     # def full_line(self, point) => Region
@@ -1328,6 +1331,7 @@ class Linter(metaclass=LinterMeta):
         region = sublime.Region(line_start + start, line_start + end)
         if len(region) == 0:
             region.b += 1
+        offending_text = vv.substr(region)
 
         return {
             "filename": filename,
@@ -1338,6 +1342,7 @@ class Linter(metaclass=LinterMeta):
             "error_type": error_type,
             "code": code,
             "msg": m.message.strip(),
+            "offending_text": offending_text
         }
 
     def get_error_type(self, error, warning):

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -29,7 +29,8 @@ if False:
         'filename': FileName,
         'uid': str,
         'priority': int,
-        'panel_line': Tuple[int, int]
+        'panel_line': Tuple[int, int],
+        'offending_text': str
     }, total=False)
 
 

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -72,12 +72,6 @@ class Settings:
             return
 
         events.broadcast('settings_changed', {'settings': self})
-        from . import style
-
-        gutter_theme_changed = self.has_changed('gutter_theme')
-        if gutter_theme_changed:
-            style.read_gutter_theme()
-        style.clear_caches()
 
         if (
             self.has_changed('linters') or
@@ -87,7 +81,7 @@ class Settings:
                 'sublime_linter_config_changed', {'hint': 'relint'})
 
         elif (
-            gutter_theme_changed or
+            self.has_changed('gutter_theme') or
             self.has_changed('highlights.demote_while_editing') or
             self.has_changed('show_marks_in_minimap') or
             self.has_changed('styles')

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -63,10 +63,11 @@ class Settings:
         if not validate_global_settings():
             return
 
+        from . import style
         gutter_theme_changed = self.has_changed('gutter_theme')
         if gutter_theme_changed:
-            from . import style
             style.read_gutter_theme()
+        style.clear_caches()
 
         if (
             self.has_changed('linters') or

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -15,6 +15,7 @@ class Settings:
         self._previous_state = {}
         self._current_state = {}
         self.__settings = None
+        self._change_count = 0
 
     def load(self):
         """Load the plugin settings."""
@@ -49,6 +50,9 @@ class Settings:
         else:
             return (old_value != current_value)
 
+    def change_count(self):
+        return self._change_count
+
     def observe(self):
         """Observe changes."""
         self.settings.clear_on_change('sublimelinter-persist-settings')
@@ -67,6 +71,7 @@ class Settings:
         """
         self._previous_state = self._current_state.copy()
         self._current_state.clear()
+        self._change_count += 1
         events.broadcast('settings_changed', {'settings': self})
 
         validate_global_settings()

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -67,27 +67,9 @@ class Settings:
         """
         self._previous_state = self._current_state.copy()
         self._current_state.clear()
-
-        if not validate_global_settings():
-            return
-
         events.broadcast('settings_changed', {'settings': self})
 
-        if (
-            self.has_changed('linters') or
-            self.has_changed('no_column_highlights_line')
-        ):
-            sublime.run_command(
-                'sublime_linter_config_changed', {'hint': 'relint'})
-
-        elif (
-            self.has_changed('gutter_theme') or
-            self.has_changed('highlights.demote_while_editing') or
-            self.has_changed('show_marks_in_minimap') or
-            self.has_changed('styles')
-        ):
-            sublime.run_command(
-                'sublime_linter_config_changed', {'hint': 'redraw'})
+        validate_global_settings()
 
 
 def get_settings_objects():

--- a/lint/style.py
+++ b/lint/style.py
@@ -14,6 +14,11 @@ WHITE_SCOPE = 'region.whitish'  # hopefully a white color
 DEFAULT_STYLES = None  # holds the styles we ship as the default settings
 
 
+@events.on('plugin_loaded')
+def on_plugin_loaded():
+    read_gutter_theme()
+
+
 @events.on('settings_changed')
 def on_settings_changed(settings, **kwargs):
     clear_caches()

--- a/lint/style.py
+++ b/lint/style.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import sublime
-from . import persist, util
+from . import events, persist, util
 
 
 logger = logging.getLogger(__name__)
@@ -12,6 +12,13 @@ logger = logging.getLogger(__name__)
 COLORIZE = True
 WHITE_SCOPE = 'region.whitish'  # hopefully a white color
 DEFAULT_STYLES = None  # holds the styles we ship as the default settings
+
+
+@events.on('settings_changed')
+def on_settings_changed(settings, **kwargs):
+    clear_caches()
+    if settings.has_changed('gutter_theme'):
+        read_gutter_theme()
 
 
 def read_gutter_theme():

--- a/panel_view.py
+++ b/panel_view.py
@@ -64,8 +64,12 @@ def plugin_unloaded():
 def on_lint_result(filename, reason=None, **kwargs):
     maybe_toggle_panel_automatically = reason in ('on_save', 'on_user_request')
     for window in sublime.windows():
-        if filename in filenames_per_window(window):
-            if panel_is_active(window):
+        panel_open = panel_is_active(window)
+        if (
+            (panel_open or maybe_toggle_panel_automatically)
+            and filename in filenames_per_window(window)
+        ):
+            if panel_open:
                 fill_panel(window)
 
             if maybe_toggle_panel_automatically:

--- a/panel_view.py
+++ b/panel_view.py
@@ -715,7 +715,7 @@ def mayby_rerender_panel(previous_token):
         return
 
     token = (view.viewport_extent(),)
-    if token != previous_token:
+    if previous_token and token != previous_token:
         window = view.window()
         if not window:
             return

--- a/panel_view.py
+++ b/panel_view.py
@@ -386,9 +386,15 @@ def fill_panel(window):
     # type: (sublime.Window) -> None
     """Create the panel if it doesn't exist, then update its contents."""
     panel = ensure_panel(window)
-    # If we're here and the user actually closed the window in the meantime,
+    # If we're here and the user actually closed the *window* in the meantime,
     # we cannot create a panel anymore, and just pass.
     if not panel:
+        return
+
+    # If the user closed the *panel* (or switched to another one), the panel
+    # has no extent anymore and we don't need to fill it.
+    vx, _ = panel.viewport_extent()
+    if vx == 0:
         return
 
     errors_by_file = get_window_errors(window, persist.file_errors)
@@ -415,7 +421,7 @@ def fill_panel(window):
             )
         )
     )  # type: Tuple[Tuple[str, int], ...]
-    widths += (('viewport', int(panel.viewport_extent()[0] // panel.em_width()) - 1), )
+    widths += (('viewport', int(vx // panel.em_width()) - 1), )
 
     to_render = []
     for fpath, errors in sorted(

--- a/panel_view.py
+++ b/panel_view.py
@@ -60,7 +60,7 @@ def plugin_unloaded():
         window.destroy_output_panel(PANEL_NAME)
 
 
-@events.on(events.LINT_RESULT)
+@events.on('lint_result_changed')
 def on_lint_result(filename, reason=None, **kwargs):
     maybe_toggle_panel_automatically = reason in ('on_save', 'on_user_request')
     for window in sublime.windows():

--- a/panel_view.py
+++ b/panel_view.py
@@ -77,11 +77,10 @@ def on_lint_result(filename, reason=None, **kwargs):
 
 
 @events.on('updated_error_positions')
-def on_updated_error_positions(view, **kwargs):
-    bid = view.buffer_id()
-    window = view.window()
-    if panel_is_active(window) and bid in buffer_ids_per_window(window):
-        fill_panel(window)
+def on_updated_error_positions(filename, **kwargs):
+    for window in sublime.windows():
+        if panel_is_active(window) and filename in filenames_per_window(window):
+            fill_panel(window)
 
 
 @events.on('renamed_file')

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -44,7 +44,7 @@ def plugin_unloaded():
             view.erase_status(STATUS_MSG_KEY)
 
 
-@events.on(events.LINT_RESULT)
+@events.on('lint_result_changed')
 def on_lint_result(filename, **kwargs):
     if State['active_filename'] == filename:
         draw(**State)

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -17,7 +17,7 @@ from .lint import elect
 from .lint import events
 from .lint import linter as linter_module
 from .lint import queue
-from .lint import persist, util, style
+from .lint import persist, util
 from .lint import reloader
 from .lint import settings
 
@@ -46,8 +46,11 @@ def plugin_loaded():
     log_handler.install()
 
     try:
-        from package_control import events
-        if events.install('SublimeLinter') or events.post_upgrade('SublimeLinter'):
+        import package_control
+        if (
+            package_control.events.install('SublimeLinter') or
+            package_control.events.post_upgrade('SublimeLinter')
+        ):
             # In case the user has an old version installed without the below
             # `unload`, we 'unload' here.
             persist.kill_switch = True
@@ -64,10 +67,10 @@ def plugin_loaded():
 
     persist.api_ready = True
     persist.kill_switch = False
+    events.broadcast('plugin_loaded')
     persist.settings.load()
     logger.info("debug mode: on")
     logger.info("version: " + util.get_sl_version())
-    style.read_gutter_theme()
 
     # Lint the visible views from the active window on startup
     bc = BackendController()
@@ -79,9 +82,11 @@ def plugin_unloaded():
     log_handler.uninstall()
 
     try:
-        from package_control import events
-
-        if events.pre_upgrade('SublimeLinter') or events.remove('SublimeLinter'):
+        import package_control
+        if (
+            package_control.events.pre_upgrade('SublimeLinter') or
+            package_control.events.remove('SublimeLinter')
+        ):
             logger.info("Enable kill_switch.")
             persist.kill_switch = True
             persist.linter_classes.clear()

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -95,6 +95,28 @@ def plugin_unloaded():
 
     queue.unload()
     persist.settings.unobserve()
+    events.off(on_settings_changed)
+
+
+@events.on('settings_changed')
+def on_settings_changed(settings, **kwargs):
+    if (
+        settings.has_changed('linters') or
+        settings.has_changed('no_column_highlights_line')
+    ):
+        sublime.run_command(
+            'sublime_linter_config_changed', {'hint': 'relint'}
+        )
+
+    elif (
+        settings.has_changed('gutter_theme') or
+        settings.has_changed('highlights.demote_while_editing') or
+        settings.has_changed('show_marks_in_minimap') or
+        settings.has_changed('styles')
+    ):
+        sublime.run_command(
+            'sublime_linter_config_changed', {'hint': 'redraw'}
+        )
 
 
 class SublimeLinterReloadCommand(sublime_plugin.WindowCommand):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -164,6 +164,9 @@ global_lock = threading.RLock()
 guard_check_linters_for_view = defaultdict(threading.Lock)  # type: DefaultDict[Bid, threading.Lock]
 buffer_filenames = {}  # type: Dict[Bid, FileName]
 buffer_syntaxes = {}  # type: Dict[Bid, str]
+lint_results_cache = defaultdict(
+    lambda: defaultdict(tuple)
+)  # type: DefaultDict[FileName, DefaultDict[LinterName, Tuple[object, ...]]]
 
 
 class BackendController(sublime_plugin.EventListener):
@@ -241,6 +244,7 @@ class BackendController(sublime_plugin.EventListener):
         for fn in to_discard:
             persist.affected_filenames_per_filename.pop(fn, None)
             persist.file_errors.pop(fn, None)
+            lint_results_cache.pop(fn, None)
 
         persist.assigned_linters.pop(bid, None)
         guard_check_linters_for_view.pop(bid, None)
@@ -425,13 +429,21 @@ def group_by_filename_and_update(
 def update_file_errors(filename, linter, errors, reason=None):
     # type: (FileName, LinterName, List[LintError], Optional[Reason]) -> None
     """Persist lint error changes and broadcast."""
-    update_errors_store(filename, linter, errors)
-    events.broadcast(events.LINT_RESULT, {
+    token = tuple(e['uid'] for e in errors) + (persist.settings.change_count(),)
+    modified = lint_results_cache[filename][linter] != token
+    lint_results_cache[filename][linter] = token
+
+    payload = {
         'filename': filename,
         'linter_name': linter,
         'errors': errors,
         'reason': reason
-    })
+    }
+    if modified:
+        update_errors_store(filename, linter, errors)
+        events.broadcast('lint_result_changed', payload)
+
+    events.broadcast(events.LINT_RESULT, payload)
 
 
 def update_errors_store(filename, linter_name, errors):

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -172,7 +172,8 @@ class TestRegexBasedParsing(_BaseTestCase):
                     'code': 'ERROR',
                     'msg': 'The message',
                     'linter': 'fakelinter',
-                    'filename': '<untitled {}>'.format(self.view.buffer_id())
+                    'filename': '<untitled {}>'.format(self.view.buffer_id()),
+                    'offending_text': 'This'
                 }
             ],
             result,
@@ -205,7 +206,7 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         result = execute_lint_task(linter, INPUT)
         drop_position_keys(result)
-        drop_keys(['code', 'msg', 'linter', 'filename'], result)
+        drop_keys(['code', 'msg', 'linter', 'filename', 'offending_text'], result)
 
         self.assertResult([{'error_type': ERROR_TYPE}], result)
 
@@ -236,7 +237,7 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         result = execute_lint_task(linter, INPUT)
         drop_position_keys(result)
-        drop_keys(['error_type', 'msg', 'linter', 'filename'], result)
+        drop_keys(['error_type', 'msg', 'linter', 'filename', 'offending_text'], result)
 
         self.assertResult([{'code': CODE}], result)
 
@@ -1155,5 +1156,7 @@ def drop_keys(keys, array, strict=False):
             item.pop(k) if strict else item.pop(k, None)
 
 
-drop_info_keys = partial(drop_keys, ['error_type', 'code', 'msg', 'linter', 'filename'])
+drop_info_keys = partial(
+    drop_keys, ['error_type', 'code', 'msg', 'linter', 'filename', 'offending_text']
+)
 drop_position_keys = partial(drop_keys, ['line', 'start', 'end', 'region'])


### PR DESCRIPTION
Various performance commits. 

```
A 
0 errors across 0 files from annotations. 150 errors in the store
group_by_filename_and_update took 35ms [D]  --> 4ms

0 errors across 0 files from flake8. 150 errors in the store
group_by_filename_and_update took 75ms [D]  --> 23ms

8 errors across 5 files from mypy. 150 errors in the store
group_by_filename_and_update took 113ms [D] --> 16ms
```
```
B
0 errors across 0 files from annotations. 150 errors in the store
group_by_filename_and_update took 166ms [D] --> 4ms

0 errors across 0 files from flake8. 150 errors in the store
group_by_filename_and_update took 127ms [D] --> 25ms

58 errors across 5 files from mypy. 150 errors in the store
group_by_filename_and_update took 292ms [D] --> 23ms
```
```
C
0 errors across 0 files from annotations. 150 errors in the store
group_by_filename_and_update took 83ms [D]  --> 8ms

0 errors across 0 files from flake8. 150 errors in the store
group_by_filename_and_update took 46ms [D]  --> 7ms

70 errors across 29 files from mypy. 150 errors in the store
group_by_filename_and_update took 975ms [D] --> 42ms
```

Must be read commit by commit. 

Solves #1623 for free in a pragmatic way: if the results change it will open the panel again. Otherwise the panel stays closed.

`settings` are now generally cached in memory. Greatly improves `settings.has_changed` which was very cheap and idiosyncratic and now just works as anyone would expect. 

Introduces new event `lint_result_changed` which otherwise is the same as our known 'lint_result' with a cache in front. Notable: Since we usually rely on our settings as a global, t.i. we're never pure anywhere probably, we use a settings 'change-count' as additional cache salt.



Fixes #1623
Fixes #1662 
Fixes #1671 