### PR TITLE
Clear `deprecation_warning` cache after reloading plugin

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -609,6 +609,7 @@ def register_linter(name, cls):
     # start, this is generally not necessary, because SL will trigger various
     # synthetic `on_activated_async` events on load.
     if persist.api_ready:
+        deprecation_warning.cache_clear()
         sublime.run_command('sublime_linter_config_changed')
         logger.info('{} linter reloaded'.format(name))
 


### PR DESCRIPTION
This is for convenience. If a user fixes a linter plugin, she wants
to see all deprecation warnings again and again, but hopefully none
of course.