### PR TITLE
Fix NodeLinter test when run locally

### DIFF
--- a/tests/test_node_linter.py
+++ b/tests/test_node_linter.py
@@ -429,18 +429,18 @@ class TestNodeLinters(DeferrableTestCase):
         linter.settings['disable_if_not_dependency'] = True
 
         when(linter).notify_unassign().thenReturn(None)
-        when(node_linter.logger).info(
-            "Skipping 'fakelinter' since it is not installed locally.\nYou "
-            "can change this behavior by setting 'disable_if_not_dependency' "
-            "to 'false'."
-        ).thenReturn(None)
+        when(node_linter.logger).info(...).thenReturn(None)
 
         try:
             linter.get_cmd()
         except linter_module.PermanentError:
             pass
 
-        verify(node_linter.logger).info(...)
+        verify(node_linter.logger).info(
+            "Skipping 'fakelinter' since it is not installed locally.\nYou "
+            "can change this behavior by setting 'disable_if_not_dependency' "
+            "to 'false'."
+        )
         verify(linter).notify_unassign()
 
     def test_disable_if_not_dependency_2(self):


### PR DESCRIPTION
For these tests, we don't run in a new window but just reuse the
current one. The current one of course usually has a working dir
attached, and if so we will issue another `logger.info` about where
we start searching for an executable.

On the other side, on the server/CI we work with an empty window.

Since it's faster to not open new windows all the time, we fix the
test by mofifying our assertion.

Introduced by 92437f6dd6af9e9313d752f06342f16677b57f79