### PR TITLE
Fix: 'Lint' command is only available for normal buffers

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -289,7 +289,13 @@ class sublime_linter_lint(sublime_plugin.TextCommand):
     """A command that lints the current view if it has a linter."""
 
     def is_enabled(self):
-        return any(elect.runnable_linters_for_view(self.view, 'on_user_request'))
+        return (
+            util.is_lintable(self.view)
+            and any(elect.runnable_linters_for_view(self.view, 'on_user_request'))
+        )
+
+    def is_visible(self):
+        return util.is_lintable(self.view)
 
     def run(self, edit):
         hit(self.view, 'on_user_request')


### PR DESCRIPTION
Fixes #1680

Overall we omit the menu entry only if the underlying buffer is
e.g. a scratch view or panel. On views for which no linter is
installed (aka 'assignable') we just gray out the menu entry.