### PR TITLE
Log when no linters match a view

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -334,6 +334,9 @@ def lint(view, view_has_changed, lock, reason):
     This function MUST run on a thread because it blocks!
     """
     linters = list(elect.assignable_linters_for_view(view, reason))
+    if not linters:
+        logger.info("No installed linter matches the view.")
+
     with lock:
         _assign_linters_to_view(view, {linter['name'] for linter in linters})
 

--- a/tests/test_sublime_linter_entrypoint.py
+++ b/tests/test_sublime_linter_entrypoint.py
@@ -1,0 +1,65 @@
+from threading import Lock
+
+from unittesting import DeferrableTestCase
+from SublimeLinter.tests.mockito import unstub, verify, when
+
+import sublime
+from SublimeLinter import sublime_linter
+from SublimeLinter.lint import Linter, persist
+
+
+class TestResultRegexes(DeferrableTestCase):
+    @classmethod
+    def setUpClass(cls):
+
+        # make sure we have a window to work with
+        s = sublime.load_settings("Preferences.sublime-settings")
+        s.set("close_windows_when_empty", False)
+
+    @classmethod
+    def tearDownClass(cls):
+        unstub()
+
+    def setUp(self):
+        sublime.run_command("new_window")
+        self.window = sublime.active_window()
+
+    def tearDown(self):
+        self.window.run_command('close_window')
+        persist.linter_classes.clear()
+        unstub()
+
+    def create_view(self, window):
+        view = window.new_file()
+        self.addCleanup(self.close_view, view)
+        return view
+
+    def close_view(self, view):
+        view.set_scratch(True)
+        view.close()
+
+    def test_happy_path(self):
+        class FakeLinter(Linter):
+            defaults = {'selector': ''}
+            cmd = 'fake_linter_1'
+
+        when(sublime_linter.backend).lint_view(...).thenReturn(None)
+
+        view = self.create_view(self.window)
+        sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request')
+
+        verify(sublime_linter.backend).lint_view(...)
+
+    def test_log_info_if_no_assignable_linter(self):
+        class FakeLinter(Linter):
+            defaults = {'selector': 'foobar'}
+            cmd = 'fake_linter_1'
+
+        when(sublime_linter.logger).info(...).thenReturn(None)
+
+        view = self.create_view(self.window)
+        sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request')
+
+        verify(sublime_linter.logger).info(
+            "No installed linter matches the view."
+        )

--- a/tests/test_sublime_linter_entrypoint.py
+++ b/tests/test_sublime_linter_entrypoint.py
@@ -63,3 +63,13 @@ class TestResultRegexes(DeferrableTestCase):
         verify(sublime_linter.logger).info(
             "No installed linter matches the view."
         )
+
+    def test_log_if_no_linter_installed(self):
+        when(sublime_linter.logger).info(...).thenReturn(None)
+
+        view = self.create_view(self.window)
+        sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request')
+
+        verify(sublime_linter.logger).info(
+            "No installed linter matches the view."
+        )


### PR DESCRIPTION
Fixes #1668

I decided against a warning when no linters are installed. This was actually never a problem in the issues. And if we *warn*, we also must throttle otherwise we would spam the console etc. 

So, I just `log.info` which only prints if in debug mode. It prints of course when no linters are installed at all, or when the user fiddles with the syntaxes/selectors and oit doesn't match.  The last case is the typical problem when you try to find your own selector.