### PR TITLE
Maybe resolve executable set by user

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -881,7 +881,10 @@ class Linter(metaclass=LinterMeta):
                 if not resolved_executable:
                     logger.error(
                         "You set 'executable' to {!r}.  "
-                        "However, 'which {}' returned nothing."
+                        "However, 'which {}' returned nothing.\n"
+                        "Try setting an absolute path to the binary. "
+                        "Also refer our troubleshooting guide: "
+                        "http://www.sublimelinter.com/en/stable/troubleshooting.html"
                         .format(executable, wanted_executable)
                     )
                     self.notify_failure()

--- a/tests/test_command_generation.py
+++ b/tests/test_command_generation.py
@@ -10,6 +10,7 @@ from SublimeLinter.lint import (
 from unittesting import DeferrableTestCase
 from SublimeLinter.tests.parameterized import parameterized as p
 from SublimeLinter.tests.mockito import (
+    contains,
     expect,
     mock,
     unstub,
@@ -210,8 +211,11 @@ class TestExecutableSetting(_BaseTestCase):
             pass
 
         verify(linter_module.logger).error(
-            "You set 'executable' to 'my_linter'.  "
-            "However, 'which my_linter' returned nothing."
+            contains(
+                "You set 'executable' to 'my_linter'.  "
+                "However, 'which my_linter' returned nothing.\n"
+                "Try setting an absolute path to the binary."
+            )
         )
         verify(linter).notify_failure()
 
@@ -258,8 +262,11 @@ class TestExecutableSetting(_BaseTestCase):
             pass
 
         verify(linter_module.logger).error(
-            "You set 'executable' to ['my_interpreter', 'my_linter'].  "
-            "However, 'which my_interpreter' returned nothing."
+            contains(
+                "You set 'executable' to ['my_interpreter', 'my_linter'].  "
+                "However, 'which my_interpreter' returned nothing.\n"
+                "Try setting an absolute path to the binary."
+            )
         )
         verify(linter).notify_failure()
 


### PR DESCRIPTION
Fixes #1635

We actually only ever expected absolute paths in the 'executable'
setting. Of course, users try short executable names here, and
wonder if it fails.

'executable' can be a plain string or a list of strings. In the latter
case, the real executable is the first item in the list.

We now either check if the given 'real' executable is there and
actually executable if it is an absolute path, or try to resolve
it with the usual `which` call.

As always, the error handling and messages make everything relatively
long.