### PR TITLE
Ensure file properties in the context come from given view

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -351,6 +351,18 @@ def get_raw_linter_settings(linter, view):
     )
 
 
+def _extract_window_variables(window):
+    # type: (sublime.Window) -> Dict[str, str]
+    # We explicitly want to compute all variables around the current file
+    # on our own.
+    variables = window.extract_variables()
+    for key in (
+        'file', 'file_path', 'file_name', 'file_base_name', 'file_extension'
+    ):
+        variables.pop(key, None)
+    return variables
+
+
 def get_view_context(view, additional_context=None):
     # type: (sublime.View, Optional[Mapping]) -> MutableMapping[str, str]
     # Note that we ship a enhanced version for 'folder' if you have multiple
@@ -358,7 +370,8 @@ def get_view_context(view, additional_context=None):
 
     window = view.window()
     context = ChainMap(
-        {}, window.extract_variables() if window else {}, os.environ)
+        {}, _extract_window_variables(window) if window else {}, os.environ
+    )  # type: MutableMapping[str, str]
 
     project_folder = guess_project_root_of_view(view)
     if project_folder:


### PR DESCRIPTION
Fixes #1690

We use `window.extract_variables()` and took it as-is for the context.
We knew we had to overwrite all file properties to get some consistency,
but we never *erased* possible file properties if the given view is
actually unsaved.

That's a bug which can be exposed *iff* the linter uses e.g. `$file`
as part of its command. The impact is relatively small because at this
time basically no linters report filenames still, and then the backend
just fills in the correct canonical filename by itself.

Typical info in the console looks like

```
> type <buffer 8869> | eslint.CMD --filename "...\linter.py"
```

indicating that buffer `8869` is linted with the name `linter.py` which
is inconsistent.

The fix is to just remove all file related properties from
`extract_variables()` unconditionally.

Note:

Avoiding the race between getting the view (in the event handler) and
actually freezing its context is impractical: We don't want to this
on the main thread because it would a waste. We don't want to abort
if we detect this inconsistency, we really just want the fixed context
in that case which leads to the same code here.