### PR TITLE
Revert broadcasting `lint_result_changed` cache layer

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -74,7 +74,7 @@ def plugin_unloaded():
             undraw(view)
 
 
-@events.on('lint_result_changed')
+@events.on(events.LINT_RESULT)
 def on_lint_result(filename, linter_name, **kwargs):
     views = list(all_views_into_file(filename))
     if not views:

--- a/panel_view.py
+++ b/panel_view.py
@@ -81,7 +81,7 @@ def unzip(zipped):
     return tuple(zip(*zipped))  # type: ignore
 
 
-@events.on('lint_result_changed')
+@events.on(events.LINT_RESULT)
 def on_lint_result(filename, linter_name, reason=None, **kwargs):
     # type: (FileName, LinterName, Reason, Any) -> None
     LINT_RESULT_CACHE[linter_name].append((filename, reason))

--- a/status_bar_view.py
+++ b/status_bar_view.py
@@ -44,7 +44,7 @@ def plugin_unloaded():
             view.erase_status(STATUS_MSG_KEY)
 
 
-@events.on('lint_result_changed')
+@events.on(events.LINT_RESULT)
 def on_lint_result(filename, **kwargs):
     if State['active_filename'] == filename:
         draw(**State)


### PR DESCRIPTION
Generally, we can only apply such broad cache layers if the render
functions are "pure", i.e. only draw the highlights if we actually
have different errors from before, otherwise they're already in place.

This breaks for the highlights often because of #1617 or rather the
underlying https://github.com/SublimeTextIssues/Core/issues/2877

I.e. whenever Sublime invalidates all drawn regions (usually because a
file gets reloaded), we can retrigger a lint but still get the same
results as before. In that case we *need* to draw because all regions
are actual dangles but the cache would prevent this. Basically our
error store and the view state are out-of-sync. This is solvable
if we can solve #1617.

For the panel, the cache is just not applicable at all. The intention
was to solve #1623 "for free" in a pragmatic way. But that's just not
the case, and actually we're breaking the `show_panel_on_save` feature.

The usage in `status_bar_view` was never important performance wise
so we can, for now, just revert the whole thing.

Partially reverts 816904c87f8eae497872fc422b07dc43781ff7af
Reopens #1623 