### PR TITLE
Ensure `active_view` is from given window

### DIFF
--- a/panel_view.py
+++ b/panel_view.py
@@ -474,8 +474,14 @@ def fill_panel(window):
     if vx == 0:
         return
 
+    active_view = State['active_view']
+    if active_view and active_view.window() == window:
+        active_filename = State['active_filename']
+    else:
+        active_view = None
+        active_filename = None
+
     errors_by_file = get_window_errors(window, persist.file_errors)
-    active_filename = State['active_filename']
     if active_filename and active_filename not in errors_by_file:
         errors_by_file[active_filename] = []
 
@@ -561,8 +567,7 @@ def fill_panel(window):
         'content': content
     }  # type: DrawInfo
 
-    active_view = State['active_view']
-    if active_view and active_view.window() == window:
+    if active_view:
         update_panel_selection(draw_info=draw_info, **State)
     else:
         draw(draw_info)

--- a/tests/test_panel_view.py
+++ b/tests/test_panel_view.py
@@ -45,7 +45,7 @@ class TestResultRegexes(DeferrableTestCase):
         window = self.window = sublime.active_window()
         panel_view.ensure_panel(window)
         window.run_command('sublime_linter_panel_toggle')  # make it visible
-        self.create_view(window)
+        self.view = self.create_view(window)
 
     def tearDown(self):
         self.window.run_command('close_window')
@@ -105,7 +105,11 @@ class TestResultRegexes(DeferrableTestCase):
     def test_active_file_comes_last(self, ERRORS, RESULT, ACTIVE_FILE):
         window = self.window
         when(panel_view).get_window_errors(...).thenReturn(ERRORS)
-        panel_view.State['active_filename'] = ACTIVE_FILE
+        panel_view.State.update({
+            'active_view': self.view,
+            'active_filename': ACTIVE_FILE,
+            'cursor': 0
+        })
 
         panel_view.fill_panel(window)
         panel = panel_view.get_panel(window)
@@ -127,7 +131,11 @@ class TestResultRegexes(DeferrableTestCase):
     def test_clean_active_file_displays_std_message(self, ERRORS, RESULT, ACTIVE_FILE):
         window = self.window
         when(panel_view).get_window_errors(...).thenReturn(ERRORS)
-        panel_view.State['active_filename'] = ACTIVE_FILE
+        panel_view.State.update({
+            'active_view': self.view,
+            'active_filename': ACTIVE_FILE,
+            'cursor': 0
+        })
 
         panel_view.fill_panel(window)
         panel = panel_view.get_panel(window)


### PR DESCRIPTION
Fixes #1693

We currently only store the `active_view` and `active_filename`
globally; but we can have a panel per window.

This change ensures the `active_filename` comes from the window
we want to draw otherwise we possible show "No lint results." for
a file actually belonging to a different window.