### PR TITLE
Log output of a failed command

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -219,7 +219,9 @@ def check_output(cmd, cwd=None):
         )
     except Exception as err:
         logger.warning(
-            "Executing `{}` failed\n  {}".format(' '.join(cmd), str(err))
+            "Executing `{}` failed\n  {}\nFailed command output: {}".format(
+                ' '.join(cmd), str(err), str(err.output)
+            )
         )
         raise
     else:


### PR DESCRIPTION
in addittion to the exception output of subprocess.check_output,

I found it very useful to see the full output in debug, as was for me
when checking an error that occurred due to wrong version of python.
Pipenv (or rather it's dependency "click") when run on macos 10.15 is
missing some required "locale" env variables in sublime, which was
fixed in versions 3.7.5 / 3.8. Ref: https://bugs.python.org/issue18378