### PR TITLE
Improve error logging for `util.check_output`

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -218,8 +218,16 @@ def check_output(cmd, cwd=None):
             startupinfo=create_startupinfo()
         )
     except Exception as err:
+        import textwrap
+        output_ = getattr(err, 'output', '')
+        if output_:
+            output_ = process_popen_output(output_)
+            output_ = textwrap.indent(output_, '  ')
+            output_ = "\n  ...\n{}".format(output_)
         logger.warning(
-            "Executing `{}` failed\n  {}".format(' '.join(cmd), str(err))
+            "Executing `{}` failed\n  {}{}".format(
+                ' '.join(cmd), str(err), output_
+            )
         )
         raise
     else:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,61 @@
+import subprocess
+from textwrap import dedent
+
+from unittesting import DeferrableTestCase
+
+from SublimeLinter.tests.mockito import (
+    unstub,
+    verify,
+    when,
+)
+
+from SublimeLinter.lint import util
+
+
+class TestCheckOutput(DeferrableTestCase):
+    def teardown(self):
+        unstub()
+
+    def test_emits_nicely_formatted_warning(self):
+        when(util.logger).warning(...)
+
+        cmd = ["python", "--foo"]
+        returncode = 2
+        output = bytes(dedent("""\
+        unknown option --foo
+        unknown option --foo
+        unknown option --foo
+        usage: python [option] ... [-c cmd | -m mod | file | -] [arg] ...
+        Try `python -h' for more information.
+        """.rstrip()), "utf8")
+        when(subprocess).check_output(...).thenRaise(
+            subprocess.CalledProcessError(returncode, cmd, output)
+        )
+        try:
+            util.check_output(cmd)
+        except Exception:
+            ...
+
+        verify(util.logger).warning("""\
+Executing `python --foo` failed
+  Command '['python', '--foo']' returned non-zero exit status 2
+  ...
+  unknown option --foo
+  unknown option --foo
+  unknown option --foo
+  usage: python [option] ... [-c cmd | -m mod | file | -] [arg] ...
+  Try `python -h' for more information.""")
+
+    def test_accepts_any_exception(self):
+        when(util.logger).warning(...)
+        when(subprocess).check_output(...).thenRaise(Exception("some message"))
+
+        cmd = ["python", "--foo"]
+        try:
+            util.check_output(cmd)
+        except Exception:
+            ...
+
+        verify(util.logger).warning("""\
+Executing `python --foo` failed
+  some message""")


### PR DESCRIPTION
Although we catch any `Exception`, it is likely that we have to deal with a `Popen` exception here. In that case the `error` has probably the `output`of the command attached, and we just nicely format it for the user.

Fixes #1695