### PR TITLE
Export our error classes

### DIFF
--- a/lint/__init__.py
+++ b/lint/__init__.py
@@ -12,7 +12,7 @@ from . import (
 from .const import WARNING, ERROR
 from .util import STREAM_STDOUT, STREAM_STDERR, STREAM_BOTH
 
-from .linter import Linter, LintMatch
+from .linter import Linter, LintMatch, TransientError, PermanentError
 from .base_linter.python_linter import PythonLinter
 from .base_linter.ruby_linter import RubyLinter
 from .base_linter.node_linter import NodeLinter

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -39,6 +39,8 @@ def paths_upwards_until_home(path):
     return chain(takewhile(lambda p: p != HOME, paths_upwards(path)), [HOME])
 
 
+# `read_json_file` is maybe used by plugins. Check `eslint` and
+# `xo` for example.
 def read_json_file(path):
     # type: (str) -> Dict[str, Any]
     return _read_json_file(path, os.path.getmtime(path))


### PR DESCRIPTION
Exporting `PermanentError` and `TransientError` is a no-brainer because
both are control flow exceptions for the linter plugins and used in the
wild.

~~About `read_json_file`: Although we have the policy to not export
anything beyond core since we're not a library, and reading a json file
is clearly a utility function, that particular function has a built-in
cache. Thus plugin authors *should* really use our function here so that
we share that cache.~~

Fixes #1713