### PR TITLE
Honor custom error types when counting for the status bar

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -152,10 +152,9 @@
     // - never: disable this feature.
     "show_panel_on_save": "never",
 
-    // Display counters in the status bar.
-    // The {}'s will be replaced by warnings and errors respectively.
-    // Example alternative: (w:{}, e:{})
-    "statusbar.counters_template": "({}|{})",
+    // DEPRECATED: Not in use! Remove the setting from your User settings
+    // to avoid future warnings.
+    "statusbar.counters_template": "",
 
     // Show the messages for problems at your cursor position.
     // - {message} will be replaced by the actual messages.

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -1,23 +1,25 @@
 from collections import defaultdict
+import time
 
 import sublime
 import sublime_plugin
 
 from .lint import events, persist, util
-from .lint.const import WARNING, ERROR
 
 
 MYPY = False
 if MYPY:
-    from typing import DefaultDict, Dict, Set
+    from typing import DefaultDict, Dict, Iterator, List, Set
     from mypy_extensions import TypedDict
 
-    Filename = str
+    FileName = str
     LinterName = str
     State_ = TypedDict('State_', {
-        'assigned_linters_per_file': DefaultDict[Filename, Set[LinterName]],
-        'failed_linters_per_file': DefaultDict[Filename, Set[LinterName]],
-        'problems_per_file': DefaultDict[Filename, Dict[LinterName, str]]
+        'assigned_linters_per_file': DefaultDict[FileName, Set[LinterName]],
+        'failed_linters_per_file': DefaultDict[FileName, Set[LinterName]],
+        'problems_per_file': DefaultDict[FileName, Dict[LinterName, str]],
+        'sweeps': DefaultDict[sublime.BufferId, int],
+        'expanded_ok': DefaultDict[sublime.BufferId, float],
     })
 
 
@@ -26,33 +28,57 @@ STATUS_ACTIVE_KEY = 'sublime_linter_status_active'
 State = {
     'assigned_linters_per_file': defaultdict(set),
     'failed_linters_per_file': defaultdict(set),
-    'problems_per_file': defaultdict(dict)
+    'problems_per_file': defaultdict(dict),
+    'sweeps': defaultdict(int),
+    'expanded_ok': defaultdict(float),
 }  # type: State_
 
 
 def plugin_unloaded():
     events.off(redraw_file)
+    events.off(on_finished_linting)
 
     for window in sublime.windows():
         for view in window.views():
             view.erase_status(STATUS_ACTIVE_KEY)
 
 
+@events.on(events.LINT_END)
+def on_finished_linting(buffer_id, **kwargs):
+    # Run on the main thread to avoid locks; all other
+    # functions mutating "sweeps" or "expanded_ok" already
+    # run on the ui thread.
+    def task():
+        State['sweeps'][buffer_id] += 1
+        if State['sweeps'][buffer_id] == 1:
+            show_expanded_ok(buffer_id)
+    sublime.set_timeout(task)
+
+
 @events.on(events.LINT_RESULT)
 def redraw_file(filename, linter_name, errors, **kwargs):
+    # type: (FileName, LinterName, List[persist.LintError], object) -> None
     problems = State['problems_per_file'][filename]
     if linter_name in State['failed_linters_per_file'][filename]:
-        problems[linter_name] = '(erred)'
+        problems[linter_name] = '?'
     elif linter_name in State['assigned_linters_per_file'][filename] or errors:
         if linter_name not in State['assigned_linters_per_file'][filename]:
             State['assigned_linters_per_file'][filename].add(linter_name)
 
-        we_count = count_problems(errors)
-        if we_count == (0, 0):
-            problems[linter_name] = '(ok)'
+        counts = count_problems(errors)
+        if sum(counts.values()) == 0:
+            problems[linter_name] = ''
         else:
-            tpl = persist.settings.get('statusbar.counters_template')
-            problems[linter_name] = tpl.format(*we_count)
+            sorted_keys = (
+                tuple(sorted(counts.keys() - {'w', 'e'}))
+                + ('w', 'e')
+            )
+            parts = ' '.join(
+                "{}:{}".format(error_type, counts[error_type])
+                for error_type in sorted_keys
+                if error_type in counts and counts[error_type] > 0
+            )
+            problems[linter_name] = '({})'.format(parts)
     else:
         problems.pop(linter_name, None)
 
@@ -65,6 +91,7 @@ def redraw_file_(filename, problems):
 
 
 def views_into_file(filename):
+    # type: (FileName) -> Iterator[sublime.View]
     return (
         view
         for window in sublime.windows()
@@ -73,21 +100,53 @@ def views_into_file(filename):
     )
 
 
+def views_with_buffer_id(bid):
+    # type: (sublime.BufferId) -> Iterator[sublime.View]
+    return (
+        view
+        for window in sublime.windows()
+        for view in window.views()
+        if view.buffer_id() == bid
+    )
+
+
 def count_problems(errors):
-    w, e = 0, 0
+    # type: (List[persist.LintError]) -> Dict[str, int]
+    counters = defaultdict(int)  # type: DefaultDict[str, int]
     for error in errors:
         error_type = error['error_type']
-        if error_type == WARNING:
-            w += 1
-        elif error_type == ERROR:
-            e += 1
-    return (w, e)
+        counters[error_type[0]] += 1
+
+    return counters
+
+
+def show_expanded_ok(bid):
+    # type: (sublime.BufferId) -> None
+    token = time.time()
+    State['expanded_ok'][bid] = token
+    sublime.set_timeout(lambda: unset_expanded_ok(bid, token), 3000)
+
+
+def unset_expanded_ok(bid, token):
+    # type: (sublime.BufferId, float) -> None
+    if State['expanded_ok'][bid] == token:
+        State['expanded_ok'].pop(bid, None)
+        view = next(views_with_buffer_id(bid), None)
+        if view:
+            filename = util.get_filename(view)
+            redraw_file_(filename, State['problems_per_file'][filename])
 
 
 class sublime_linter_assigned(sublime_plugin.WindowCommand):
-    def run(self, filename, linter_names):
-        State['assigned_linters_per_file'][filename] = set(linter_names)
+    def run(self, filename, buffer_id, linter_names):
+        # type: (FileName, sublime.BufferId, List[LinterName]) -> None
         State['failed_linters_per_file'][filename] = set()
+        if State['assigned_linters_per_file'][filename] != set(linter_names):
+            State['assigned_linters_per_file'][filename] = set(linter_names)
+            State['sweeps'][buffer_id] = 0
+            show_expanded_ok(buffer_id)
+            # Redraw to get immediate visual response
+            redraw_file_(filename, State['problems_per_file'][filename])
 
 
 class sublime_linter_unassigned(sublime_plugin.WindowCommand):
@@ -102,18 +161,35 @@ class sublime_linter_failed(sublime_plugin.WindowCommand):
 
 
 class UpdateState(sublime_plugin.EventListener):
-    def on_load_async(self, view):
-        filename = util.get_filename(view)
-        draw(view, State['problems_per_file'][filename])
-
-    on_clone_async = on_load_async
+    def on_close(self, view):
+        # type: (sublime.View) -> None
+        State['sweeps'].pop(view.buffer_id(), None)
 
 
 def draw(view, problems):
+    def by_severity(item):
+        linter_name, summary = item
+        if summary == '':
+            return (0, linter_name)
+        elif summary[0] == '?':
+            return (2, linter_name)
+        return (1, linter_name)
+
     if persist.settings.get('statusbar.show_active_linters'):
-        message = ', '.join(
+        bid = view.buffer_id()
+        if (
+            problems.keys()
+            and not State['expanded_ok'][bid]
+            and State['sweeps'][bid] >= 1
+            and all(part == '' for part in problems.values())
+        ):
+            message = 'ok'
+            view.set_status(STATUS_ACTIVE_KEY, message)
+            return
+
+        message = ' '.join(
             '{}{}'.format(linter_name, summary)
-            for linter_name, summary in sorted(problems.items())
+            for linter_name, summary in sorted(problems.items(), key=by_severity)
         )
         view.set_status(STATUS_ACTIVE_KEY, message)
     else:

--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -64,7 +64,7 @@ class RubyLinter(linter.Linter):
             ruby = util.which('jruby')
 
         if not rbenv and not ruby:
-            msg = '{} deactivated, cannot locate ruby, rbenv or rvm-auto-ruby'.format(self.name, cmd[0])
+            msg = "{} deactivated, cannot locate ruby, rbenv or rvm-auto-ruby".format(self.name)
             logger.warning(msg)
             return True, None
 

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -42,6 +42,7 @@ settings = Settings()
 file_errors = defaultdict(list)  # type: DefaultDict[FileName, List[LintError]]
 linter_classes = {}  # type: Dict[str, Type[Linter]]
 assigned_linters = {}  # type: Dict[Bid, Set[LinterName]]
+actual_linters = {}  # type: Dict[FileName, Set[LinterName]]
 
 # A mapping between actually linted files and other filenames that they
 # reported errors for

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -14,6 +14,10 @@ contexts:
         - ensure-file-meta-scope
         - expect-filename
 
+    - match: '  No lint results.(?: Running (?:(.+?)(?:, )?)\.)?'
+      captures:
+        1: string
+
     - match: '^\s+(?=[0-9: ]+error)'
       push:
         - ensure-error-meta-scope

--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -14,9 +14,9 @@ contexts:
         - ensure-file-meta-scope
         - expect-filename
 
-    - match: '  No lint results.(?: Running (?:(.+?)(?:, )?)\.)?'
+    - match: '  No lint results.*$'
       captures:
-        1: string
+        0: comment
 
     - match: '^\s+(?=[0-9: ]+error)'
       push:

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -509,6 +509,7 @@ def _assign_linters_to_view(view, next_linters):
     persist.assigned_linters[bid] = next_linters
     window.run_command('sublime_linter_assigned', {
         'filename': filename,
+        'buffer_id': bid,
         'linter_names': list(next_linters)
     })
 

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -358,7 +358,7 @@ def lint(view, view_has_changed, lock, reason):
     if persist.settings.get('kill_old_processes'):
         kill_active_popen_calls(bid)
 
-    with broadcast_lint_runtime(bid), remember_runtime(
+    with broadcast_lint_runtime(filename), remember_runtime(
         "Linting '{}' took {{:.2f}}s".format(util.canonical_filename(view))
     ):
         sink = partial(
@@ -505,7 +505,6 @@ def _assign_linters_to_view(view, next_linters):
     persist.assigned_linters[bid] = next_linters
     window.run_command('sublime_linter_assigned', {
         'filename': filename,
-        'buffer_id': bid,
         'linter_names': list(next_linters)
     })
 
@@ -577,10 +576,10 @@ def remember_runtime(log_msg):
 
 
 @contextmanager
-def broadcast_lint_runtime(bid):
-    # type: (sublime.BufferId) -> Iterator[None]
-    events.broadcast(events.LINT_START, {'buffer_id': bid})
+def broadcast_lint_runtime(filename):
+    # type: (FileName) -> Iterator[None]
+    events.broadcast(events.LINT_START, {'filename': filename})
     try:
         yield
     finally:
-        events.broadcast(events.LINT_END, {'buffer_id': bid})
+        events.broadcast(events.LINT_END, {'filename': filename})


### PR DESCRIPTION
Fixes #1726

~~We now count [w]arnings, [e]rrors and all [o]ther types. Also make "non-errors"
available as the sum of warnings and others. Trivially add "total" for the total
sum.~~

~~The counter template switches to named variables (e.g. `{total}`) from the
limited positional filling. T.i. we switch from a tuple as data format to a
dict.~~

~~The default format uses `non-errors` in-place of `warnings` to avoid the case
that both shown counters are zero but the panel still shows "problems", for
example "notes" or "suggestions".~~

Completely revamped above approach during design phase. Consider reading the full thread.

Redesign status bar widget. Deprecate "statusbar.counters_template" setting. The setting is unused now. 