### PR TITLE
Continue spinning if the user activates a special view

### DIFF
--- a/busy_indicator_view.py
+++ b/busy_indicator_view.py
@@ -6,6 +6,19 @@ import time
 from .lint import events, util
 
 
+MYPY = False
+if MYPY:
+    from typing import Dict, Optional
+    from mypy_extensions import TypedDict
+
+    Filename = str
+    LinterName = str
+    State_ = TypedDict('State_', {
+        'active_view': Optional[sublime.View],
+        'running': Dict[sublime.BufferId, float],
+    })
+
+
 INITIAL_DELAY = 2
 CYCLE_TIME = 200
 TIMEOUT = 20
@@ -14,7 +27,7 @@ STATUS_BUSY_KEY = "sublime_linter_status_busy"
 State = {
     'active_view': None,
     'running': {}
-}
+}  # type: State_
 
 
 def plugin_loaded():
@@ -35,24 +48,30 @@ def plugin_unloaded():
 
 @events.on(events.LINT_START)
 def on_begin_linting(buffer_id):
+    # type: (sublime.BufferId) -> None
     State['running'][buffer_id] = time.time()
 
     active_view = State['active_view']
     if active_view and active_view.buffer_id() == buffer_id:
-        sublime.set_timeout_async(lambda: draw(**State), INITIAL_DELAY * 1000)
+        sublime.set_timeout_async(
+            lambda: draw(active_view),  # type: ignore  # mypy bug
+            INITIAL_DELAY * 1000
+        )
 
 
 @events.on(events.LINT_END)
 def on_finished_linting(buffer_id, **kwargs):
+    # type: (sublime.BufferId, object) -> None
     State['running'].pop(buffer_id, None)
 
     active_view = State['active_view']
     if active_view and active_view.buffer_id() == buffer_id:
-        draw(**State)
+        draw(active_view)
 
 
 class UpdateState(sublime_plugin.EventListener):
     def on_activated(self, active_view):
+        # type: (sublime.View) -> None
         if not util.is_lintable(active_view):
             return
 
@@ -60,7 +79,7 @@ class UpdateState(sublime_plugin.EventListener):
             'active_view': active_view
         })
 
-        draw(**State)
+        draw(active_view)
 
 
 indicators = [
@@ -72,14 +91,15 @@ indicators = [
 ]
 
 
-def draw(active_view, running, **kwargs):
-    buffer_id = active_view.buffer_id()
-    start_time = running.get(buffer_id, None)
+def draw(view):
+    # type: (sublime.View) -> None
+    buffer_id = view.buffer_id()
+    start_time = State['running'].get(buffer_id, None)
     now = time.time()
     if start_time and (INITIAL_DELAY <= (now - start_time) < TIMEOUT):
         num = len(indicators)
         text = indicators[int((now - start_time) * 1000 / CYCLE_TIME) % num]
-        active_view.set_status(STATUS_BUSY_KEY, text)
-        sublime.set_timeout_async(lambda: draw(**State), CYCLE_TIME)
+        view.set_status(STATUS_BUSY_KEY, text)
+        sublime.set_timeout_async(lambda: draw(view), CYCLE_TIME)
     else:
-        active_view.erase_status(STATUS_BUSY_KEY)
+        view.erase_status(STATUS_BUSY_KEY)

--- a/busy_indicator_view.py
+++ b/busy_indicator_view.py
@@ -3,7 +3,7 @@ import sublime_plugin
 
 import time
 
-from .lint import events
+from .lint import events, util
 
 
 INITIAL_DELAY = 2
@@ -18,9 +18,11 @@ State = {
 
 
 def plugin_loaded():
-    State.update({
-        'active_view': sublime.active_window().active_view()
-    })
+    active_view = sublime.active_window().active_view()
+    if util.is_lintable(active_view):
+        State.update({
+            'active_view': active_view
+        })
 
 
 def plugin_unloaded():
@@ -50,7 +52,10 @@ def on_finished_linting(buffer_id, **kwargs):
 
 
 class UpdateState(sublime_plugin.EventListener):
-    def on_activated_async(self, active_view):
+    def on_activated(self, active_view):
+        if not util.is_lintable(active_view):
+            return
+
         State.update({
             'active_view': active_view
         })


### PR DESCRIPTION
Fixes #1727

The busy spinner immediately stops spinning if the user opens or
activates a different view. This is only the right thing if the selected
view is a non-special view.

The fix is to check `util.is_lintable` before accepting the new view
as the "active" one. `is_lintable` filters all panels for us.

We switch to `on_activated` (t.i. the version on the UI thread) because
this reduces status bar repaints (flicker) if you really `<tab>` to a
new view while the spinner is showing.

(Basically being "sync" here we avoid one repaint; without it Sublime
would first update the status bar info to match the new view, then we
would kick in and update the spinner; with it we do this in one paint.)