### PR TITLE
Fix: Use "outline" again as fallback in ST3

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -65,7 +65,7 @@ SOME_WS = re.compile(r'\s')
 FALLBACK_MARK_STYLE = 'outline'
 
 WS_ONLY = re.compile(r'^\s+$')
-MULTILINES = re.compile('\n')
+MULTILINES = re.compile('\n(?=.)')
 
 # Sublime >= 4074 supports underline styles on white space
 # https://github.com/sublimehq/sublime_text/issues/137

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -67,9 +67,9 @@ FALLBACK_MARK_STYLE = 'outline'
 WS_ONLY = re.compile(r'^\s+$')
 MULTILINES = re.compile('\n')
 
-# Sublime > 4074 supports underline styles on white space
+# Sublime >= 4074 supports underline styles on white space
 # https://github.com/sublimehq/sublime_text/issues/137
-SUBLIME_SUPPORTS_WS_SQUIGGLES = int(sublime.version()) > 4074
+SUBLIME_SUPPORTS_WS_SQUIGGLES = int(sublime.version()) >= 4074
 
 State = {
     'active_view': None,
@@ -297,11 +297,9 @@ def _compute_flags(error):
     mark_style = style.get_value('mark_style', error, 'none')
     selected_text = error['offending_text']
     if SUBLIME_SUPPORTS_WS_SQUIGGLES:
-        # Work around Sublime bug, which cannot draw 'underlines' on spaces
-        regex = SOME_WS
-    else:
-        # In newer Sublime versions, we still prefer outlines over multi-line errors
         regex = MULTILINES
+    else:
+        regex = SOME_WS
     if mark_style in UNDERLINE_STYLES and regex.search(selected_text):
         mark_style = FALLBACK_MARK_STYLE
 


### PR DESCRIPTION
Well, #1741 is basically wrong on every line, don't use drugs and then
code.

- The Sublime change has been introduced *with* v4074 so it's `>=`
- The conditional must be flipped