### PR TITLE
Fix: Guard read from global `THROTTLER_TOKENS`

### DIFF
--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -240,7 +240,8 @@ def throttled_on_args(fn, *args, **kwargs):
 
     def program():
         with THROTTLER_LOCK:
-            ok = THROTTLER_TOKENS[key] == action
+            # Use `get` bc during hot-reload `THROTTLER_TOKENS` gets emptied
+            ok = THROTTLER_TOKENS.get(key) == action
         if ok:
             action()
 


### PR DESCRIPTION
Although the closure would naturally guarantee that `key` is in
`THROTTLER_TOKENS` at the call time, we actually loose all state during
hot-reload.

We thus need to use the safer `get` method which returns `None` as a
fallback resulting in *not* running queued actions just after reload.