### PR TITLE
Implement keyboard navigation for the error panel

### DIFF
--- a/goto_commands.py
+++ b/goto_commands.py
@@ -16,13 +16,13 @@ if MYPY:
 
 
 class sublime_linter_goto_error(sublime_plugin.TextCommand):
-    def run(self, edit, direction='next', count=1, wrap=False):
-        # type: (sublime.Edit, Direction, int, bool) -> None
-        goto(self.view, direction, count, wrap)
+    def run(self, edit, direction='next', count=1, wrap=False, transient=False):
+        # type: (sublime.Edit, Direction, int, bool, bool) -> None
+        goto(self.view, direction, count, wrap, transient)
 
 
-def goto(view, direction, count, wrap):
-    # type: (sublime.View, Direction, int, bool) -> None
+def goto(view, direction, count, wrap, transient):
+    # type: (sublime.View, Direction, int, bool, bool) -> None
     filename = util.get_filename(view)
     errors = persist.file_errors.get(filename)
     if not errors:
@@ -74,7 +74,7 @@ def goto(view, direction, count, wrap):
     else:
         point = jump_positions[count - 1]
 
-    move_to(view, point)
+    move_to(view, point, transient)
 
 
 class _sublime_linter_move_cursor(sublime_plugin.TextCommand):
@@ -87,9 +87,10 @@ class _sublime_linter_move_cursor(sublime_plugin.TextCommand):
         self.view.show(point)
 
 
-def move_to(view, point):
-    # type: (sublime.View, int) -> None
-    history_list.get_jump_history_for_view(view).push_selection(view)
+def move_to(view, point, transient):
+    # type: (sublime.View, int, bool) -> None
+    if not transient:
+        history_list.get_jump_history_for_view(view).push_selection(view)
     view.run_command('_sublime_linter_move_cursor', {'point': point})
 
 

--- a/keymaps/Default.sublime-keymap
+++ b/keymaps/Default.sublime-keymap
@@ -1,0 +1,23 @@
+[
+    {
+        "keys": ["enter"],
+        "command": "sublime_linter_panel_commit",
+        "context": [
+            { "key": "setting.sl_error_panel" },
+        ]
+    },
+    {
+        "keys": ["down"],
+        "command": "sublime_linter_panel_next",
+        "context": [
+            { "key": "setting.sl_error_panel" },
+        ]
+    },
+    {
+        "keys": ["up"],
+        "command": "sublime_linter_panel_previous",
+        "context": [
+            { "key": "setting.sl_error_panel" },
+        ]
+    },
+]


### PR DESCRIPTION
Fixes #1717

As discussed in #1717, explore a keyboard centric error panel.  

For usage, probably bind or rebind the panel toggle

```
  {
      "keys": ["ctrl+k", "ctrl+a"],
      "command": "sublime_linter_panel_toggle",
      "args": {"focus": true}
  },
```

Features:

- `ctrl+k, ctrl+a` with `focus: True`, opens the panel and moves the focus, 
  after that `enter` or `esc` both closes the panel. 

- If you instead use `up` or `down` you select the next or previous error and scroll it into the view. After that, `esc` to close the panel and return to the previous editing position. `enter` to close the panel and keep the cursor at the selected error. 

- You can also just open the panel without `focus` set, then click. Then e.g. `enter` to go to that location. 

Not implemented (yet?):

- `ctrl+k, ctrl+a` with `focus: True` only opens and never closes. (T.i. it does not toggle.)

- Does not go to the next visible error if it would be in another file. Stays in the current file.