### PR TITLE
Quick action context menu - use clicked position

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,24 +1,11 @@
 [
     {
-        "id": "sublimelinter",
-        "caption": "Linter",
-        "children": [
-            {
-                "id": "sublimelinter-lint",
-                "caption": "Lint This View",
-                "command": "sublime_linter_lint"
-            },
-            {
-                "id": "sublimelinter-highlights",
-                "caption": "Toggle Highlights",
-                "command": "sublime_linter_toggle_highlights"
-            },
-            {
-                "id": "sublimelinter-fix",
-                "caption": "Quick Action",
-                "command": "sublime_linter_quick_actions",
-                "args": { "prefer_panel": true }
-            }
-        ]
+        "caption": "Lint This View",
+        "command": "sublime_linter_lint"
+    },
+    {
+        "caption": "Linter Quick Action",
+        "command": "sublime_linter_quick_actions",
+        "args": { "prefer_panel": true }
     }
 ]

--- a/quick_actions.py
+++ b/quick_actions.py
@@ -15,8 +15,11 @@ if MYPY:
 
 class sublime_linter_quick_actions(sublime_plugin.TextCommand):
     def is_visible(self, prefer_panel=False, **kwargs):
-        filename = util.get_filename(self.view)
-        return len(persist.file_errors[filename]) > 0
+        if 'event' in kwargs:
+            filename = util.get_filename(self.view)
+            return len(persist.file_errors[filename]) > 0
+        else:
+            return True
 
     def is_enabled(self, prefer_panel=False, **kwargs):
         # type: (bool, object) -> bool

--- a/quick_actions.py
+++ b/quick_actions.py
@@ -21,17 +21,24 @@ class sublime_linter_quick_actions(sublime_plugin.TextCommand):
         else:
             return True
 
+    def want_event(self):
+        return True
+
     def run(self, edit, prefer_panel=False, **kwargs):
         # type: (sublime.Edit, bool, object) -> None
         view = self.view
         window = view.window()
         assert window
+        sel = view.sel()[0]
 
-        if len(self.view.sel()) != 1:
+        if 'event' in kwargs:
+            vector = (kwargs['event']['x'], kwargs['event']['y'])
+            point = view.window_to_text(vector)
+            sel = sublime.Region(point, point)
+        elif len(self.view.sel()) != 1:
             window.status_message("Quick actions don't support multiple selections")
             return
 
-        sel = view.sel()[0]
         filename = util.get_filename(view)
         if sel.empty():
             char_selection = sublime.Region(sel.a, sel.a + 1)

--- a/quick_actions.py
+++ b/quick_actions.py
@@ -14,6 +14,10 @@ if MYPY:
 
 
 class sublime_linter_quick_actions(sublime_plugin.TextCommand):
+    def is_visible(self, prefer_panel=False, **kwargs):
+        filename = util.get_filename(self.view)
+        return len(persist.file_errors[filename]) > 0
+
     def is_enabled(self, prefer_panel=False, **kwargs):
         # type: (bool, object) -> bool
         if 'event' in kwargs:

--- a/quick_actions.py
+++ b/quick_actions.py
@@ -16,6 +16,8 @@ if MYPY:
 class sublime_linter_quick_actions(sublime_plugin.TextCommand):
     def is_enabled(self, prefer_panel=False, **kwargs):
         # type: (bool, object) -> bool
+        if 'event' in kwargs:
+            return True
         if prefer_panel:
             return len(self.view.sel()) == 1
         else:
@@ -35,6 +37,10 @@ class sublime_linter_quick_actions(sublime_plugin.TextCommand):
             vector = (kwargs['event']['x'], kwargs['event']['y'])
             point = view.window_to_text(vector)
             sel = sublime.Region(point, point)
+            for selection in view.sel():
+                if selection.contains(point):
+                    sel = selection
+                    break
         elif len(self.view.sel()) != 1:
             window.status_message("Quick actions don't support multiple selections")
             return


### PR DESCRIPTION
When triggering quick actions through the context menu, use the position you clicked on, not the selection. I was wrong, it *is* actually possible, just nobody uses this? (Or nobody uses context menus...).

I right-clicked the position at the arrow:
<img width="578" alt="Screen Shot 2020-06-29 at 22 06 50" src="https://user-images.githubusercontent.com/2543659/86050932-e1691180-ba54-11ea-82a6-40171f2cf5d4.png">

So, the selection is overruled if an `'event'` is passed, which contains x/y coords we can convert to a text point. 

Just as a proof of concept to get your thoughts here.