### PR TITLE
Show "Lint this view" only if it makes sense

### DIFF
--- a/goto_commands.py
+++ b/goto_commands.py
@@ -5,6 +5,7 @@ from Default import history_list
 from itertools import dropwhile, takewhile
 
 from .lint import persist, util
+from .lint.util import flash
 
 
 MYPY = False
@@ -91,9 +92,3 @@ def move_to(view, point):
     # type: (sublime.View, int) -> None
     history_list.get_jump_history_for_view(view).push_selection(view)
     view.run_command('_sublime_linter_move_cursor', {'point': point})
-
-
-def flash(view, msg):
-    # type: (sublime.View, str) -> None
-    window = view.window() or sublime.active_window()
-    window.status_message(msg)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -220,6 +220,14 @@ class ViewSettings:
             self.view.id(), self.prefix.rstrip('.'))
 
 
+NOT_EXPANDABLE_SETTINGS = {
+    "lint_mode",
+    "selector",
+    "disable",
+    "filter_errors",
+}
+
+
 class LinterSettings:
     """
     Smallest possible dict-like container for linter settings to lazy
@@ -235,6 +243,9 @@ class LinterSettings:
 
     def __getitem__(self, key):
         # type: (str) -> Any
+        if key in NOT_EXPANDABLE_SETTINGS:
+            return self.raw_settings[key]
+
         try:
             return self._computed_settings[key]
         except KeyError:

--- a/lint/util.py
+++ b/lint/util.py
@@ -65,6 +65,12 @@ def clear_message():
     window.run_command("sublime_linter_remove_panel")
 
 
+def flash(view, msg):
+    # type: (sublime.View, str) -> None
+    window = view.window() or sublime.active_window()
+    window.status_message(msg)
+
+
 def distinct_until_buffer_changed(method):
     # Sublime has problems to hold the distinction between buffers and views.
     # It usually emits multiple identical events if you have multiple views


### PR DESCRIPTION
Since we place our menu entry very much at the top of the context menu,
we want to show it only when it could be relevant for the user.

We assume that this is never the case when all linters for the view
actually run in background mode.  ~~We grey out the entry if some non-
background linters can't run at this point.  Usually only applicable
for linters which run against the real files on disk if the view is
currently dirty/not saved.~~ We never grey, we show an entry only 
if you can use it at this point in time. 