### PR TITLE
Two removals

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -322,7 +322,7 @@ def get_raw_linter_settings(linter, view):
     # type: (Type[Linter], sublime.View) -> MutableMapping[str, Any]
     """Return 'raw' linter settings without variables substituted."""
     defaults = linter.defaults or {}
-    user_settings = persist.settings.get('linters', {}).get(linter.name, {})
+    global_settings = persist.settings.get('linters', {}).get(linter.name, {})
     view_settings = ViewSettings(
         view, 'SublimeLinter.linters.{}.'.format(linter.name)
     )  # type: Mapping[str, Any]  # type: ignore
@@ -330,7 +330,7 @@ def get_raw_linter_settings(linter, view):
     return ChainMap(
         {},
         view_settings,
-        user_settings,
+        global_settings,
         defaults,
         {'lint_mode': persist.settings.get('lint_mode')}
     )

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -323,31 +323,6 @@ def get_raw_linter_settings(linter, view):
     """Return 'raw' linter settings without variables substituted."""
     defaults = linter.defaults or {}
     user_settings = persist.settings.get('linters', {}).get(linter.name, {})
-
-    # We actually don't want to lint detached views, so failing here
-    # when there is no window would be more appropriate, but also less
-    # convenient.
-    window = view.window()
-    if window:
-        data = window.project_data() or {}
-        if 'SublimeLinter' in data:
-            project_file_name = window.project_file_name()
-            deprecation_warning(
-                "Project settings for SublimeLinter have a new form and follow "
-                "Sublime's standard now. You can read more about it here: "
-                "http://www.sublimelinter.com/en/stable/settings.html#project-settings \n"
-                "If you just open '{}' now and save the file, a popup will "
-                "show the necessary changes."
-                .format(project_file_name)
-            )
-        project_settings = (
-            data.get('SublimeLinter', {})
-                .get('linters', {})
-                .get(linter.name, {})
-        )
-    else:
-        project_settings = {}
-
     view_settings = ViewSettings(
         view, 'SublimeLinter.linters.{}.'.format(linter.name)
     )  # type: Mapping[str, Any]  # type: ignore
@@ -355,7 +330,6 @@ def get_raw_linter_settings(linter, view):
     return ChainMap(
         {},
         view_settings,
-        project_settings,
         user_settings,
         defaults,
         {'lint_mode': persist.settings.get('lint_mode')}

--- a/lint/util.py
+++ b/lint/util.py
@@ -36,14 +36,6 @@ def on_settings_changed(settings, **kwargs):
     get_augmented_path.cache_clear()
 
 
-def printf(*args):
-    """Print args to the console, prefixed by the plugin name."""
-    print('SublimeLinter: ', end='')
-    for arg in args:
-        print(arg, end=' ')
-    print()
-
-
 @contextmanager
 def print_runtime(message):
     start_time = time.perf_counter()

--- a/tests/test_command_generation.py
+++ b/tests/test_command_generation.py
@@ -551,30 +551,6 @@ class TestDeprecations(_BaseTestCase):
             "has been deprecated, use '${args}' instead."
         )
 
-    def test_non_standard_project_settings_warn(self):
-        class FakeLinter(Linter):
-            cmd = ('fake_linter_1', )
-            defaults = {'selector': None}
-        PROJECT_FILE_NAME = '/h/a/b/foo.sublime-project'
-
-        window = mock(spec=sublime.Window)
-        when(self.view).window().thenReturn(window)
-        when(window).extract_variables().thenReturn({})
-        when(window).project_data().thenReturn({"SublimeLinter": {}})
-        when(window).project_file_name().thenReturn(PROJECT_FILE_NAME)
-        when(linter_module.logger).warning(...)
-
-        linter_module.get_linter_settings(FakeLinter, self.view)
-
-        verify(linter_module.logger).warning(
-            "Project settings for SublimeLinter have a new form and follow Sublime's "
-            "standard now. You can read more about it here: "
-            "http://www.sublimelinter.com/en/stable/settings.html#project-settings \n"
-            "If you just open '{}' now and save the file, a popup will "
-            "show the necessary changes."
-            .format(PROJECT_FILE_NAME)
-        )
-
     def test_old_file_marker_in_cmd_warns_stdin_linter(self):
         class FakeLinter(Linter):
             cmd = ('fake_linter_1', '@')


### PR DESCRIPTION
- Remove `util.printf` probably forgotten in #1723

- Hard deprecate so called project settings; de-facto deprecated since 4.6.6, finally deprecated in 4.13.0