### PR TITLE
For mypy, ignore comment must come after type comments

### DIFF
--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -420,7 +420,7 @@ def fix_mypy_error(error, view):
             line
         )
         or maybe_add_before_string(
-            "  # ",
+            r"  # (?!type:)",
             "  # type: ignore[{}]".format(code),
             line
         )
@@ -515,14 +515,13 @@ def indentation(line):
     return line.text[:level]
 
 
-def maybe_add_before_string(needle, text, line):
+def maybe_add_before_string(pattern, text, line):
     # type: (str, str, TextRange) -> Optional[TextRange]
-    try:
-        start = line.text.index(needle)
-    except ValueError:
-        return None
-    else:
+    match = re.search(pattern, line.text)
+    if match:
+        start, _ = match.span()
         return TextRange(
             text,
             sublime.Region(line.range.a + start)
         )
+    return None

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -213,6 +213,11 @@ class TestIgnoreFixers(DeferrableTestCase):
             "view = window.new_file()  # type: ignore[attr]  # comment ",
             "view = window.new_file()  # type: ignore[attr, no-idea]  # comment ",
         ),
+        (
+            "keep existing type comment in-place",
+            "view = window.new_file()  # type: sublime.View",
+            "view = window.new_file()  # type: sublime.View  # type: ignore[no-idea]",
+        ),
     ])
     def test_mypy(self, _description, BEFORE, AFTER):
         view = self.create_view(self.window)


### PR DESCRIPTION
Given a type comment

```
view = window.new_file()  # type: sublime.View
```

an ignore comment must come last

```
view = window.new_file()  # type: sublime.View  # type: ignore[no-idea]
```

See added test.

