### PR TITLE
Allow for customization of Quick Fixes

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -110,6 +110,14 @@
                 }
             ],
 
+            // Specify what form of quick fix to implement if there are
+            // multiple options
+            "quick_fix_settings": {
+                // An ESLint can either have an eslint-disable-next-line or an
+                // eslint-disable-line comment
+                "eslint": "previous_line"
+            },
+
             // The current working dir the lint job will run in.
             "working_dir": "",
 

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -109,6 +109,15 @@
                             },
                             "additionalProperties":false
                         }
+                    },
+                    "quick_fix_settings": {
+                        "type":"object",
+                        "properties": {
+                            "eslint": {
+                                "type": "string",
+                                "enum": ["previous_line", "same_line"]
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This commit implements the capacity to configure the Quick Fixes
made available by SublimeLinter. This commit deals solely with the
ESLint Quick Fixes but lays the foundation for extending the
customization to the other linters that can apply the Quick Fix feature.

Taking ESLint as our example, it is personal preference whether an
ESLint violation is ignored with an `// eslint-disable-next-line
VIOLATION(S)` or an `// eslint-disable-line VIOLATION(S)` comment.
Currently, SublimeLinter only provides the functionality to use the
`// eslint-disable-next-line` comment. It would be preferable to be able
to configure this to use the type of inline Quick Fix that the
programmer prefers.

TODO - Actually detail the final SublimeLinter settings

@kaste (or another maintainer) - I am looking for a bit of advice as to what you think of this feature and whether I should pursue it from here and if I should, how you feel the schema settings should look. This is a bit of an "in theory" PR, which is why I've made it a draft, as I am looking for maintainer feedback, particularly on the schema settings, and how best to access those settings.