### PR TITLE
Ensure to skip saved-file-only-linter for unnamed files

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1063,7 +1063,9 @@ class Linter(metaclass=LinterMeta):
         # type: (sublime.View, LinterSettings, Reason) -> bool
         """Decide whether the linter can run at this point in time."""
         # A 'saved-file-only' linter does not run on unsaved views
-        if cls.tempfile_suffix == '-' and view.is_dirty():
+        if cls.tempfile_suffix == '-' and (
+            view.is_dirty() or not view.file_name()
+        ):
             return False
 
         if reason not in KNOWN_REASONS:  # be open

--- a/tests/test_sublime_linter_entrypoint.py
+++ b/tests/test_sublime_linter_entrypoint.py
@@ -8,7 +8,7 @@ from SublimeLinter import sublime_linter
 from SublimeLinter.lint import Linter, persist
 
 
-class TestResultRegexes(DeferrableTestCase):
+class TestLinterElection(DeferrableTestCase):
     @classmethod
     def setUpClass(cls):
 

--- a/tests/test_sublime_linter_entrypoint.py
+++ b/tests/test_sublime_linter_entrypoint.py
@@ -60,6 +60,7 @@ class TestLinterElection(DeferrableTestCase):
         when(sublime_linter.backend).lint_view(...).thenReturn(None)
 
         view = self.create_view(self.window)
+        assert not view.is_dirty(), "Just created views should not be marked dirty"
         assert view.file_name() is None
         sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request')
 
@@ -74,8 +75,10 @@ class TestLinterElection(DeferrableTestCase):
         when(sublime_linter.backend).lint_view(...).thenReturn(None)
 
         view = self.create_view(self.window)
+        when(view).file_name().thenReturn("some_filename.txt")
         replace_view_content(view, "Some text.")
         assert view.is_dirty()
+        assert view.file_name()
         sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request')
 
         verify(sublime_linter.backend, times=0).lint_view(...)


### PR DESCRIPTION
`file_on_disk` linters should *not* run on newly created (empty) files.  We always just asked `is_dirty()` which is true for all unnamed, *non-empty* views so this PR resolves an obvious but edge case.  Surprising it went unnoticed for so long.