### PR TITLE
Let LintMatch recognize end_line and end_col

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -164,8 +164,12 @@ class VirtualView:
         """Return the start/end character positions for the given line."""
         start = self._newlines[line]
         end = self._newlines[min(line + 1, len(self._newlines) - 1)]
-
         return start, end
+
+    def full_line_region(self, line):
+        # type: (int) -> sublime.Region
+        """Return the (full) line region including any trailing newline char."""
+        return sublime.Region(*self.full_line(line))
 
     def select_line(self, line):
         # type: (int) -> str
@@ -1350,14 +1354,14 @@ class Linter(metaclass=LinterMeta):
         col = m.col
         if col is not None:
             # Pin the column to the start/end line offsets
-            start, end = vv.full_line(line)
-            col = max(min(col, (end - start) - 1), 0)
+            line_region = vv.full_line_region(line)
+            col = max(min(col, len(line_region) - 1), 0)
 
         line, start, end = self.reposition_match(line, col, m, vv)
 
         # find the region to highlight for this error
-        line_start, _ = vv.full_line(line)
-        region = sublime.Region(line_start + start, line_start + end)
+        line_region = vv.full_line_region(line)
+        region = sublime.Region(line_region.a + start, line_region.a + end)
         if len(region) == 0:
             region.b += 1
         offending_text = vv.substr(region)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -58,7 +58,9 @@ ACCEPTED_REASONS_PER_MODE = {
 KNOWN_REASONS = set(chain(*ACCEPTED_REASONS_PER_MODE.values()))
 
 LEGACY_LINT_MATCH_DEF = ("match", "line", "col", "error", "warning", "message", "near")
-COMMON_CAPTURING_NAMES = ("filename", "error_type", "code") + LEGACY_LINT_MATCH_DEF
+COMMON_CAPTURING_NAMES = (
+    "filename", "error_type", "code", "end_line", "end_col"
+) + LEGACY_LINT_MATCH_DEF
 
 
 class LintMatch(dict):

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -82,6 +82,20 @@ class LintMatch(dict):
 
     """
 
+    if MYPY:
+        match = None       # type: Optional[object]
+        filename = None    # type: Optional[str]
+        line = None        # type: int
+        col = None         # type: Optional[int]
+        end_line = None    # type: Optional[int]
+        end_col = None     # type: Optional[int]
+        error_type = None  # type: Optional[str]
+        code = None        # type: Optional[str]
+        message = None     # type: str
+        error = None       # type: Optional[str]
+        warning = None     # type: Optional[str]
+        near = None        # type: Optional[str]
+
     def __init__(self, *args, **kwargs):
         if len(args) == 7:
             self.update(zip(LEGACY_LINT_MATCH_DEF, args))
@@ -1323,11 +1337,8 @@ class Linter(metaclass=LinterMeta):
             # use the filename of the current view
             filename = util.get_filename(self.view)
 
-        line = m.line  # type: int
-        col = m.col    # type: Optional[int]
-
         # Ensure `line` is within bounds
-        line = max(min(line, vv.max_lines()), 0)
+        line = max(min(m.line, vv.max_lines()), 0)
         if line != m.line:
             logger.warning(
                 "Reported line '{}' is not within the code we're linting.\n"
@@ -1336,6 +1347,7 @@ class Linter(metaclass=LinterMeta):
                 .format(m.line + self.line_col_base[0])
             )
 
+        col = m.col
         if col is not None:
             # Pin the column to the start/end line offsets
             start, end = vv.full_line(line)

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -144,6 +144,7 @@ class VirtualView:
         newlines.append(len(code))
 
     def full_line(self, line):
+        # type: (int) -> Tuple[int, int]
         """Return the start/end character positions for the given line."""
         start = self._newlines[line]
         end = self._newlines[min(line + 1, len(self._newlines) - 1)]
@@ -151,14 +152,17 @@ class VirtualView:
         return start, end
 
     def select_line(self, line):
+        # type: (int) -> str
         """Return code for the given line."""
         start, end = self.full_line(line)
         return self._code[start:end]
 
     def max_lines(self):
+        # type: () -> int
         return len(self._newlines) - 2
 
     def substr(self, region):
+        # type: (sublime.Region) -> str
         return self._code[region.begin():region.end()]
 
     # Actual Sublime API would look like:

--- a/tests/test_loose_lintmatch.py
+++ b/tests/test_loose_lintmatch.py
@@ -31,7 +31,7 @@ class TestLooseLintMatch(DeferrableTestCase):
 
         for k in (
             "match", "line", "col", "error", "warning", "message", "near",
-            "filename", "error_type", "code",
+            "filename", "error_type", "code", "end_line", "end_col",
         ):
             self.assertEqual(getattr(rv, k), '' if k == 'message' else None)
 

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -633,6 +633,26 @@ class TestRegexBasedParsing(_BaseTestCase):
             result,
         )
 
+    def test_ensure_reposition_match_can_change_the_line(self):
+        INPUT = "0123456789\n012foo3456789"
+        OUTPUT = "stdin:1:1 ERROR: The message"
+
+        def reposition_match(line, col, m, vv):
+            return 1, 3, 6
+
+        linter = self.create_linter()
+        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
+        when(linter).reposition_match(...).thenAnswer(reposition_match)
+
+        result = execute_lint_task(linter, INPUT)
+        drop_info_keys(result)
+        self.assertResult([{
+            'line': 1,
+            'start': 3,
+            'end': 6,
+            'region': sublime.Region(14, 17)
+        }], result)
+
     def test_multiline_false(self):
         linter = self.create_linter()
         self.assertNotEqual(linter.regex.flags & re.MULTILINE, re.MULTILINE)


### PR DESCRIPTION
Fixes #1584 

Add support for `end_line` and `end_col` in `LintMatch`.  This is usually only useful for JSON linters, at least I don't know any compact line-based stdout format which outputs this information.  

This is basically extracted from the eslint plugin.  It works with the companion PR over there https://github.com/SublimeLinter/SublimeLinter-eslint/pull/309

Of course, generalizing it here, handling the edge cases and do the proper clamping/error handling, logging doubles the code from eslint. 

---

By looking at the code, we capture `end` in `LintError` which is unused as we nowadays use `region` throughout the app.  But computing it makes this PR a bit more unreadable.  A future PR should remove it.  (We still use `line` and `start` basically as a cached value to present in the error panel; so we don't have to call `view.rowcol` per render.)  

--- 

The last commit has a refactoring which is strictly speaking a "major" update in that we don't allow "holes" in the underlying `LintMatch` dict.  A hole is for example, a missing key `col` etc.  We now fill in these "holes" and set the value `None`.  This should be of no particular interest as the user probably already used the dotted notation `match.col` which already exchanged a missing key with `None` in such cases. The old tuple unpacking we see in old plugins did this as well.

Usually we don't want the doubled optionality we technically had: first, maybe the key is present, then maybe the value is None.  The dotted, object notation already opted in for the optionality on the value, not the key, so we finally follow.  

No tests enforced the old behavior as well.