### PR TITLE
Log detailed information about the queued linting tasks

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -77,19 +77,23 @@ def run_tasks(tasks, next):
 
 def warn_excessive_tasks(view, uow):
     # type: (sublime.View, Dict[LinterName, List[Task[LintResult]]]) -> None
-    for linter_name, tasks in uow.items():
-        if len(tasks) > 3:
-            logger.warning(
-                "'{}' puts {} {} tasks on the queue."
-                .format(short_canonical_filename(view), len(tasks), linter_name)
-            )
-
     total_tasks = sum(len(tasks) for tasks in uow.values())
     if total_tasks > 4:
-        logger.warning(
-            "'{}' puts in total {}(!) tasks on the queue."
-            .format(short_canonical_filename(view), total_tasks)
+        linter_info = ", ".join(
+            "{}x {}".format(len(tasks), linter_name)
+            for linter_name, tasks in uow.items()
         )
+        logger.warning(
+            "'{}' puts in total {}(!) tasks on the queue:  {}."
+            .format(short_canonical_filename(view), total_tasks, linter_info)
+        )
+    else:
+        for linter_name, tasks in uow.items():
+            if len(tasks) > 3:
+                logger.warning(
+                    "'{}' puts {} {} tasks on the queue."
+                    .format(short_canonical_filename(view), len(tasks), linter_name)
+                )
 
 
 def tasks_per_linter(view, view_has_changed, linter_class, settings):


### PR DESCRIPTION
If for some buffer we put "excessively many" tasks on the queue,
currently more than 4, log detailed information about which linter
uses how many tasks.  E.g.

```
SublimeLinter: backend.py:88          WARNING: 'index.html' puts in
total 6(!) tasks on the queue:  1x htmlhint, 1x htmltidy, 1x eslint,
1x annotations, 2x flow.
```

Compared to before:

```
SublimeLinter: backend.py:88          WARNING: 'index.html' puts in
total 6(!) tasks on the queue.
```