### PR TITLE
Fix matching absolute Windows file paths in the panel

### DIFF
--- a/panel/panel.sublime-syntax
+++ b/panel/panel.sublime-syntax
@@ -47,8 +47,9 @@ contexts:
 
   expect-filename:
     - include: pop-at-end
-    - match: ([^:]+)
-      scope: entity.name.filename.sublime_linter
+    - match: '((\S:)?[^:]+):'
+      captures:
+        1: entity.name.filename.sublime_linter
       pop: true
 
   ensure-error-meta-scope:

--- a/panel/syntax_test_panel
+++ b/panel/syntax_test_panel
@@ -71,3 +71,16 @@ highlight_view.py:
                                               message
 #                                             ^^^^^^^ markup.quote.linter-message.sublime_linter
 
+
+C:\foo\highlight_view.py:
+# <- entity.name.filename.sublime_linter
+#^^^^^^^^^^^^^^^^^^^^^^^ entity.name.filename.sublime_linter
+# <- meta.error_panel.fileline.sublime_linter
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.error_panel.fileline.sublime_linter
+
+/foo/highlight_view.py:
+# <- entity.name.filename.sublime_linter
+#^^^^^^^^^^^^^^^^^^^^^ entity.name.filename.sublime_linter
+# <- meta.error_panel.fileline.sublime_linter
+#^^^^^^^^^^^^^^^^^^^^^^ meta.error_panel.fileline.sublime_linter
+


### PR DESCRIPTION
Obviously, absolute Windows paths can contain a `:` for which our syntax pattern failed.  See added test.