### PR TITLE
Remove `end` key from `LintError`

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -217,7 +217,7 @@ def filter_errors(errors, group_fn):
 
 def by_position(error):
     # type: (LintError) -> Hashable
-    return (error['line'], error['start'], error['end'])
+    return error['line'], error['start'], error['region'].end()
 
 
 def by_line(error):
@@ -639,14 +639,11 @@ def maybe_update_error_store(view):
             continue
 
         line, start = view.rowcol(region.begin())
-        endLine, end = view.rowcol(region.end())
         error = error.copy()
         error.update({
             'region': region,
             'line': line,
             'start': start,
-            'endLine': endLine,
-            'end': end
         })
         new_errors.append(error)
 
@@ -972,7 +969,7 @@ def join_msgs(errors, show_count, width, pt):
     for error_type in sorted(grouped_by_type.keys(), key=sort_by_type):
         errors_by_type = sorted(
             grouped_by_type[error_type],
-            key=lambda e: (e["linter"], e["start"], e["end"])
+            key=lambda e: (e["linter"], e["region"])
         )
 
         filled_templates = []

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -178,7 +178,7 @@ def execute_lint_task(linter, code, offsets, view_has_changed):
 
 
 PROPERTIES_FOR_UID = (
-    'filename', 'linter', 'line', 'start', 'end', 'error_type', 'code', 'msg',
+    'filename', 'linter', 'line', 'start', 'error_type', 'code', 'msg',
 )
 
 
@@ -201,37 +201,22 @@ def finalize_errors(linter, errors, offsets):
     line_offset, col_offset, pt_offset = offsets
 
     for error in errors:
-        error.setdefault('filename', view_filename)
         belongs_to_main_file = (
             os.path.normcase(error['filename']) == os.path.normcase(view_filename)
         )
 
-        line, start, end = error['line'], error['start'], error['end']
+        region, line, start = error['region'], error['line'], error['start']
         if belongs_to_main_file:  # offsets are for the main file only
             if line == 0:
                 start += col_offset
-                end += col_offset
-
             line += line_offset
-
-        try:
-            region = error['region']
-        except KeyError:
-            line_start = view.text_point(line, 0)
-            region = sublime.Region(line_start + start, line_start + end)
-            if len(region) == 0:
-                region.b = region.b + 1
-
-        else:
-            if belongs_to_main_file:  # offsets are for the main file only
-                region = sublime.Region(region.a + pt_offset, region.b + pt_offset)
+            region = sublime.Region(region.a + pt_offset, region.b + pt_offset)
 
         error.update({
             'linter': linter_name,
             'region': region,
             'line': line,
             'start': start,
-            'end': end,
         })
 
         error.update({

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1421,7 +1421,6 @@ class Linter(metaclass=LinterMeta):
             "filename": filename,
             "line": line,
             "start": start,
-            "end": end,
             "region": region,
             "error_type": error_type,
             "code": code,

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1367,9 +1367,10 @@ class Linter(metaclass=LinterMeta):
         line_region = vv.full_line_region(line)
 
         if m.end_line is None and m.end_col is None:
-            col = None if m.col is None else max(min(m.col, len(line_region) - 1), 0)
-            line, start, end = self.reposition_match(line, col, m, vv)
+            _col = None if m.col is None else max(min(m.col, len(line_region) - 1), 0)
+            line, col, end = self.reposition_match(line, _col, m, vv)
             line_region = vv.full_line_region(line)  # read again as `line` might have changed
+            region = sublime.Region(line_region.a + col, line_region.a + end)
 
         else:
             col = 0 if m.col is None else max(min(m.col, len(line_region) - 1), 0)
@@ -1405,14 +1406,8 @@ class Linter(metaclass=LinterMeta):
                         .format(m.end_col, col)
                     )
 
-            for _line in range(line, end_line):
-                text = vv.select_line(_line)
-                end_col += len(text)
+            region = sublime.Region(line_region.a + col, end_line_region.a + end_col)
 
-            line, start, end = line, col, end_col
-
-        # find the region to highlight for this error
-        region = sublime.Region(line_region.a + start, line_region.a + end)
         if len(region) == 0:
             region.b += 1
         offending_text = vv.substr(region)
@@ -1420,7 +1415,7 @@ class Linter(metaclass=LinterMeta):
         return {
             "filename": filename,
             "line": line,
-            "start": start,
+            "start": col,
             "region": region,
             "error_type": error_type,
             "code": code,

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -20,7 +20,6 @@ if MYPY:
     LintError = TypedDict('LintError', {
         'line': int,
         'start': int,
-        'end': int,
         'region': sublime.Region,
         'linter': LinterName,
         'error_type': str,

--- a/panel_view.py
+++ b/panel_view.py
@@ -361,7 +361,7 @@ def get_window_errors(window, errors_by_file):
     return {
         filename: sorted(
             errors,
-            key=lambda e: (e["line"], e["start"], e["linter"], e["end"])
+            key=lambda e: (e["line"], e["start"], e["linter"], e["region"].end())
         )
         for filename, errors in (
             (filename, errors_by_file.get(filename))

--- a/tests/test_panel_view.py
+++ b/tests/test_panel_view.py
@@ -13,7 +13,6 @@ CODE = 'arbitrary_violation'
 STD_ERROR = {
     'line': 0,
     'start': 0,
-    'end': '2',
     'region': sublime.Region(0, 2),
     'error_type': 'error',
     'linter': 'the_foo',

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -268,7 +268,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 0, 'end': 4, 'region': sublime.Region(0, 4)}],
+            [{'line': 0, 'start': 0, 'region': sublime.Region(0, 4)}],
             result,
         )
 
@@ -306,7 +306,6 @@ class TestRegexBasedParsing(_BaseTestCase):
                 {
                     'line': 5,
                     'start': 10,
-                    'end': 14,
                     'region': sublime.Region(char_offset + 0, char_offset + 4),
                 }
             ],
@@ -340,7 +339,6 @@ class TestRegexBasedParsing(_BaseTestCase):
                 {
                     'line': 6,
                     'start': 0,
-                    'end': 4,
                     'region': sublime.Region(char_offset + 0, char_offset + 4),
                 }
             ],
@@ -359,7 +357,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 0, 'end': 1, 'region': sublime.Region(0, 1)}],
+            [{'line': 0, 'start': 0, 'region': sublime.Region(0, 1)}],
             result,
         )
 
@@ -382,7 +380,6 @@ class TestRegexBasedParsing(_BaseTestCase):
                 {
                     'line': 0,
                     'start': 0,
-                    'end': 10,
                     'region': sublime.Region(0, 10),
                 }
             ],
@@ -410,7 +407,6 @@ class TestRegexBasedParsing(_BaseTestCase):
                 {
                     'line': 0,
                     'start': 0,
-                    'end': 10,
                     'region': sublime.Region(0, 10),
                 }
             ],
@@ -436,7 +432,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 0, 'end': 0, 'region': sublime.Region(0, 1)}],
+            [{'line': 0, 'start': 0, 'region': sublime.Region(0, 1)}],
             result,
         )
 
@@ -458,7 +454,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 1, 'end': 5, 'region': sublime.Region(1, 5)}],
+            [{'line': 0, 'start': 1, 'region': sublime.Region(1, 5)}],
             result,
         )
 
@@ -480,7 +476,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 5, 'end': 8, 'region': sublime.Region(5, 8)}],
+            [{'line': 0, 'start': 5, 'region': sublime.Region(5, 8)}],
             result,
         )
 
@@ -511,7 +507,6 @@ class TestRegexBasedParsing(_BaseTestCase):
                 {
                     'line': 0,
                     'start': 0,
-                    'end': 10,
                     'region': sublime.Region(0, 10),
                 }
             ],
@@ -541,7 +536,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 0, 'end': 0, 'region': sublime.Region(0, 1)}],
+            [{'line': 0, 'start': 0, 'region': sublime.Region(0, 1)}],
             result,
         )
 
@@ -599,7 +594,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 0, 'end': 0, 'region': sublime.Region(0, 1)}],
+            [{'line': 0, 'start': 0, 'region': sublime.Region(0, 1)}],
             result,
         )
 
@@ -638,7 +633,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 6, 'end': 9, 'region': sublime.Region(6, 9)}],
+            [{'line': 0, 'start': 6, 'region': sublime.Region(6, 9)}],
             result,
         )
 
@@ -658,7 +653,6 @@ class TestRegexBasedParsing(_BaseTestCase):
         self.assertResult([{
             'line': 1,
             'start': 3,
-            'end': 6,
             'region': sublime.Region(14, 17)
         }], result)
 
@@ -719,7 +713,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         drop_info_keys(result)
 
         self.assertResult(
-            [{'line': 0, 'start': 5, 'end': 7, 'region': sublime.Region(5, 7)}],
+            [{'line': 0, 'start': 5, 'region': sublime.Region(5, 7)}],
             result,
         )
 
@@ -739,7 +733,6 @@ class TestRegexBasedParsing(_BaseTestCase):
                 {
                     'line': 0,
                     'start': 9,
-                    'end': 10,
                     'region': sublime.Region(9, 10),
                 }
             ],
@@ -780,7 +773,6 @@ class TestRegexBasedParsing(_BaseTestCase):
         self.assertResult([{
             'line': LINE,
             'start': 0,
-            'end': 10,
             'region': sublime.Region(0 + PT_OFFSET, 10 + PT_OFFSET)
         }], result)
 
@@ -978,7 +970,6 @@ class TestRegexBasedParsing(_BaseTestCase):
         self.assertResult([{
             'line': 1,
             'start': 17,
-            'end': 21,
             'region': sublime.Region(22, 26)
         }], result)
 
@@ -1006,7 +997,6 @@ class TestRegexBasedParsing(_BaseTestCase):
         self.assertResult([{
             'line': 0,
             'start': 17,
-            'end': 21,
             'region': sublime.Region(17, 21)
         }], result)
 
@@ -1038,7 +1028,6 @@ class TestEndLineEndColumn(_BaseTestCase):
         self.assertResult([{
             'line': 0,
             'start': 4,
-            'end': 21,
             'region': sublime.Region(4, 21)
         }], result)
 
@@ -1047,31 +1036,31 @@ class TestEndLineEndColumn(_BaseTestCase):
             "given all values",
             {'line': 0, 'col': 4, 'end_line': 1, 'end_col': 7},
             "foo456789\n0123foo",
-            {'line': 0, 'start': 4, 'end': 21, 'region': sublime.Region(4, 21)}
+            {'line': 0, 'start': 4, 'region': sublime.Region(4, 21)}
         ),
         (
             "no columns provided",
             {'line': 0, 'end_line': 1},
             "0123foo456789\n0123foo456789",
-            {'line': 0, 'start': 0, 'end': 27, 'region': sublime.Region(0, 27)}
+            {'line': 0, 'start': 0, 'region': sublime.Region(0, 27)}
         ),
         (
             "no end column",
             {'line': 0, 'col': 4, 'end_line': 1},
             "foo456789\n0123foo456789",
-            {'line': 0, 'start': 4, 'end': 27, 'region': sublime.Region(4, 27)}
+            {'line': 0, 'start': 4, 'region': sublime.Region(4, 27)}
         ),
         (
             "no start column",
             {'line': 0, 'end_line': 1, 'end_col': 7},
             "0123foo456789\n0123foo",
-            {'line': 0, 'start': 0, 'end': 21, 'region': sublime.Region(0, 21)}
+            {'line': 0, 'start': 0, 'region': sublime.Region(0, 21)}
         ),
         (
             "no end line but end column",
             {'line': 0, 'col': 4, 'end_col': 7},
             "foo",
-            {'line': 0, 'start': 4, 'end': 7, 'region': sublime.Region(4, 7)}
+            {'line': 0, 'start': 4, 'region': sublime.Region(4, 7)}
         ),
 
         # clamping wrong values
@@ -1079,31 +1068,31 @@ class TestEndLineEndColumn(_BaseTestCase):
             "clamp out of bounds columns",
             {'line': 0, 'col': 40, 'end_col': 30},
             "\n",
-            {'line': 0, 'start': 13, 'end': 13, 'region': sublime.Region(13, 14)}
+            {'line': 0, 'start': 13, 'region': sublime.Region(13, 14)}
         ),
         (
             "clamp out of bounds columns (no trailing newline)",
             {'line': 1, 'col': 40, 'end_col': 30},
             "9",
-            {'line': 1, 'start': 12, 'end': 13, 'region': sublime.Region(26, 27)}
+            {'line': 1, 'start': 12, 'region': sublime.Region(26, 27)}
         ),
         (
             "clamp end line being above start line",
             {'line': 1, 'col': 4, 'end_line': 0, 'end_col': 7},
             "foo",
-            {'line': 1, 'start': 4, 'end': 7, 'region': sublime.Region(18, 21)}
+            {'line': 1, 'start': 4, 'region': sublime.Region(18, 21)}
         ),
         (
             "clamp end column is before start column",
             {'line': 0, 'col': 4, 'end_col': 3},
             "f",
-            {'line': 0, 'start': 4, 'end': 4, 'region': sublime.Region(4, 5)}
+            {'line': 0, 'start': 4, 'region': sublime.Region(4, 5)}
         ),
         (
             "clamp end line",
             {'line': 0, 'col': 4, 'end_line': 10, 'end_col': 7},
             "foo456789\n0123foo",
-            {'line': 0, 'start': 4, 'end': 21, 'region': sublime.Region(4, 21)}
+            {'line': 0, 'start': 4, 'region': sublime.Region(4, 21)}
         ),
 
     ])
@@ -1290,4 +1279,4 @@ def drop_keys(keys, array, strict=False):
 drop_info_keys = partial(
     drop_keys, ['error_type', 'code', 'msg', 'linter', 'filename', 'offending_text']
 )
-drop_position_keys = partial(drop_keys, ['line', 'start', 'end', 'region'])
+drop_position_keys = partial(drop_keys, ['line', 'start', 'region'])


### PR DESCRIPTION
Specifying a "start" and "end" value for an error has been superseded
by the use of "region".  We only use "line"/"start" as a cached value
for display in the panel.

Other than that, "end" is used for sorting as there can be more than one
error at a given start position.  `len(region)` or `region.end()` work
here as well.

Notice that we remove a lot of finalizing in `backend.finalize_errors`
which is okay as the code is unused in the wild, and not covered by any
tests.  Of course, we ideally have only *one* place where we "finalize"
errors and this is now `process_match`.  In a future refactoring, it is
advisable to move `process_match` to the `backend`.

Not computing an "end" if `end_col` is given finally makes computing the 
region less confusing.

