### PR TITLE
Fix: Draw dangle and icon in EOF position

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -622,12 +622,16 @@ def maybe_update_error_store(view):
         # XXX: Why keep the error in the store when we don't have
         # a region key for it in the store?
         key = uid_key_map.get(uid, None)
-        region = head(view.get_regions(key)) if key else None
+        if key is None:
+            new_errors.append(error)
+            continue
+
+        region = head(view.get_regions(key))
         if region is None or region == error['region']:
             new_errors.append(error)
             continue
-        else:
-            changed = True
+
+        changed = True
 
         if region.empty():
             # Either the user edited away our region (and the error)
@@ -635,7 +639,7 @@ def maybe_update_error_store(view):
             # zero length (and moved to a different line at col 0).
             # It is useless now so we remove the error by not
             # copying it.
-            erase_view_region(view, key)  # type: ignore
+            erase_view_region(view, key)
             continue
 
         line, start = view.rowcol(region.begin())

--- a/highlight_view.py
+++ b/highlight_view.py
@@ -307,6 +307,8 @@ def _compute_flags(error):
     flags = MARK_STYLES[mark_style]
     if not persist.settings.get('show_marks_in_minimap'):
         flags |= sublime.HIDE_ON_MINIMAP
+    if error['region'].empty():
+        flags |= sublime.DRAW_EMPTY_AS_OVERWRITE
     return flags
 
 
@@ -413,6 +415,13 @@ class Squiggle(str):
     def visible(self):
         # type: () -> bool
         return bool(self.icon or (self.scope and not self.flags == sublime.HIDDEN))
+
+    def intentional_empty(self):
+        # type: () -> bool
+        return (
+            self.flags & sublime.DRAW_EMPTY_AS_OVERWRITE
+            == sublime.DRAW_EMPTY_AS_OVERWRITE
+        )
 
 
 def get_demote_scope():
@@ -568,6 +577,7 @@ def revalidate_regions(view):
 
     selections = get_current_sel(view)  # frozen sel() for this operation
     region_keys = get_regions_keys(view)
+    eof = view.size()
     for key in region_keys:
         if isinstance(key, Squiggle) and key.visible():
             # We can have keys without any region drawn for example
@@ -595,7 +605,17 @@ def revalidate_regions(view):
             filtered_regions = [
                 region
                 for region in regions
-                if not region.empty()
+                if not region.empty() or (
+                    # There is no 1:1 mapping from a GutterKey to an error as
+                    # it is for Squiggles, so we can't have an
+                    # `intentional_empty` flag either.  Thus, we do the right
+                    # thing by observing:
+                    # Keep the icon for an empty region, if it's at EOF
+                    # position *and* the cursor is not in it. This is probably
+                    # good enough for an edge case.
+                    region.a == eof
+                    and not any(region.contains(s) for s in selections)
+                )
             ]
             if len(filtered_regions) != len(regions):
                 draw_view_region(view, key, filtered_regions)
@@ -633,7 +653,7 @@ def maybe_update_error_store(view):
 
         changed = True
 
-        if region.empty():
+        if region.empty() and not key.intentional_empty():
             # Either the user edited away our region (and the error)
             # or: Dangle! Sublime has invalidated our region, it has
             # zero length (and moved to a different line at col 0).

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -188,6 +188,10 @@ class VirtualView:
         # type: () -> int
         return len(self._newlines) - 2
 
+    def size(self):
+        # type: () -> int
+        return len(self._code)
+
     def substr(self, region):
         # type: (sublime.Region) -> str
         return self._code[region.begin():region.end()]
@@ -1408,15 +1412,17 @@ class Linter(metaclass=LinterMeta):
 
             region = sublime.Region(line_region.a + col, end_line_region.a + end_col)
 
-        if len(region) == 0:
-            region.b += 1
-        offending_text = vv.substr(region)
+        # ensure a length of 1 but do not exceed eof (`size()`)
+        normalized_region = sublime.Region(
+            region.a, min(vv.size(), max(region.a + 1, region.b))
+        )
+        offending_text = vv.substr(normalized_region)
 
         return {
             "filename": filename,
             "line": line,
             "start": col,
-            "region": region,
+            "region": normalized_region,
             "error_type": error_type,
             "code": code,
             "msg": m.message.strip(),


### PR DESCRIPTION
Fixes #1784

We always ensured regions of size 1 for all errors, because it looks
better to not have dangles all over the code.  We further recognize
empty regions which can happen when the user edits on errors, or deletes
or moves blocks of line, and remove these automatically.  That means
an empty region has a special meaning in SublimeLinter.

Unfortunately, Sublime will not draw squiggles for regions that go past
the EOF at all as #1784 has shown.

Let the linter produce empty regions for that exact edge case on EOF,
t.i. exactly the region `Region(view.size())`.  However, if only parts
of a file are linted, the virtual view inside the linter can "think" it
has an error on eof when it is actually on the end of the linted *part*
of the file only.  Check in the backend, and maybe undo what the linter
did.

Draw empty regions as dangles, t.i. with the flag
`DRAW_EMPTY_AS_OVERWRITE`, and ensure they're excluded from our dangles/
zombie protection.
