### PR TITLE
Add `self.logger` to the linter classes

### DIFF
--- a/lint/base_linter/composer_linter.py
+++ b/lint/base_linter/composer_linter.py
@@ -3,14 +3,10 @@
 import codecs
 import json
 import hashlib
-import logging
 import os
 import shutil
 
 from .. import linter, util
-
-
-logger = logging.getLogger(__name__)
 
 
 class ComposerLinter(linter.Linter):
@@ -55,9 +51,11 @@ class ComposerLinter(linter.Linter):
         if global_cmd:
             return True, global_cmd
         else:
-            logger.warning('{} cannot locate \'{}\'\n'
-                           'Please refer to the readme of this plugin and our troubleshooting guide: '
-                           'http://www.sublimelinter.com/en/stable/troubleshooting.html'.format(self.name, cmd[0]))
+            self.logger.warning(
+                '{} cannot locate \'{}\'\n'
+                'Please refer to the readme of this plugin and our troubleshooting guide: '
+                'http://www.sublimelinter.com/en/stable/troubleshooting.html'.format(self.name, cmd[0])
+            )
             return True, None
 
     def get_manifest_path(self):

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -3,7 +3,6 @@
 from functools import lru_cache
 from itertools import chain, takewhile
 import json
-import logging
 import os
 import shutil
 
@@ -14,7 +13,6 @@ if False:
     from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 
-logger = logging.getLogger(__name__)
 HOME = os.path.expanduser('~')
 
 
@@ -80,7 +78,7 @@ class NodeLinter(linter.Linter):
         npm_name = cmd[0]
         start_dir = self.get_start_dir()
         if start_dir:
-            logger.info(
+            self.logger.info(
                 "Searching executable for '{}' starting at '{}'."
                 .format(npm_name, start_dir)
             )
@@ -89,7 +87,7 @@ class NodeLinter(linter.Linter):
                 return True, local_cmd
 
         if self.settings.get('disable_if_not_dependency', False):
-            logger.info(
+            self.logger.info(
                 "Skipping '{}' since it is not installed locally.\n"
                 "You can change this behavior by setting 'disable_if_not_dependency' to 'false'."
                 .format(self.name)
@@ -124,7 +122,7 @@ class NodeLinter(linter.Linter):
                 try:
                     manifest = read_json_file(manifest_file)
                 except Exception as err:
-                    logger.warning(
+                    self.logger.warning(
                         "We found a 'package.json' at {}; however, reading it raised\n  {}"
                         .format(path, str(err))
                     )
@@ -139,7 +137,7 @@ class NodeLinter(linter.Linter):
                     pass
                 else:
                     if not os.path.exists(os.path.join(path, 'node_modules', '.bin')):
-                        logger.warning(
+                        self.logger.warning(
                             "We want to execute 'node {}'; but you should first "
                             "'npm install' this project.".format(script)
                         )
@@ -151,7 +149,7 @@ class NodeLinter(linter.Linter):
                         self.context['project_root'] = path
                         return [node_binary, script]
 
-                    logger.warning(
+                    self.logger.warning(
                         "We want to execute 'node {}'; however, finding a node executable "
                         "failed.".format(script)
                     )
@@ -173,7 +171,7 @@ class NodeLinter(linter.Linter):
                         if yarn_binary:
                             return [yarn_binary, 'run', '--silent', npm_name]
 
-                        logger.warning(
+                        self.logger.warning(
                             "This seems like a Yarn PnP project. However, finding "
                             "a Yarn executable failed. Make sure to install Yarn first."
                         )
@@ -190,7 +188,7 @@ class NodeLinter(linter.Linter):
                             return executable
 
                     package_lock_exists = os.path.exists(os.path.join(path, 'package-lock.json'))
-                    logger.warning(
+                    self.logger.warning(
                         "Skipping '{}' for now which is listed as a {} "
                         "in {} but not installed.  Forgot to '{} install'?"
                         .format(
@@ -216,7 +214,7 @@ class NodeLinter(linter.Linter):
                 if isinstance(result, util.popen_output)
                 else result
             ):
-                logger.warning(
+                self.logger.warning(
                     "We did execute 'yarn run --silent {0}' but "
                     "'{0}' cannot be found.  Forgot to 'yarn install'?"
                     .format(npm_name)

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -1,7 +1,6 @@
 """This module exports the PythonLinter subclass of Linter."""
 
 from functools import lru_cache
-import logging
 import os
 import re
 
@@ -11,9 +10,6 @@ from .. import linter, util
 
 if False:
     from typing import List, Optional, Tuple, Union
-
-
-logger = logging.getLogger(__name__)
 
 
 class PythonLinter(linter.Linter):
@@ -40,7 +36,7 @@ class PythonLinter(linter.Linter):
         # `python` can be number or a string. If it is a string it should
         # point to a python environment, NOT a python binary.
         python = self.settings.get('python', None)
-        logger.info(
+        self.logger.info(
             "{}: wanted python is '{}'".format(self.name, python)
         )
 
@@ -51,7 +47,7 @@ class PythonLinter(linter.Linter):
             if VERSION_RE.match(python):
                 python_bin = find_python_version(python)
                 if python_bin is None:
-                    logger.error(
+                    self.logger.error(
                         "{} deactivated, cannot locate '{}' "
                         "for given python '{}'"
                         .format(self.name, cmd_name, python)
@@ -59,7 +55,7 @@ class PythonLinter(linter.Linter):
                     # Do not fallback, user specified something we didn't find
                     return True, None
 
-                logger.info(
+                self.logger.info(
                     "{}: Using '{}' for given python '{}'"
                     .format(self.name, python_bin, python)
                 )
@@ -67,7 +63,7 @@ class PythonLinter(linter.Linter):
 
             else:
                 if not os.path.exists(python):
-                    logger.error(
+                    self.logger.error(
                         "{} deactivated, cannot locate '{}'"
                         .format(self.name, python)
                     )
@@ -80,7 +76,7 @@ class PythonLinter(linter.Linter):
         # experience. So we kick in some 'magic'
         executable = self._ask_pipenv(cmd_name)
         if executable:
-            logger.info(
+            self.logger.info(
                 "{}: Using {} according to 'pipenv'"
                 .format(self.name, executable)
             )
@@ -89,14 +85,14 @@ class PythonLinter(linter.Linter):
         # Should we try a `pyenv which` as well? Problem: I don't have it,
         # it's MacOS only.
 
-        logger.info(
+        self.logger.info(
             "{}: trying to use globally installed {}"
             .format(self.name, cmd_name)
         )
         # fallback, similiar to a which(cmd)
         executable = util.which(cmd_name)
         if executable is None:
-            logger.warning(
+            self.logger.warning(
                 "cannot locate '{}'. Fill in the 'python' or "
                 "'executable' setting."
                 .format(self.name)
@@ -122,7 +118,7 @@ class PythonLinter(linter.Linter):
 
         executable = find_script_by_python_env(venv, linter_name)
         if not executable:
-            logger.info(
+            self.logger.info(
                 "{} is not installed in the virtual env at '{}'."
                 .format(linter_name, venv)
             )

--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -1,15 +1,11 @@
 """This module exports the RubyLinter subclass of Linter."""
 
-import logging
 import os
 import re
 import shlex
 import sublime
 
 from .. import linter, util
-
-
-logger = logging.getLogger(__name__)
 
 
 CMD_RE = re.compile(r'(?P<gem>.+?)@ruby')
@@ -65,7 +61,7 @@ class RubyLinter(linter.Linter):
 
         if not rbenv and not ruby:
             msg = "{} deactivated, cannot locate ruby, rbenv or rvm-auto-ruby".format(self.name)
-            logger.warning(msg)
+            self.logger.warning(msg)
             return True, None
 
         if isinstance(cmd, str):
@@ -94,7 +90,7 @@ class RubyLinter(linter.Linter):
                     ruby_cmd = [ruby, gem_path]
             else:
                 msg = '{} deactivated, cannot locate the gem \'{}\''.format(self.name, gem)
-                logger.warning(msg)
+                self.logger.warning(msg)
                 return True, None
         else:
             ruby_cmd = [ruby]

--- a/tests/test_command_generation.py
+++ b/tests/test_command_generation.py
@@ -203,14 +203,14 @@ class TestExecutableSetting(_BaseTestCase):
         linter = FakeLinter(self.view, settings)
         when(linter).notify_failure().thenReturn(None)
         when(util).which(...).thenReturn(None)
-        when(linter_module.logger).error(...)
+        when(linter.logger).error(...)
 
         try:
             linter.lint(INPUT, VIEW_UNCHANGED)
         except linter_module.PermanentError:
             pass
 
-        verify(linter_module.logger).error(
+        verify(linter.logger).error(
             contains(
                 "You set 'executable' to 'my_linter'.  "
                 "However, 'which my_linter' returned nothing.\n"
@@ -230,14 +230,14 @@ class TestExecutableSetting(_BaseTestCase):
         linter = FakeLinter(self.view, settings)
         when(linter).notify_failure().thenReturn(None)
         when(util).which(...).thenReturn(None)
-        when(linter_module.logger).error(...)
+        when(linter.logger).error(...)
 
         try:
             linter.lint(INPUT, VIEW_UNCHANGED)
         except linter_module.PermanentError:
             pass
 
-        verify(linter_module.logger).error(
+        verify(linter.logger).error(
             "You set 'executable' to '/usr/bin/my_linter'.  However, "
             "'/usr/bin/my_linter' does not exist or is not executable. "
         )
@@ -254,14 +254,14 @@ class TestExecutableSetting(_BaseTestCase):
         linter = FakeLinter(self.view, settings)
         when(linter).notify_failure().thenReturn(None)
         when(util).which(...).thenReturn(None)
-        when(linter_module.logger).error(...)
+        when(linter.logger).error(...)
 
         try:
             linter.lint(INPUT, VIEW_UNCHANGED)
         except linter_module.PermanentError:
             pass
 
-        verify(linter_module.logger).error(
+        verify(linter.logger).error(
             contains(
                 "You set 'executable' to ['my_interpreter', 'my_linter'].  "
                 "However, 'which my_interpreter' returned nothing.\n"
@@ -281,14 +281,14 @@ class TestExecutableSetting(_BaseTestCase):
         linter = FakeLinter(self.view, settings)
         when(linter).notify_failure().thenReturn(None)
         when(util).which(...).thenReturn(None)
-        when(linter_module.logger).error(...)
+        when(linter.logger).error(...)
 
         try:
             linter.lint(INPUT, VIEW_UNCHANGED)
         except linter_module.PermanentError:
             pass
 
-        verify(linter_module.logger).error(
+        verify(linter.logger).error(
             "You set 'executable' to ['/usr/bin/my_interpreter', 'my_linter'].  "
             "However, '/usr/bin/my_interpreter' does not exist or is not executable. "
         )
@@ -466,14 +466,14 @@ class TestWorkingDirSetting(_BaseTestCase):
         when('os.path').isdir(dir).thenReturn(False)
 
         linter = FakeLinter(self.view, settings)
-        with expect(linter_module.logger).error(
+        with expect(linter.logger).error(
             "{}: wanted working_dir '{}' is not a directory".format('fakelinter', dir)
         ):
             actual = linter.get_working_dir()
 
             # Looks like we're using an outdated version of mockito,
             # which does not automatically verify on `__exit__`.
-            verifyNoUnwantedInteractions(linter_module.logger)
+            verifyNoUnwantedInteractions(linter.logger)
 
         self.assertEqual(None, actual)
 

--- a/tests/test_filter_results.py
+++ b/tests/test_filter_results.py
@@ -152,8 +152,8 @@ class TestPostFilterResults(_BaseTestCase):
             """)
 
         when(linter)._communicate(...).thenReturn(OUTPUT)
-        expect(linter_module.logger, times=1).error(message)
+        expect(linter.logger, times=1).error(message)
         execute_lint_task(linter, INPUT)
         # `execute_lint_task` eats all uncatched errors, so we check again
         # to get faster and nicer output during the test
-        verifyNoUnwantedInteractions(linter_module.logger)
+        verifyNoUnwantedInteractions(linter.logger)

--- a/tests/test_linter_validity.py
+++ b/tests/test_linter_validity.py
@@ -330,19 +330,19 @@ class TestRegexCompiling(DeferrableTestCase):
         OUTPUT = """\
         errrrors
         """
-        when(linter_module.logger).error(...).thenReturn(None)
 
         linter_class = def_linter()
         view = self.create_view(sublime.active_window())
         linter = linter_class(view, {})
         when(util).which('foo').thenReturn('foo.exe')
         when(linter)._communicate(...).thenReturn(OUTPUT)
+        when(linter.logger).error(...).thenReturn(None)
 
         try:
             linter.lint(INPUT, lambda: False)
         except Exception:
             pass
 
-        verify(linter_module.logger).error(
+        verify(linter.logger).error(
             contains("'self.regex' is not defined.")
         )

--- a/tests/test_node_linter.py
+++ b/tests/test_node_linter.py
@@ -78,12 +78,12 @@ class TestNodeLinters(DeferrableTestCase):
     def test_not_globally_installed_warn(self):
         linter = make_fake_linter(self.view)
 
-        when(linter_module.logger).warning(...).thenReturn(None)
+        when(linter.logger).warning(...).thenReturn(None)
 
         cmd = linter.get_cmd()
         self.assertEqual(cmd, None)
 
-        verify(linter_module.logger).warning(...)
+        verify(linter.logger).warning(...)
 
     @p.expand([
         ('/p',),
@@ -158,7 +158,7 @@ class TestNodeLinters(DeferrableTestCase):
         linter = make_fake_linter(self.view)
 
         when(linter).notify_failure().thenReturn(None)
-        when(node_linter.logger).warning(
+        when(linter.logger).warning(
             contains(
                 "We found a 'package.json' at {}; however, reading it raised"
                 .format(ROOT_DIR)
@@ -173,7 +173,7 @@ class TestNodeLinters(DeferrableTestCase):
         except linter_module.PermanentError:
             pass
 
-        verify(node_linter.logger).warning(...)
+        verify(linter.logger).warning(...)
         verify(linter).notify_failure()
 
     @p.expand([
@@ -203,7 +203,7 @@ class TestNodeLinters(DeferrableTestCase):
         linter = make_fake_linter(self.view)
 
         when(linter).notify_failure().thenReturn(None)
-        when(node_linter.logger).warning(
+        when(linter.logger).warning(
             "Skipping 'mylinter' for now which is listed as a {} in {} but "
             "not installed.  Forgot to '{} install'?"
             .format(DEPENDENCY_TYPE, PRESENT_PACKAGE_FILE, EXPECTED_PACKAGE_MANAGER)
@@ -222,7 +222,7 @@ class TestNodeLinters(DeferrableTestCase):
         except linter_module.PermanentError:
             pass
 
-        verify(node_linter.logger).warning(...)
+        verify(linter.logger).warning(...)
         verify(linter).notify_failure()
 
     @p.expand([
@@ -262,7 +262,7 @@ class TestNodeLinters(DeferrableTestCase):
         linter = make_fake_linter(self.view)
 
         when(linter).notify_failure().thenReturn(None)
-        when(node_linter.logger).warning(
+        when(linter.logger).warning(
             "We want to execute 'node {}'; but you should first 'npm install' "
             "this project."
             .format(SCRIPT_FILE)
@@ -277,7 +277,7 @@ class TestNodeLinters(DeferrableTestCase):
         except linter_module.PermanentError:
             pass
 
-        verify(node_linter.logger).warning(...)
+        verify(linter.logger).warning(...)
         verify(linter).notify_failure()
 
     @p.expand([
@@ -293,7 +293,7 @@ class TestNodeLinters(DeferrableTestCase):
         linter = make_fake_linter(self.view)
 
         when(linter).notify_failure().thenReturn(None)
-        when(node_linter.logger).warning(
+        when(linter.logger).warning(
             "We want to execute 'node {}'; however, finding a node executable failed."
             .format(SCRIPT_FILE)
         ).thenReturn(None)
@@ -309,7 +309,7 @@ class TestNodeLinters(DeferrableTestCase):
         except linter_module.PermanentError:
             pass
 
-        verify(node_linter.logger).warning(...)
+        verify(linter.logger).warning(...)
         verify(linter).notify_failure()
 
     @p.expand([
@@ -370,7 +370,7 @@ class TestNodeLinters(DeferrableTestCase):
         linter = make_fake_linter(self.view)
 
         when(linter).notify_failure().thenReturn(None)
-        when(node_linter.logger).warning(
+        when(linter.logger).warning(
             "This seems like a Yarn PnP project. However, finding "
             "a Yarn executable failed. Make sure to install Yarn first."
         ).thenReturn(None)
@@ -387,7 +387,7 @@ class TestNodeLinters(DeferrableTestCase):
         except linter_module.PermanentError:
             pass
 
-        verify(node_linter.logger).warning(...)
+        verify(linter.logger).warning(...)
         verify(linter).notify_failure()
 
     @p.expand([
@@ -402,7 +402,7 @@ class TestNodeLinters(DeferrableTestCase):
         linter = make_fake_linter(self.view)
 
         when(linter).notify_failure().thenReturn(None)
-        when(node_linter.logger).warning(
+        when(linter.logger).warning(
             "We did execute 'yarn run --silent mylinter' but "
             "'mylinter' cannot be found.  Forgot to 'yarn install'?"
         ).thenReturn(None)
@@ -421,7 +421,7 @@ class TestNodeLinters(DeferrableTestCase):
         except linter_module.PermanentError:
             pass
 
-        verify(node_linter.logger).warning(...)
+        verify(linter.logger).warning(...)
         verify(linter).notify_failure()
 
     def test_disable_if_not_dependency(self):
@@ -429,14 +429,14 @@ class TestNodeLinters(DeferrableTestCase):
         linter.settings['disable_if_not_dependency'] = True
 
         when(linter).notify_unassign().thenReturn(None)
-        when(node_linter.logger).info(...).thenReturn(None)
+        when(linter.logger).info(...).thenReturn(None)
 
         try:
             linter.get_cmd()
         except linter_module.PermanentError:
             pass
 
-        verify(node_linter.logger).info(
+        verify(linter.logger).info(
             "Skipping 'fakelinter' since it is not installed locally.\nYou "
             "can change this behavior by setting 'disable_if_not_dependency' "
             "to 'false'."

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -764,7 +764,7 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         self.set_buffer_content(INPUT)
         when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
-        when(linter_module.logger).warning(...)
+        when(linter.logger).warning(...)
 
         result = execute_lint_task(linter, INPUT)
         drop_info_keys(result)
@@ -822,7 +822,7 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
 
-        with expect(linter_module.logger, times=1).warning(
+        with expect(linter.logger, times=1).warning(
             "Reported line '{}' is not within the code we're linting.\n"
             "Maybe the linter reports problems from multiple files "
             "or `line_col_base` is not set correctly."
@@ -832,7 +832,7 @@ class TestRegexBasedParsing(_BaseTestCase):
 
             # Looks like we're using an outdated version of mockito,
             # which does not automatically verify on `__exit__`.
-            verifyNoUnwantedInteractions(linter_module.logger)
+            verifyNoUnwantedInteractions(linter.logger)
 
     @p.expand([
         ((0, 0), "0\n1", "stdin:0:1 ERROR: The message"),
@@ -848,11 +848,11 @@ class TestRegexBasedParsing(_BaseTestCase):
         linter.line_col_base = LINE_COL_BASE
 
         when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
-        when(linter_module.logger).warning(...)
+        when(linter.logger).warning(...)
 
         execute_lint_task(linter, INPUT)
 
-        verify(linter_module.logger, times=0).warning(...)
+        verify(linter.logger, times=0).warning(...)
 
     @p.expand([
         (FakeLinter, "0123456789", "stdin:1:1 ERROR: The message"),
@@ -971,7 +971,7 @@ class TestRegexBasedParsing(_BaseTestCase):
         linter = self.create_linter(FakeLinterCaptureFilename)
         when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
 
-        with expect(linter_module.logger, times=1).warning(...):
+        with expect(linter.logger, times=1).warning(...):
             execute_lint_task(linter, INPUT)
 
     def test_ensure_errors_from_other_files_have_correct_regions(self):


### PR DESCRIPTION
For convenience, add a `self.logger` to all linter classes so that users
don't have to `import logging; logger = ...` at their plugins.

Especially setting the correct namespace for the logger was difficult
for end-users, and I always had to lead them in the right direction.

Note that we also use this namespaced logger within our code finally
as the "logging" approach has been quiet succeful.
