### PR TITLE
Raise `PermanentError` if no executable can be found

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1112,9 +1112,9 @@ class Linter(metaclass=LinterMeta):
             output = self.run(None, code)  # type: Union[str, util.popen_output]
         else:
             cmd = self.get_cmd()
-            if not cmd:  # We couldn't find an executable
+            if not cmd:
                 self.notify_failure()
-                return []
+                raise PermanentError("couldn't find an executable")
 
             output = self.run(cmd, code)
 

--- a/tests/test_command_generation.py
+++ b/tests/test_command_generation.py
@@ -679,7 +679,7 @@ class TestContextSensitiveExecutablePathContract(_BaseTestCase):
         linter = FakeLinter(self.view, {})
         when(linter).context_sensitive_executable_path(...).thenReturn((True, None))
 
-        with expect(linter, times=0)._communicate(...):
+        with self.assertRaises(linter_module.PermanentError):
             linter.lint(INPUT, VIEW_UNCHANGED)
 
     def test_returns_false_and_any_indicates_fallback(self):


### PR DESCRIPTION
Returning `[]`, the empty list, is conceptually wrong as it also denotes
a "green" view.  Raise here because we can't continue, the backend will
catch it and do the right thing, for example erase all squiggles.