### PR TITLE
Fix `MULTILINES` regex to also match "\n\n"

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -66,7 +66,7 @@ SOME_WS = re.compile(r'\s')
 FALLBACK_MARK_STYLE = 'outline'
 
 WS_ONLY = re.compile(r'^\s+$')
-MULTILINES = re.compile('\n(?=.)')
+MULTILINES = re.compile('(?s)\n(?=.)')
 
 # Sublime >= 4074 supports underline styles on white space
 # https://github.com/sublimehq/sublime_text/issues/137


### PR DESCRIPTION
We want to catch errors on multiple lines, t.i. the string contains a
`\n` plus *any* other character (the `.`) including other newline chars
(`(?s)`).

Note: We don't just look for a single `\n` because linters might report
exactly on the EOL position.