### PR TITLE
Add shellcheck ignore action

### DIFF
--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -454,34 +454,6 @@ def fix_shellcheck_error(error, view):
         )
     )
 
-
-@quick_actions_for("shellcheck")
-def shellcheck_goto_documentation(errors, view):
-    # type: (List[LintError], Optional[sublime.View]) -> Iterator[QuickAction]
-    if view:
-        region = view.sel()[0]
-
-        for error in errors:
-            match = re.search(SHELLCHECK_CODE_PATTERN, error["msg"])
-
-            code = match.groups("code")[0];
-
-            yield QuickAction(
-                "shellcheck: Open documentation — {}".format(error['msg']),
-                # partial(eslint_ignore_block, errors, region),
-                partial(shellcheck_open_documentation_in_browser, code, region),
-                "",
-                solves=[]
-            )
-
-def shellcheck_open_documentation_in_browser(errorCode, region, view):
-    # type: (List[LintError], sublime.Region, sublime.View) -> Iterator[TextRange]
-    webbrowser.open_new_tab("https://github.com/koalaman/shellcheck/wiki/{}".format(errorCode))
-
-    # return generator without any text commands
-    return
-    yield
-
 def line_from_point(view, pt):
     # type: (sublime.View, int) -> TextRange
     line_region = view.line(pt)

--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -431,8 +431,6 @@ def fix_mypy_error(error, view):
         )
     )
 
-SHELLCHECK_CODE_PATTERN=r"\[(?P<code>SC\d+)\]$"
-
 @ignore_rules_inline("shellcheck")
 def fix_shellcheck_error(error, view):
     # type: (LintError, sublime.View) -> Iterator[TextRange]

--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from functools import partial
 from itertools import chain
-import webbrowser
 import re
 
 import sublime
@@ -431,6 +430,10 @@ def fix_mypy_error(error, view):
         )
     )
 
+
+SHELLCHECK_CODE_PATTERN=r"\[(?P<code>SC\d+)\]$"
+
+
 @ignore_rules_inline("shellcheck")
 def fix_shellcheck_error(error, view):
     # type: (LintError, sublime.View) -> Iterator[TextRange]
@@ -451,6 +454,7 @@ def fix_shellcheck_error(error, view):
             line
         )
     )
+
 
 def line_from_point(view, pt):
     # type: (sublime.View, int) -> TextRange

--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -431,7 +431,7 @@ def fix_mypy_error(error, view):
     )
 
 
-SHELLCHECK_CODE_PATTERN=r"\[(?P<code>SC\d+)\]$"
+SHELLCHECK_CODE_PATTERN = r"\[(?P<code>SC\d+)\]$"
 
 
 @ignore_rules_inline("shellcheck")

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -13,6 +13,7 @@ from SublimeLinter.lint.quick_fix import (
     fix_flake8_error,
     fix_mypy_error,
     fix_stylelint_error,
+    fix_shellcheck_error,
     ignore_rules_actions,
 
 
@@ -353,7 +354,7 @@ class TestIgnoreFixers(DeferrableTestCase):
         BEFORE, POS = "".join(BEFORE.split("|")), BEFORE.index("|")
         view.run_command("insert", {"characters": BEFORE})
         error = dict(code="SC2154", region=sublime.Region(POS))
-        edit = fix_eslint_error(error, view)
+        edit = fix_shellcheck_error(error, view)
         apply_edits(view, edit)
         view_content = view.substr(sublime.Region(0, view.size()))
         self.assertEquals(AFTER, view_content)

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -344,11 +344,11 @@ class TestIgnoreFixers(DeferrableTestCase):
         ),
         (
             "add to existing rule",
-            "# shellcheck disable=SC2154\nr|esult=$variable"
+            "# shellcheck disable=SC2154\nr|esult=$variable",
             "# shellcheck disable=SC2154,SC2154\nresult=$variable"
         ),
     ])
-    def test_eslint(self, _description, BEFORE, AFTER):
+    def test_shellcheck(self, _description, BEFORE, AFTER):
         view = self.create_view(self.window)
         BEFORE, POS = "".join(BEFORE.split("|")), BEFORE.index("|")
         view.run_command("insert", {"characters": BEFORE})

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -345,15 +345,15 @@ class TestIgnoreFixers(DeferrableTestCase):
         ),
         (
             "add to existing rule",
-            "# shellcheck disable=SC2154\nr|esult=$variable",
-            "# shellcheck disable=SC2154,SC2154\nresult=$variable"
+            "# shellcheck disable=SC2034\nr|esult=$variable",
+            "# shellcheck disable=SC2034,SC2154\nresult=$variable"
         ),
     ])
     def test_shellcheck(self, _description, BEFORE, AFTER):
         view = self.create_view(self.window)
         BEFORE, POS = "".join(BEFORE.split("|")), BEFORE.index("|")
         view.run_command("insert", {"characters": BEFORE})
-        error = dict(code="SC2154", region=sublime.Region(POS))
+        error = dict(msg="variable is referenced but not assigned. [SC2154]", region=sublime.Region(POS))
         edit = fix_shellcheck_error(error, view)
         apply_edits(view, edit)
         view_content = view.substr(sublime.Region(0, view.size()))

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -335,3 +335,25 @@ class TestIgnoreFixers(DeferrableTestCase):
         apply_edits(view, edit)
         view_content = view.substr(sublime.Region(0, view.size()))
         self.assertEquals(AFTER, view_content)
+
+    @p.expand([
+        (
+            "clean line",
+            "r|esult=$variable",
+            "# shellcheck disable=SC2154\nresult=$variable"
+        ),
+        (
+            "add to existing rule",
+            "# shellcheck disable=SC2154\nr|esult=$variable"
+            "# shellcheck disable=SC2154,SC2154\nresult=$variable"
+        ),
+    ])
+    def test_eslint(self, _description, BEFORE, AFTER):
+        view = self.create_view(self.window)
+        BEFORE, POS = "".join(BEFORE.split("|")), BEFORE.index("|")
+        view.run_command("insert", {"characters": BEFORE})
+        error = dict(code="SC2154", region=sublime.Region(POS))
+        edit = fix_eslint_error(error, view)
+        apply_edits(view, edit)
+        view_content = view.substr(sublime.Region(0, view.size()))
+        self.assertEquals(AFTER, view_content)


### PR DESCRIPTION
Hi,
I stumbled upon the experimental QuickAction API that was introduced last year.
I really like the idea, because it can really improve SublimeLinter's usefulness. While for some languages, LSP is now the better choice, some linters are so simple that Quick Actions are easier implemented without a whole language server.

So as an experiment, I added shellcheck ignore + go to docs quick action to https://github.com/SublimeLinter/SublimeLinter-shellcheck

I would like to see this as an official API, although I guess the project has gone a bit quiet. Here are some suggestions:

- as far as I can see, only the ignore actions can be embedded into the popup as quick fix buttons. But I think it would also be useful to embed "go to documentation" and possibly other actions
- the embedded quick fixes need the option to set a name for the action. At the moment, it's just "⌦" which doesn't really tell you what will happen
- if additional quick actions are available, the popup should have a button at the bottom (next to "Copy") that opens the quick action panel
- the current implementation seems to assume that all quick actions use TextCommand. It's possible to not use it of course, but if this API was going public, quick actions should not be required to use a TextCommand
