### PR TITLE
Let codes within styles definitions be prefixes

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -93,7 +93,7 @@ a case-insensitive regex pattern, and then matched against the error type, code 
 
 .. note::
 
-    This will completely supress the matching errors. If you only want to visually demote some errors, take a look at the :ref:`styles <linter_styles>` section below.
+    This will completely suppress the matching errors. If you only want to visually demote some errors, take a look at the :ref:`styles <linter_styles>` section below.
 
 Some examples:
 

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -220,12 +220,15 @@ Example: this changes the appearance of whitespace warnings in flake8:
                         "mark_style": "outline",
                         "scope": "comment",
                         "icon": "none",
-                        "codes": ["W293", "W291", "W292"]
+                        "codes": ["W291", "W292", "W293"]
                     }
                 ]
             }
         }
     }
+
+Note `codes` are actually prefix matchers, so the above could be simplified to
+`["W29"]` or even `["W"]`.
 
 .. note::
 

--- a/lint/style.py
+++ b/lint/style.py
@@ -59,7 +59,7 @@ def get_value_(key, linter, code, error_type, default):
     linter_styles = persist.settings.get('linters', {}).get(linter, {}).get('styles', [])
     global_styles = persist.settings.get('styles', [])
     for style_definition in linter_styles:
-        if code in style_definition.get('codes', []):
+        if any(map(code.startswith, style_definition.get('codes', []))):
             try:
                 return style_definition[key]
             except KeyError:


### PR DESCRIPTION
If the user specifies `codes` in the linters `styles` section, handle
them as prefix matches.

E.g. let a `W2` match against `W290,W291,...`.

This makes sense as `codes` or rule names typically have some namespacy
or hierarchical form, like rubocops `layout/whitespace/line-ending` or
the typical eslint form: `<plugin-name>/<rule-name>`.

Doing this implicitly without requiring a special token, e.g. `W2*` or
something similar, simplifies the implementation to a one-liner.  It
may be good enough.