### PR TITLE
Add generic enabled switch

### DIFF
--- a/lint/const.py
+++ b/lint/const.py
@@ -1,4 +1,5 @@
 PROTECTED_REGIONS_KEY = "sublime_linter.protected_regions"
+IS_ENABLED_SWITCH = "SublimeLinter.enabled?"
 
 WARNING = "warning"
 ERROR = "error"

--- a/lint/settings.py
+++ b/lint/settings.py
@@ -2,6 +2,7 @@ import logging
 
 import sublime
 from . import events, util
+from .const import IS_ENABLED_SWITCH
 from jsonschema import validate, FormatChecker, ValidationError
 
 
@@ -150,7 +151,7 @@ def validate_project_settings(filename):
     sl_settings = {
         key: value
         for key, value in settings.items()
-        if key.startswith('SublimeLinter.')
+        if key.startswith('SublimeLinter.') and key != IS_ENABLED_SWITCH
     }
     if not sl_settings:
         util.clear_message()
@@ -164,9 +165,11 @@ def validate_project_settings(filename):
     if invalid_top_level_keys:
         logger.error(
             "Invalid settings in '{}':\n"
-            "Only 'SublimeLinter.linters.*' keys are allowed. "
-            "Got {}.".format(
+            "Only '{}' and 'SublimeLinter.linters.*' "
+            "keys are allowed. Got {}."
+            .format(
                 filename,
+                IS_ENABLED_SWITCH,
                 ', '.join(map(repr, invalid_top_level_keys))
             )
         )

--- a/lint/util.py
+++ b/lint/util.py
@@ -13,6 +13,7 @@ import threading
 
 import sublime
 from . import events
+from .const import IS_ENABLED_SWITCH
 
 
 MYPY = False
@@ -132,6 +133,10 @@ def is_lintable(view):
     being opened is in the Sublime Text packages directory.
 
     """
+    enabled = view.settings().get(IS_ENABLED_SWITCH)
+    if enabled is not None:
+        return enabled
+
     if (
         not view.window() or
         view.is_scratch() or

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -21,6 +21,7 @@ from .lint import queue
 from .lint import reloader
 from .lint import settings
 from .lint import util
+from .lint.const import IS_ENABLED_SWITCH
 from .lint.util import flash
 
 
@@ -356,9 +357,12 @@ def lint(view, view_has_changed, lock, reason):
 
     This function MUST run on a thread because it blocks!
     """
-    linters = list(elect.assignable_linters_for_view(view, reason))
-    if not linters:
-        logger.info("No installed linter matches the view.")
+    if view.settings().get(IS_ENABLED_SWITCH) is False:
+        linters = []
+    else:
+        linters = list(elect.assignable_linters_for_view(view, reason))
+        if not linters:
+            logger.info("No installed linter matches the view.")
 
     with lock:
         _assign_linters_to_view(view, {linter['name'] for linter in linters})


### PR DESCRIPTION
Fixes #1848
Fixes #545

Introduce a special key `SublimeLinter.enabled?` read from the view
settings which is a 3-state toggle (`null, true, false`).

This can be set to `True` for specific views as requested by #1848 to
"force" lintability of them.

On the other hand it could be set in the project settings, for example
to `False`, to toggle SublimeLinter off completely for that project.