### PR TITLE
Fix: Allow setting keys with funny suffixes

### DIFF
--- a/lint/linter.py
+++ b/lint/linter.py
@@ -626,7 +626,7 @@ class LinterMeta(type):
         for name, value in defaults.items():
             match = ARG_RE.match(name)
 
-            if match:
+            if match and match.group('prefix'):
                 name = match.group('name')
                 args_map[name] = match.groupdict()
 

--- a/tests/test_user_args_dsl.py
+++ b/tests/test_user_args_dsl.py
@@ -209,3 +209,23 @@ class TestArgsDSL(_BaseTestCase):
         linter = FakeLinterArgDSL(self.view, settings)
         with expect(linter)._communicate(['fake_linter_1'], ...):
             linter.lint(INPUT, VIEW_UNCHANGED)
+
+    @p.expand([
+        ('enabled?',),
+        ('funny+',),
+        ('not,so,fast',),
+        ('rude!',),
+    ])
+    def test_setting_names_which_are_not_args(self, arg):
+        # Docstring is here to get verbose parameterized printing
+        """"""
+        class FakeLinterArgDSL(Linter):
+            defaults = {
+                'selector': None,
+                arg: 42
+            }
+            cmd = 'fake_linter_1'
+
+        settings = linter_module.get_linter_settings(FakeLinterArgDSL, self.view)
+        linter = FakeLinterArgDSL(self.view, settings)
+        self.assertEqual(linter.settings.get(arg), 42)


### PR DESCRIPTION
Setting keys can have a special format and then SublimeLinter will
treat them as arguments to the linter binary.

The logic in `build_args` for this is that the setting must have a
prefix of either `@`, `-`, or `--`.  Unfortunately, we did not follow
this logic when building the linter class in `LinterMeta`, but instead
we threw away some settings.

E.g. `enabled?` does match our pretest regex because of the trailing
`?` but fails the later test because it has no prefix.

Fix this by testing for a prefix in `LinterMeta` as well.