### PR TITLE
Make `events.broadcast` thread aware

### DIFF
--- a/lint/events.py
+++ b/lint/events.py
@@ -22,7 +22,7 @@ def unsubscribe(topic, fn):
 
 
 def broadcast(topic, payload={}):
-    for fn in listeners.get(topic, []):
+    for fn in listeners.get(topic, []).copy():
         try:
             fn(**payload)
         except Exception:


### PR DESCRIPTION
If during `broadcast` we get new subscribers or loose some, `listeners`
changes throwing us out of the `for` loop.  That's usual so instead of
iterating over the "original" list just iterate over a copy of it.