### PR TITLE
Maint fixer code

### DIFF
--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -13,9 +13,10 @@ flatten = chain.from_iterable
 MYPY = False
 if MYPY:
     from typing import (
-        Callable, DefaultDict, Dict, Final, Iterable, Iterator, List,
+        Callable, DefaultDict, Dict, Iterable, Iterator, List,
         NamedTuple, Optional, Set, TypeVar, Union
     )
+    from typing_extensions import Final
     T = TypeVar("T")
     S = TypeVar("S")
     LintError = persist.LintError

--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -429,7 +429,23 @@ def fix_e266(error, view):
     )
 
 
-@ignore_rules_inline("mypy", except_for={"syntax"})
+@provide_fix_for("mypy", lambda e: e["msg"] == 'Unused "type: ignore" comment')
+def fix_mypy_unused_ignore(error, view):
+    # type: (LintError, sublime.View) -> Iterator[TextRange]
+    line = line_error_is_on(view, error)
+    match = re.search(r"\s*#\s*type:\s*ignore\[.+]", line.text)
+    if match:
+        a, b = match.span()
+        yield TextRange("", sublime.Region(line.range.a + a, line.range.a + b))
+
+
+@ignore_rules_inline(
+    "mypy",
+    except_for=lambda e: (
+        e.get("code") == "syntax"
+        or e["msg"] == 'Unused "type: ignore" comment'
+    )
+)
 def fix_mypy_error(error, view):
     # type: (LintError, sublime.View) -> Iterator[TextRange]
     line = line_error_is_on(view, error)

--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -440,7 +440,7 @@ def fix_shellcheck_error(error, view):
     # type: (LintError, sublime.View) -> Iterator[TextRange]
     line = line_error_is_on(view, error)
     match = re.search(SHELLCHECK_CODE_PATTERN, error["msg"])
-
+    assert match
     code = match.groups("code")[0]
 
     yield (

--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -76,7 +76,7 @@ def apply_edits(view, edits):
 
 if MYPY:
     Provider = Callable[[List[LintError], Optional[sublime.View]], Iterator[QuickAction]]
-    F = TypeVar("F", bound=Provider)
+    T_provider = TypeVar("T_provider", bound=Provider)
 
 PROVIDERS = defaultdict(
     dict
@@ -92,9 +92,9 @@ def namespacy_name(fn):
 
 
 def quick_actions_for(linter_name):
-    # type: (str) -> Callable[[F], F]
+    # type: (str) -> Callable[[T_provider], T_provider]
     def register(fn):
-        # type: (F) -> F
+        # type: (T_provider) -> T_provider
         ns_name = namespacy_name(fn)
         PROVIDERS[linter_name][ns_name] = fn
         fn.unregister = lambda: PROVIDERS[linter_name].pop(ns_name, None)  # type: ignore[attr-defined]

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -12,6 +12,7 @@ from SublimeLinter.lint.quick_fix import (
     eslint_ignore_block,
     fix_flake8_error,
     fix_mypy_error,
+    fix_mypy_unused_ignore,
     fix_stylelint_error,
     fix_shellcheck_error,
     ignore_rules_actions,
@@ -230,6 +231,22 @@ class TestIgnoreFixers(DeferrableTestCase):
         view.run_command("insert", {"characters": BEFORE})
         error = dict(code="no-idea", region=sublime.Region(4))
         edit = fix_mypy_error(error, view)
+        apply_edits(view, edit)
+        view_content = view.substr(sublime.Region(0, view.size()))
+        self.assertEquals(AFTER, view_content)
+
+    @p.expand([
+        (
+            "remove ignore comment at EOL",
+            "partial(fixer, error),  # type: ignore[arg-type]",
+            "partial(fixer, error),",
+        ),
+    ])
+    def test_mypy_unused_ignore(self, _description, BEFORE, AFTER):
+        view = self.create_view(self.window)
+        view.run_command("insert", {"characters": BEFORE})
+        error = dict(msg='Unused "type: ignore" comment', region=sublime.Region(4))
+        edit = fix_mypy_unused_ignore(error, view)
         apply_edits(view, edit)
         view_content = view.substr(sublime.Region(0, view.size()))
         self.assertEquals(AFTER, view_content)

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -87,7 +87,12 @@ class TestActionReducer(DeferrableTestCase):
         except_for = set()
 
         actions = ignore_rules_actions(
-            DEFAULT_SUBJECT, DEFAULT_DETAIL, except_for, fixer, ERRORS, None
+            DEFAULT_SUBJECT,
+            DEFAULT_DETAIL,
+            lambda e: not e["code"] or e["code"] in except_for,
+            fixer,
+            ERRORS,
+            None
         )
         self.assertEquals(RESULT, [action.description for action in actions])
 


### PR DESCRIPTION
- adds fixer for unused mypy ignore comment -- t.i. it removes the "type: ignore" comment in that case