### PR TITLE
Add fixer for `codespell`

### DIFF
--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -469,6 +469,17 @@ def fix_mypy_error(error, view):
     )
 
 
+def codespell_error_has_exactly_one_suggestion(error):
+    return len(error["msg"].split(" ==> ")[1].split(",")) == 1
+
+
+@provide_fix_for("codespell", when=codespell_error_has_exactly_one_suggestion)
+def fix_codespell_error(error, view):
+    # type: (LintError, sublime.View) -> Iterator[TextRange]
+    correction = error["msg"].split(" ==> ")[1]
+    yield TextRange(correction, error["region"])
+
+
 SHELLCHECK_CODE_PATTERN = r"\[(?P<code>SC\d+)\]$"
 
 

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -10,6 +10,7 @@ from SublimeLinter.lint.quick_fix import (
     apply_edits,
     fix_eslint_error,
     eslint_ignore_block,
+    fix_codespell_error,
     fix_flake8_error,
     fix_mypy_error,
     fix_mypy_unused_ignore,
@@ -247,6 +248,22 @@ class TestIgnoreFixers(DeferrableTestCase):
         view.run_command("insert", {"characters": BEFORE})
         error = dict(msg='Unused "type: ignore" comment', region=sublime.Region(4))
         edit = fix_mypy_unused_ignore(error, view)
+        apply_edits(view, edit)
+        view_content = view.substr(sublime.Region(0, view.size()))
+        self.assertEquals(AFTER, view_content)
+
+    @p.expand([
+        (
+            "replace word",
+            "# test crate",
+            "# test create",
+        ),
+    ])
+    def test_codespell(self, _description, BEFORE, AFTER):
+        view = self.create_view(self.window)
+        view.run_command("insert", {"characters": BEFORE})
+        error = dict(msg='crate  ==> create', region=sublime.Region(7, 12))
+        edit = fix_codespell_error(error, view)
         apply_edits(view, edit)
         view_content = view.substr(sublime.Region(0, view.size()))
         self.assertEquals(AFTER, view_content)


### PR DESCRIPTION
Usually our fixers are ignorers but codespell has no inline ignore function yet, so we actually fix the typos.  😎 