### PR TITLE
Pin `flake8<6.0.0`

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -25,4 +25,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - run: pip install "flake8<6.0.0"
     - uses: TrueBrain/actions-flake8@v2


### PR DESCRIPTION
flake8 (or pyflakes v3) decided to remove support for type comments so we have to pin our version here.

See https://github.com/PyCQA/pyflakes/issues/740