### PR TITLE
Convert bytes to string even for the empty case

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -212,8 +212,8 @@ def check_output(cmd, cwd=None):
     except Exception as err:
         import textwrap
         output_ = getattr(err, 'output', '')
+        output_ = process_popen_output(output_)
         if output_:
-            output_ = process_popen_output(output_)
             output_ = textwrap.indent(output_, '  ')
             output_ = "\n  ...\n{}".format(output_)
         logger.warning(


### PR DESCRIPTION
If we don't convert, the later `format` will coerce to the literal `b''`.  We don't want that but `''` (t.i. nothing) in the message.