### PR TITLE
Use correct import for PC events

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -49,7 +49,7 @@ def plugin_loaded():
     log_handler.install()
 
     try:
-        import package_control
+        import package_control.events
         if (
             package_control.events.install('SublimeLinter') or
             package_control.events.post_upgrade('SublimeLinter')


### PR DESCRIPTION
The previous way probably worked for PC3 but did not with the in-progress PC4 because the events module is not imported by `package_control/__init__.py`. Any consumers of a submodule should directly import that module, however, so I adjusted the import here.

Full tracebeck when using PC4 dev version:

```
Traceback (most recent call last):
  File "/opt/sublime_text/Lib/python33/sublime_plugin.py", line 528, in on_api_ready
    plc()
  File "/home/fichte/.config/sublime-text/Installed Packages/SublimeLinter.sublime-package/sublime_linter.py", line 54, in plugin_loaded
    package_control.events.install('SublimeLinter') or
AttributeError: 'module' object has no attribute 'events'
```

Edit: PC doesn't import the `events` module by default in [3.4.1](https://github.com/wbond/package_control/blob/8b947d227bfee2b514283e650c3f88c954ae1026/package_control/__init__.py) either, so this probably only ever worked by chance, e.g. another plugin importing it earlier.