### PR TITLE
Serialize squiggle side-effects on the UI thread

### DIFF
--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -72,6 +72,7 @@ def plugin_loaded():
     persist.kill_switch = False
     events.broadcast('plugin_loaded')
     persist.settings.load()
+    util.determine_thread_names()
     logger.info("debug mode: on")
     logger.info("version: " + util.get_sl_version())
 


### PR DESCRIPTION
Fixes #1891
Fixes sublimehq/sublime_text#5846

The idea of the code was to serialize the side-effects of drawing squiggles while on different threads.  The code wanted to protect the view effects (`[add|erase]_regions`) and our in-memory store of these regions (`CURRENTSTORE`).  Using a `threading.Lock` looked easy and convenient.

This didn't work out because the UI thread itself holds a lock on all views so that e.g. a `view.add_regions` waits for the UI thread to be available again.

Then we have the following scenario:

1. On the worker, we acquire our `StorageLock` because of e.g. new linter results.
2. The user edits and thus `on_modified` fires on the UI thread to `revalidate_regions`.  This implicitly locks the view.  We then try to acquire the `StorageLock`.  The intention was to just wait for (1) to complete, speed did not matter here.
3. On the worker we call `view.add_regions` which never returns because it awaits the (implicit) lock of the view.

In consequence we deadlock: (3) waits for (2), but (2) waits for (1).

The fix:

Remove the `Lock` and serialize all side-effects on the UI thread using tasks.  Use decorators to mark the essential functions.

- `@assert_on_ui_thread` marks the inner functions that used the `Lock` before.  It raises `RuntimeError`s if the functions are wrongly used on a different thread.

- `@ensure_on_ui_thread` lifts functions onto the UI thread if necessary.

Lifting the inner functions (the "edges") (e.g. `draw_view_region`) is too costly as we don't want to create possible hundred tasks on the UI for hundred squiggles to draw.  We also want them to be bundled, t.i. drawn at once.  Therefore the dev has to decide which upper function should be marked `ensure_on_ui_thread`.

I use a decorator here to lift the whole function because not lifting is an error.  T.i. I don't expect a legal call to e.g. `draw` from anything else than the UI thread.