### PR TITLE
Improve fixing unused mypy ignore comments

### DIFF
--- a/lint/quick_fix.py
+++ b/lint/quick_fix.py
@@ -433,7 +433,7 @@ def fix_e266(error, view):
 def fix_mypy_unused_ignore(error, view):
     # type: (LintError, sublime.View) -> Iterator[TextRange]
     line = line_error_is_on(view, error)
-    match = re.search(r"\s*#\s*type:\s*ignore\[.+]", line.text)
+    match = re.search(r"\s*#\s*type:\s*ignore(\[.+])?", line.text)
     if match:
         a, b = match.span()
         yield TextRange("", sublime.Region(line.range.a + a, line.range.a + b))

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -242,6 +242,11 @@ class TestIgnoreFixers(DeferrableTestCase):
             "partial(fixer, error),  # type: ignore[arg-type]",
             "partial(fixer, error),",
         ),
+        (
+            "remove bare ignore comment at EOL",
+            "partial(fixer, error),  # type: ignore",
+            "partial(fixer, error),",
+        ),
     ])
     def test_mypy_unused_ignore(self, _description, BEFORE, AFTER):
         view = self.create_view(self.window)

--- a/tests/test_ignore_fixers.py
+++ b/tests/test_ignore_fixers.py
@@ -14,6 +14,7 @@ from SublimeLinter.lint.quick_fix import (
     fix_flake8_error,
     fix_mypy_error,
     fix_mypy_unused_ignore,
+    fix_mypy_specific_unused_ignore,
     fix_stylelint_error,
     fix_shellcheck_error,
     ignore_rules_actions,
@@ -253,6 +254,32 @@ class TestIgnoreFixers(DeferrableTestCase):
         view.run_command("insert", {"characters": BEFORE})
         error = dict(msg='Unused "type: ignore" comment', region=sublime.Region(4))
         edit = fix_mypy_unused_ignore(error, view)
+        apply_edits(view, edit)
+        view_content = view.substr(sublime.Region(0, view.size()))
+        self.assertEquals(AFTER, view_content)
+
+    @p.expand([
+        (
+            "remove ignore comment at EOL 1",
+            "partial(fixer, error),  # type: ignore[arg-type, import, other]",
+            "partial(fixer, error),  # type: ignore[arg-type]",
+        ),
+        (
+            "remove ignore comment at EOL 2",
+            "partial(fixer, error),  # type: ignore[arg-type, other, import]",
+            "partial(fixer, error),  # type: ignore[arg-type]",
+        ),
+        (
+            "remove ignore comment at EOL 3",
+            "partial(fixer, error),  # type: ignore[other, import, arg-type]",
+            "partial(fixer, error),  # type: ignore[arg-type]",
+        ),
+    ])
+    def test_mypy_specific_unused_ignore(self, _description, BEFORE, AFTER):
+        view = self.create_view(self.window)
+        view.run_command("insert", {"characters": BEFORE})
+        error = dict(msg='Unused "type: ignore[import, other]" comment', region=sublime.Region(4))
+        edit = fix_mypy_specific_unused_ignore(error, view)
         apply_edits(view, edit)
         view_content = view.substr(sublime.Region(0, view.size()))
         self.assertEquals(AFTER, view_content)


### PR DESCRIPTION
E.g.

```
	some_code  # type: ignore          # < bare ignore all comment
	some_code  # type: ignore[import]  # <== what we already supported
```

```
	# type: ignore[attr-defined, import, other]
	# type: ignore[attr-defined]
```