### PR TITLE
Detect all Yarn projects, PnP or not

### DIFF
--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -214,12 +214,11 @@ class NodeLinter(linter.Linter):
 
                     self.logger.warning(
                         "Skipping '{}' for now which is listed as a {} "
-                        "in {} but not installed.  Forgot to '{} install'?"
+                        "in {} but not installed.  Forgot to 'npm install'?"
                         .format(
                             npm_name,
                             'dependency' if is_dep else 'devDependency',
-                            manifest_file,
-                            'npm'
+                            manifest_file
                         )
                     )
                     self.notify_failure()

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -57,7 +57,7 @@ def is_yarn_project(path, manifest):
         return name == 'yarn' or name == '@yarnpkg/berry'
 
     yarn_files = ['yarn.lock', '.yarnrc.yml', '.yarnrc']
-    if [file for file in yarn_files if os.path.exists(os.path.join(path, file))]:
+    if any(os.path.exists(os.path.join(path, file)) for file in yarn_files):
         return True
 
     return os.path.exists(os.path.join(path, 'node_modules', '.yarn-integrity'))

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -51,8 +51,10 @@ def is_yarn_project(path, manifest):
     # type: (str, Dict[str, Any]) -> bool
     package_manager = manifest.get('packageManager')
     if isinstance(package_manager, str):
-        name = package_manager.split('@')[0]
-        return name == 'yarn'
+        # When this field was being adopted and hadn't been standardised yet
+        # package managers could have scoped names, i.e. `@<scope>/<package>`
+        name = package_manager.rsplit('@', 1)[0]
+        return name == 'yarn' or name == '@yarnpkg/berry'
 
     yarn_files = ['yarn.lock', '.yarnrc.yml', '.yarnrc']
     if [file for file in yarn_files if os.path.exists(os.path.join(path, file))]:

--- a/tests/test_node_linter.py
+++ b/tests/test_node_linter.py
@@ -177,27 +177,17 @@ class TestNodeLinters(DeferrableTestCase):
         verify(linter).notify_failure()
 
     @p.expand([
-        ('/p', {'dependencies': {'mylinter': '0.2'}}, 'dependency', False, False, 'npm'),
-        ('/p', {'dependencies': {'mylinter': '0.2'}}, 'dependency', False, True, 'npm'),
-        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, 'devDependency', False, False, 'npm'),
-        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, 'devDependency', False, True, 'npm'),
-        ('/p', {'dependencies': {'mylinter': '0.2'}}, 'dependency', True, False, 'yarn'),
-        ('/p', {'dependencies': {'mylinter': '0.2'}}, 'dependency', True, True, 'npm'),
-        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, 'devDependency', True, False, 'yarn'),
-        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, 'devDependency', True, True, 'npm'),
+        ('/p', {'dependencies': {'mylinter': '0.2'}}, 'dependency', 'npm'),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, 'devDependency', 'npm'),
     ])
     def test_uninstalled_local_dependency(
         self,
         ROOT_DIR,
         CONTENT,
         DEPENDENCY_TYPE,
-        HAS_YARN_LOCK,
-        HAS_PACKAGE_LOCK,
         EXPECTED_PACKAGE_MANAGER,
     ):
         PRESENT_PACKAGE_FILE = os.path.join(ROOT_DIR, 'package.json')
-        PACKAGE_LOCK_FILE = os.path.join(ROOT_DIR, 'package-lock.json')
-        YARN_LOCK_FILE = os.path.join(ROOT_DIR, 'yarn.lock')
 
         when(self.view).file_name().thenReturn('/p/a/f.js')
         linter = make_fake_linter(self.view)
@@ -211,10 +201,6 @@ class TestNodeLinters(DeferrableTestCase):
         exists = os.path.exists
         when(os.path).exists(...).thenAnswer(exists)
         when(os.path).exists(PRESENT_PACKAGE_FILE).thenReturn(True)
-        if HAS_YARN_LOCK:
-            when(os.path).exists(YARN_LOCK_FILE).thenReturn(True)
-        if HAS_PACKAGE_LOCK:
-            when(os.path).exists(PACKAGE_LOCK_FILE).thenReturn(True)
         when(node_linter).read_json_file(PRESENT_PACKAGE_FILE).thenReturn(CONTENT)
 
         try:
@@ -331,12 +317,26 @@ class TestNodeLinters(DeferrableTestCase):
         self.assertEqual(cmd, ['fake.exe'])
 
     @p.expand([
-        ('/p', {'dependencies': {'mylinter': '0.2'}, 'installConfig': {'pnp': True}}, False),
-        ('/p/a', {'devDependencies': {'mylinter': '0.2'}, 'installConfig': {'pnp': True}}, False),
-        ('/p', {'dependencies': {'mylinter': '0.2'}}, True),
-        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, True),
+        ('/p', {'dependencies': {'mylinter': '0.2'}, 'packageManager': 'yarn@3.5.0'}),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}, 'packageManager': 'yarn@3.5.0'}),
+        ('/p', {'dependencies': {'mylinter': '0.2'}}, True, False, False, False),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, True, False, False, False),
+        ('/p', {'dependencies': {'mylinter': '0.2'}}, False, True, False, False),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, False, True, False, False),
+        ('/p', {'dependencies': {'mylinter': '0.2'}}, False, False, True, False),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, False, False, True, False),
+        ('/p', {'dependencies': {'mylinter': '0.2'}}, False, False, False, True),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, False, False, False, True),
     ])
-    def test_installed_yarn_pnp_project(self, ROOT_DIR, CONTENT, PNP_JS_EXISTS):
+    def test_installed_yarn_project(
+        self,
+        ROOT_DIR,
+        CONTENT,
+        HAS_YARN_LOCK=False,
+        HAS_YARNRC_YML=False,
+        HAS_YARNRC=False,
+        HAS_YARN_INTEGRITY=False
+    ):
         PRESENT_PACKAGE_FILE = os.path.join(ROOT_DIR, 'package.json')
         YARN_BIN = '/path/to/yarn'
 
@@ -346,8 +346,10 @@ class TestNodeLinters(DeferrableTestCase):
         exists = os.path.exists
         when(os.path).exists(...).thenAnswer(exists)
         when(os.path).exists(PRESENT_PACKAGE_FILE).thenReturn(True)
-        when(os.path).exists(os.path.join(ROOT_DIR, 'yarn.lock')).thenReturn(True)
-        when(os.path).exists(os.path.join(ROOT_DIR, '.pnp.js')).thenReturn(PNP_JS_EXISTS)
+        when(os.path).exists(os.path.join(ROOT_DIR, 'yarn.lock')).thenReturn(HAS_YARN_LOCK)
+        when(os.path).exists(os.path.join(ROOT_DIR, '.yarnrc.yml')).thenReturn(HAS_YARNRC_YML)
+        when(os.path).exists(os.path.join(ROOT_DIR, '.yarnrc')).thenReturn(HAS_YARNRC)
+        when(os.path).exists(os.path.join(ROOT_DIR, 'node_modules', '.yarn-integrity')).thenReturn(HAS_YARN_INTEGRITY)
         when(shutil).which(...).thenReturn(None)
         when(shutil).which('yarn').thenReturn(YARN_BIN)
         when(node_linter).read_json_file(PRESENT_PACKAGE_FILE).thenReturn(CONTENT)
@@ -358,12 +360,17 @@ class TestNodeLinters(DeferrableTestCase):
         self.assertEqual(working_dir, ROOT_DIR)
 
     @p.expand([
-        ('/p', {'dependencies': {'mylinter': '0.2'}, 'installConfig': {'pnp': True}}),
-        ('/p/a', {'devDependencies': {'mylinter': '0.2'}, 'installConfig': {'pnp': True}}),
+        ('/p', {'dependencies': {'mylinter': '0.2'}, 'packageManager': 'yarn@3.5.0'}),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}, 'packageManager': 'yarn@3.5.0'}),
         ('/p', {'dependencies': {'mylinter': '0.2'}}, True),
         ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, True),
     ])
-    def test_yarn_pnp_project_warn_no_yarn(self, ROOT_DIR, CONTENT, PNP_JS_EXISTS=False):
+    def test_yarn_project_warn_no_yarn(
+        self,
+        ROOT_DIR,
+        CONTENT,
+        HAS_YARN_LOCK=False
+    ):
         PRESENT_PACKAGE_FILE = os.path.join(ROOT_DIR, 'package.json')
 
         when(self.view).file_name().thenReturn('/p/a/f.js')
@@ -371,14 +378,13 @@ class TestNodeLinters(DeferrableTestCase):
 
         when(linter).notify_failure().thenReturn(None)
         when(linter.logger).warning(
-            "This seems like a Yarn PnP project. However, finding "
+            "This seems like a Yarn project. However, finding "
             "a Yarn executable failed. Make sure to install Yarn first."
         ).thenReturn(None)
         exists = os.path.exists
         when(os.path).exists(...).thenAnswer(exists)
         when(os.path).exists(PRESENT_PACKAGE_FILE).thenReturn(True)
-        when(os.path).exists(os.path.join(ROOT_DIR, 'yarn.lock')).thenReturn(True)
-        when(os.path).exists(os.path.join(ROOT_DIR, '.pnp.js')).thenReturn(PNP_JS_EXISTS)
+        when(os.path).exists(os.path.join(ROOT_DIR, 'yarn.lock')).thenReturn(HAS_YARN_LOCK)
         when(shutil).which(...).thenReturn(None)
         when(node_linter).read_json_file(PRESENT_PACKAGE_FILE).thenReturn(CONTENT)
 
@@ -394,7 +400,7 @@ class TestNodeLinters(DeferrableTestCase):
         ('/p', {'dependencies': {'mylinter': '0.2'}}),
         ('/p/a', {'devDependencies': {'mylinter': '0.2'}}),
     ])
-    def test_yarn_pnp_project_warn_not_completely_installed(self, ROOT_DIR, CONTENT):
+    def test_yarn_project_warn_not_completely_installed(self, ROOT_DIR, CONTENT):
         PRESENT_PACKAGE_FILE = os.path.join(ROOT_DIR, 'package.json')
         YARN_BIN = '/path/to/yarn'
 
@@ -410,7 +416,6 @@ class TestNodeLinters(DeferrableTestCase):
         when(os.path).exists(...).thenAnswer(exists)
         when(os.path).exists(PRESENT_PACKAGE_FILE).thenReturn(True)
         when(os.path).exists(os.path.join(ROOT_DIR, 'yarn.lock')).thenReturn(True)
-        when(os.path).exists(os.path.join(ROOT_DIR, '.pnp.js')).thenReturn(True)
         when(shutil).which(...).thenReturn(None)
         when(shutil).which('yarn').thenReturn(YARN_BIN)
         when(node_linter).read_json_file(PRESENT_PACKAGE_FILE).thenReturn(CONTENT)

--- a/tests/test_node_linter.py
+++ b/tests/test_node_linter.py
@@ -177,15 +177,14 @@ class TestNodeLinters(DeferrableTestCase):
         verify(linter).notify_failure()
 
     @p.expand([
-        ('/p', {'dependencies': {'mylinter': '0.2'}}, 'dependency', 'npm'),
-        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, 'devDependency', 'npm'),
+        ('/p', {'dependencies': {'mylinter': '0.2'}}, 'dependency'),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, 'devDependency'),
     ])
     def test_uninstalled_local_dependency(
         self,
         ROOT_DIR,
         CONTENT,
         DEPENDENCY_TYPE,
-        EXPECTED_PACKAGE_MANAGER,
     ):
         PRESENT_PACKAGE_FILE = os.path.join(ROOT_DIR, 'package.json')
 
@@ -195,8 +194,8 @@ class TestNodeLinters(DeferrableTestCase):
         when(linter).notify_failure().thenReturn(None)
         when(linter.logger).warning(
             "Skipping 'mylinter' for now which is listed as a {} in {} but "
-            "not installed.  Forgot to '{} install'?"
-            .format(DEPENDENCY_TYPE, PRESENT_PACKAGE_FILE, EXPECTED_PACKAGE_MANAGER)
+            "not installed.  Forgot to 'npm install'?"
+            .format(DEPENDENCY_TYPE, PRESENT_PACKAGE_FILE)
         ).thenReturn(None)
         exists = os.path.exists
         when(os.path).exists(...).thenAnswer(exists)

--- a/tests/test_node_linter.py
+++ b/tests/test_node_linter.py
@@ -319,6 +319,8 @@ class TestNodeLinters(DeferrableTestCase):
     @p.expand([
         ('/p', {'dependencies': {'mylinter': '0.2'}, 'packageManager': 'yarn@3.5.0'}),
         ('/p/a', {'devDependencies': {'mylinter': '0.2'}, 'packageManager': 'yarn@3.5.0'}),
+        ('/p', {'dependencies': {'mylinter': '0.2'}, 'packageManager': '@yarnpkg/berry@2'}),
+        ('/p/a', {'devDependencies': {'mylinter': '0.2'}, 'packageManager': '@yarnpkg/berry@2'}),
         ('/p', {'dependencies': {'mylinter': '0.2'}}, True, False, False, False),
         ('/p/a', {'devDependencies': {'mylinter': '0.2'}}, True, False, False, False),
         ('/p', {'dependencies': {'mylinter': '0.2'}}, False, True, False, False),


### PR DESCRIPTION
In its current form, SublimeLinter avoids calling Node's binary when invoking a linter installed with npm, preferring to run executables while relying on the implementation detail of the `node_modules` linker, i.e. `node_modules/.bin`. However, a Yarn PnP project (*de facto* any project not relying on [Node Resolution Algorithm](https://nodejs.org/api/modules.html#modules_all_together)) doesn't play well with this strategy due to using a different install mode to manage its dependencies. The algorithm used to determine whether a project used the PnP linker (#1649) relied on, among other things, existence of Yarn-specific files including a `.pnp.js` mapper. Recent versions of Yarn (since 3+) don't generate files with that extension anymore, having moved towards `.pnp.cjs` in tandem with `.pnp.loader.mjs` should the project require PnP API compatible with ESM. That part could be fixed by globbing `.pnp.*js` in about two lines of code. Continuing with this approach, however, has shortcomings:

- [a project may use a different install strategy e.g. pnpm](https://yarnpkg.com/advanced/rulebook#user-scripts-shouldnt-hardcode-the-node_modulesbin-folder)
- [`yarn.lock` might not be generated](https://yarnpkg.com/getting-started/qa#should-lockfiles-be-committed-to-the-repository)
- [the layout of `node_modules` might not always be the same](https://yarnpkg.com/advanced/rulebook#modules-shouldnt-hardcode-node_modules-paths-to-access-other-modules)

This PR aims to provide a better solution by not relying on implementation modules of various package resolution methods, hoisting etc. instead always calling Yarn regardless of linker used, effectively deferring executable lookup to the package manager.

The proposed algorithm relies on the following markers in order to determine whether the project is a Yarn-based project:
- [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) key in `package.json` containing `yarn`
- [`.yarn.lock`](https://yarnpkg.com/getting-started/qa#should-lockfiles-be-committed-to-the-repository)
- [`.yarnrc.yml`](https://yarnpkg.com/configuration/yarnrc) (Yarn >= 2)
- [`.yarnrc`](https://classic.yarnpkg.com/en/docs/yarnrc) (Yarn 1.x)
- `node_modules/.yarn-integrity` (veeeeery legacy, last resort)

See also: #1644