### PR TITLE
Use `shellenv` for proper environment handling

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,7 +1,8 @@
 {
     "*": {
         "*": [
-            "jsonschema"
+            "jsonschema",
+            "shellenv"
         ]
     }
 }

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -7,6 +7,7 @@ from itertools import chain
 import logging
 import os
 import re
+import shellenv
 import shlex
 import subprocess
 import tempfile
@@ -40,8 +41,8 @@ BASE_CLASSES = ('PythonLinter', 'RubyLinter', 'NodeLinter', 'ComposerLinter')
 # set as well.
 UTF8_ENV_VARS = {
     'PYTHONIOENCODING': 'utf8',
-    'LANG': 'en_US.UTF-8',
-    'LC_CTYPE': 'en_US.UTF-8',
+#     'LANG': 'en_US.UTF-8',
+#     'LC_CTYPE': 'en_US.UTF-8',
 }
 BASE_LINT_ENVIRONMENT = ChainMap(UTF8_ENV_VARS, os.environ)
 
@@ -1056,7 +1057,15 @@ class Linter(metaclass=LinterMeta):
                 .format(self.name)
             )
 
-        return ChainMap({}, self.settings.get('env', {}), self.env, BASE_LINT_ENVIRONMENT)
+        _, environment = shellenv.get_env()
+
+        return ChainMap(
+            {},
+            self.settings.get('env', {}),
+            self.env,
+            BASE_LINT_ENVIRONMENT,
+            environment,
+        )
 
     @classmethod
     def can_lint_view(cls, view, settings):

--- a/lint/util.py
+++ b/lint/util.py
@@ -6,10 +6,11 @@ import locale
 import logging
 import os
 import re
+import shellenv
 import shutil
 import subprocess
-import time
 import threading
+import time
 
 import sublime
 from . import events
@@ -232,7 +233,8 @@ def get_augmented_path():
         for path in persist.settings.get('paths', {}).get(sublime.platform(), [])
     ]  # type: List[str]
 
-    augmented_path = os.pathsep.join(paths + [os.environ['PATH']])
+    _, login_shell_paths = shellenv.get_path()
+    augmented_path = os.pathsep.join(paths + [os.environ['PATH']] + login_shell_paths)
     if logger.isEnabledFor(logging.INFO):
         debug_print_env(augmented_path)
     return augmented_path


### PR DESCRIPTION
Use `shellenv` for:

- searching executables in proper `$PATH`;
- spawn linters in proper environment.