### PR TITLE
Snake_case remaining commands

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -1017,7 +1017,7 @@ class TooltipController(sublime_plugin.EventListener):
                     open_tooltip(view, point, line_report=False)
 
 
-class SublimeLinterLineReportCommand(sublime_plugin.WindowCommand):
+class sublime_linter_line_report(sublime_plugin.WindowCommand):
     def run(self):
         view = self.window.active_view()
         if not view:

--- a/message_view.py
+++ b/message_view.py
@@ -10,7 +10,7 @@ def plugin_unloaded():
         window.destroy_output_panel(PANEL_NAME)
 
 
-class SublimeLinterDisplayPanelCommand(sublime_plugin.WindowCommand):
+class sublime_linter_display_panel(sublime_plugin.WindowCommand):
     def run(self, msg=""):
         window = self.window
 
@@ -37,7 +37,7 @@ class SublimeLinterDisplayPanelCommand(sublime_plugin.WindowCommand):
         window.run_command("show_panel", {"panel": OUTPUT_PANEL})
 
 
-class SublimeLinterRemovePanelCommand(sublime_plugin.WindowCommand):
+class sublime_linter_remove_panel(sublime_plugin.WindowCommand):
     def run(self):
         self.window.destroy_output_panel(PANEL_NAME)
 

--- a/panel_view.py
+++ b/panel_view.py
@@ -277,7 +277,7 @@ def toggle_panel_if_errors(window, filenames):
         window.run_command("hide_panel", {"panel": OUTPUT_PANEL})
 
 
-class SublimeLinterPanelToggleCommand(sublime_plugin.WindowCommand):
+class sublime_linter_panel_toggle(sublime_plugin.WindowCommand):
     def run(self):
         if panel_is_active(self.window):
             self.window.run_command("hide_panel", {"panel": OUTPUT_PANEL})

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -123,7 +123,7 @@ def on_settings_changed(settings, **kwargs):
         )
 
 
-class SublimeLinterReloadCommand(sublime_plugin.WindowCommand):
+class sublime_linter_reload(sublime_plugin.WindowCommand):
     def run(self):
         log_handler.uninstall()
         try:


### PR DESCRIPTION
For better navigation and search, all commands should be snake-cased
and without the `Command` suffix.  By doing so the class name and the
calling name, used in the key-bindings and as argument to `run_command`,
match.
