### PR TITLE
Hotfix how validator loads its schemas

### DIFF
--- a/vendor/jsonschema/_utils.py
+++ b/vendor/jsonschema/_utils.py
@@ -1,10 +1,8 @@
 import itertools
-import json
-import os
-import pkgutil
 import re
 
 from .compat import str_types, MutableMapping, urlsplit
+from .schemas import schemas
 
 
 class URIDict(MutableMapping):
@@ -51,14 +49,14 @@ class Unset(object):
 
 def load_schema(name):
     """
-    Load a schema from ./schemas/``name``.json and return it.
+    Load a schema from .schemas and return it.
+    Note: `schemas` used to be a resource folder with two json files.
+    Because we're in a zip file when jsonschema is vendored we can't load
+    these easily, hence these json files are now python modules with
+    dictionaries in it.
 
     """
-
-    fpath = os.path.join(os.path.dirname(__file__), "schemas", "{}.json".format(name))
-    with open(fpath, "r") as f:
-        data = f.read()
-    return json.loads(data)
+    return schemas[name]
 
 
 def indent(string, times=1):

--- a/vendor/jsonschema/schemas/__init__.py
+++ b/vendor/jsonschema/schemas/__init__.py
@@ -1,0 +1,7 @@
+from .draft3 import draft3
+from .draft4 import draft4
+
+schemas = {
+    "draft3": draft3,
+    "draft4": draft4,
+}

--- a/vendor/jsonschema/schemas/draft3.py
+++ b/vendor/jsonschema/schemas/draft3.py
@@ -1,4 +1,4 @@
-{
+draft3 = {
     "$schema": "http://json-schema.org/draft-03/schema#",
     "dependencies": {
         "exclusiveMaximum": "maximum",
@@ -71,25 +71,25 @@
                 "string",
                 "array"
             ],
-            "uniqueItems": true
+            "uniqueItems": True
         },
         "divisibleBy": {
             "default": 1,
-            "exclusiveMinimum": true,
+            "exclusiveMinimum": True,
             "minimum": 0,
             "type": "number"
         },
         "enum": {
             "minItems": 1,
             "type": "array",
-            "uniqueItems": true
+            "uniqueItems": True
         },
         "exclusiveMaximum": {
-            "default": false,
+            "default": False,
             "type": "boolean"
         },
         "exclusiveMinimum": {
-            "default": false,
+            "default": False,
             "type": "boolean"
         },
         "extends": {
@@ -170,7 +170,7 @@
             "type": "object"
         },
         "required": {
-            "default": false,
+            "default": False,
             "type": "boolean"
         },
         "title": {
@@ -190,10 +190,10 @@
                 "string",
                 "array"
             ],
-            "uniqueItems": true
+            "uniqueItems": True
         },
         "uniqueItems": {
-            "default": false,
+            "default": False,
             "type": "boolean"
         }
     },

--- a/vendor/jsonschema/schemas/draft4.py
+++ b/vendor/jsonschema/schemas/draft4.py
@@ -1,4 +1,4 @@
-{
+draft4 = {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "default": {},
     "definitions": {
@@ -40,7 +40,7 @@
             },
             "minItems": 1,
             "type": "array",
-            "uniqueItems": true
+            "uniqueItems": True
         }
     },
     "dependencies": {
@@ -113,14 +113,14 @@
         "enum": {
             "minItems": 1,
             "type": "array",
-            "uniqueItems": true
+            "uniqueItems": True
         },
         "exclusiveMaximum": {
-            "default": false,
+            "default": False,
             "type": "boolean"
         },
         "exclusiveMinimum": {
-            "default": false,
+            "default": False,
             "type": "boolean"
         },
         "format": {
@@ -166,7 +166,7 @@
             "type": "number"
         },
         "multipleOf": {
-            "exclusiveMinimum": true,
+            "exclusiveMinimum": True,
             "minimum": 0,
             "type": "number"
         },
@@ -211,12 +211,12 @@
                     },
                     "minItems": 1,
                     "type": "array",
-                    "uniqueItems": true
+                    "uniqueItems": True
                 }
             ]
         },
         "uniqueItems": {
-            "default": false,
+            "default": False,
             "type": "boolean"
         }
     },


### PR DESCRIPTION
Since we vendored jsonschema its resources can't be loaded like before anymore.  (That's because we're in a zip file usually.)

Just transform the resource json files into dicts in python modules to make it work.