### PR TITLE
Read `UI_THREAD_NAME` at import name

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -33,22 +33,19 @@ logger = logging.getLogger(__name__)
 STREAM_STDOUT = 1
 STREAM_STDERR = 2
 STREAM_BOTH = STREAM_STDOUT + STREAM_STDERR
-UI_THREAD_NAME = None  # type: Optional[str]
+
 ANSI_COLOR_RE = re.compile(r'\033\[[0-9;]*m')
 ERROR_PANEL_NAME = "SublimeLinter Messages"
 ERROR_OUTPUT_PANEL = "output." + ERROR_PANEL_NAME
+try:
+    UI_THREAD_NAME  # type: ignore[used-before-def]
+except NameError:
+    UI_THREAD_NAME: str = threading.current_thread().name
 
 
 @events.on('settings_changed')
 def on_settings_changed(settings, **kwargs):
     get_augmented_path.cache_clear()
-
-
-def determine_thread_names():
-    def callback():
-        global UI_THREAD_NAME
-        UI_THREAD_NAME = threading.current_thread().name
-    sublime.set_timeout(callback)
 
 
 def ensure_on_ui_thread(fn):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -72,7 +72,6 @@ def plugin_loaded():
     persist.kill_switch = False
     events.broadcast('plugin_loaded')
     persist.settings.load()
-    util.determine_thread_names()
     logger.info("debug mode: on")
     logger.info("version: " + util.get_sl_version())
 


### PR DESCRIPTION
Fixes #1937

Actually the `set_timeout` dance is not necessary as -- at least on the initial startup -- at import time of Sublime the current thread is the main thread.  Just initialize `UI_THREAD_NAME` as a side-effect of starting.