### PR TITLE
Resurrect `determine_thread_names`

### DIFF
--- a/lint/util.py
+++ b/lint/util.py
@@ -40,12 +40,19 @@ ERROR_OUTPUT_PANEL = "output." + ERROR_PANEL_NAME
 try:
     UI_THREAD_NAME  # type: ignore[used-before-def]
 except NameError:
-    UI_THREAD_NAME: str = threading.current_thread().name
+    UI_THREAD_NAME = None  # type: Optional[str]
 
 
 @events.on('settings_changed')
 def on_settings_changed(settings, **kwargs):
     get_augmented_path.cache_clear()
+
+
+def determine_thread_names():
+    def callback():
+        global UI_THREAD_NAME
+        UI_THREAD_NAME = threading.current_thread().name
+    sublime.set_timeout(callback)
 
 
 def ensure_on_ui_thread(fn):

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -72,6 +72,7 @@ def plugin_loaded():
     persist.kill_switch = False
     events.broadcast('plugin_loaded')
     persist.settings.load()
+    util.determine_thread_names()
     logger.info("debug mode: on")
     logger.info("version: " + util.get_sl_version())
 


### PR DESCRIPTION
Partially reverts commit ba0a43271bdcf2d7970f1e9492f2ab811dcaf00b.

To keep #1937 fixed, which was a reloading error, just skip initializing `UI_THREAD_NAME` on module-reload.