### PR TITLE
Set `__abstract__` on a linter class to not register it

### DIFF
--- a/lint/base_linter/composer_linter.py
+++ b/lint/base_linter/composer_linter.py
@@ -17,6 +17,7 @@ class ComposerLinter(linter.Linter):
     By doing so, they automatically get the following features:
 
     """
+    __abstract__ = True
 
     def __init__(self, view, settings):
         """Initialize a new ComposerLinter instance."""

--- a/lint/base_linter/node_linter.py
+++ b/lint/base_linter/node_linter.py
@@ -64,6 +64,7 @@ class NodeLinter(linter.Linter):
     By doing so, they automatically get the following features:
 
     """
+    __abstract__ = True
 
     def context_sensitive_executable_path(self, cmd):
         # type: (List[str]) -> Tuple[bool, Union[None, str, List[str]]]

--- a/lint/base_linter/python_linter.py
+++ b/lint/base_linter/python_linter.py
@@ -47,6 +47,7 @@ class PythonLinter(linter.Linter):
     - Searches and sets `project_root` which in turn affects which
       `working_dir` we will use (if not overridden by the user).
     """
+    __abstract__ = True
 
     config_file_names = (".flake8", "pytest.ini", ".pylintrc")
     """File or directory names that would count as marking the root of a project.

--- a/lint/base_linter/ruby_linter.py
+++ b/lint/base_linter/ruby_linter.py
@@ -21,6 +21,7 @@ class RubyLinter(linter.Linter):
     - Support for rbenv and rvm (via rvm-auto-ruby).
 
     """
+    __abstract__ = True
 
     def context_sensitive_executable_path(self, cmd):
         """

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -33,7 +33,6 @@ logger = logging.getLogger(__name__)
 
 
 ARG_RE = re.compile(r'(?P<prefix>@|--?)?(?P<name>[@\w][\w\-]*)(?:(?P<joiner>[=:])?(?:(?P<sep>.)(?P<multiple>\+)?)?)?')
-BASE_CLASSES = ('PythonLinter', 'RubyLinter', 'NodeLinter', 'ComposerLinter')
 
 # Many linters use stdin, and we convert text to utf-8
 # before sending to stdin, so we have to make sure stdin
@@ -466,10 +465,9 @@ class LinterMeta(type):
 
         Finally, the class is registered as a linter for its configured syntax.
         """
-        if not bases:
-            return
-
-        if cls_name in BASE_CLASSES:
+        cls.__abstract__ = is_abstract = attrs.get("__abstract__", False)
+        if is_abstract:
+            logger.debug(f"Skip abstract {cls_name}.")
             return
 
         name = attrs.get('name') or cls_name.lower()  # type: str  # type: ignore[assignment]
@@ -673,6 +671,7 @@ class Linter(metaclass=LinterMeta):
     Subclasses must at a minimum define the attributes syntax, cmd, and regex.
 
     """
+    __abstract__ = True
 
     #
     # Public attributes


### PR DESCRIPTION
We always hardcoded the base linter class names (in `BASE_CLASSES`). Make that proper by defining a class attribute.