### PR TITLE
Fix generator return value

### DIFF
--- a/lint/backend.py
+++ b/lint/backend.py
@@ -107,7 +107,7 @@ def tasks_per_linter(view, view_has_changed, linter_class, settings):
     # type: (sublime.View, ViewChangedFn, Type[Linter], LinterSettings) -> Iterator[Task[LintResult]]
     selector = settings.get('selector')
     if selector is None:
-        return []
+        return
 
     for region in extract_lintable_regions(view, selector):
         linter = linter_class(view, settings.clone())


### PR DESCRIPTION
That's a clear semantic misunderstanding from me.  The use-case of the return statement is to abort the generator.  In that case we don't return a "final value".