### PR TITLE
Add new setting enable_cells=False

### DIFF
--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -46,6 +46,21 @@ For both, Python and Node, SublimeLinter has sophisticated ways to find *locally
 
 When the `disable_if_not_dependency` setting is set to `true`, SublimeLinter will not attempt to use globally installed binaries if a local installation cannot be found. Instead, it will skip linting such projects altogether.
 
+enable_cells
+------------
+
+SublimeLinter is capable of linting just parts of a view if the whole file
+doesn't match a given "selector".  E.g. it can lint code blocks inside
+markdown documents.  By default, this is turned off as most linters don't have
+a good understanding of such sub-blocks -- let's call them cells, as in:
+notebook cells -- out of their box.
+
+Set `enable_cells` to `true` to opt-in.
+
+You may then also want to configure the linter itself, e.g. to use per-file
+overrides to only report whitespace errors or to exclude any unused-var
+warnings, etc for such files to mitigate false warnings.
+
 env
 ---
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -1100,13 +1100,17 @@ class Linter(metaclass=LinterMeta):
     def matches_selector(cls, view, settings):
         # type: (sublime.View, LinterSettings) -> bool
         selector = settings.get('selector', None)
-        if selector is not None:
-            return bool(
-                # Use `score_selector` here as well, so that empty views
-                # select their 'main' linters
-                view.score_selector(0, selector) or
-                view.find_by_selector(selector)
-            )
+        if selector is None:
+            return False
+
+        # Use `score_selector` so that empty views
+        # select their 'main' linters
+        if view.score_selector(0, selector):
+            return True
+
+        if settings.get("enable_cells", False):
+            return bool(view.find_by_selector(selector))
+
         return False
 
     @classmethod

--- a/messages.json
+++ b/messages.json
@@ -6,5 +6,6 @@
     "4.20.0": "messages/4.20.0.txt",
     "4.22.0": "messages/4.22.0.txt",
     "4.24.0": "messages/4.24.0.txt",
-    "4.25.0": "messages/4.25.0.txt"
+    "4.25.0": "messages/4.25.0.txt",
+    "4.26.0": "messages/4.26.0.txt"
 }

--- a/messages/4.26.0.txt
+++ b/messages/4.26.0.txt
@@ -1,0 +1,26 @@
+SublimeLinter 4.26.0
+
+BREAKING CHANGE:  TL;DR - By default, only whole files are linted from now on.
+
+SublimeLinter was always capable of linting just parts of a view if the whole
+file did not match a given "selector".  E.g. it could lint code blocks inside
+markdown documents.  There was no way to opt-out of this behavior, except
+maybe to use the `excludes` setting to exclude all `*.md` files, although most
+linters don't have a good understanding of such sub-blocks -- let's call them
+cells, as in: notebook cells.
+
+v4.26.0 introduces a new setting `enable_cells` which defaults to `False`
+(which makes it a breaking change).  Plugin authors can opt-in in their
+plugin, so can users, on a case-by-case basis.
+
+E.g. you could still let `flake8` run on python blocks in your docs if
+you want to but then probably also configure per-file overrides, e.g. to only
+report whitespace errors or to exclude any unused-var warnings, etc for them.
+
+
+
+Sincerely,
+💕
+
+
+Yes, I do enjoy coffee:  https://paypal.me/herrkaste


### PR DESCRIPTION
SublimeLinter always linted parts of a view, t.i. it did not *only*
operate on whole files.  E.g. it could lint code blocks inside markdown
documents.  There was no way to opt-out of this behavior, except maybe
to use the `excludes` setting to exclude all `*.md` files.

Let's call these sub-blocks "cells", as in: notebook cells.  Normal
linters do not understand a cell structure of a document just out of
their box, and in that *normal* case linting cells is practically
useless.

Let's introduce a new setting `enable_cells` which defaults to `False`
(which makes it a breaking change).  Plugin authors can opt-in in their
plugin, so can users on a case-by-case basis.

E.g. you could still let `flake8` run on python blocks in your docs if
you want to but then probably configure per-file overrides, e.g. to only
report whitespace errors or to exclude any unused-var warnings, etc.