### PR TITLE
Allow a list of lint reasons as lint mode

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -56,11 +56,20 @@
     "kill_old_processes": true,
 
     // Lint Mode determines when the linter is run.
-    // - background: asynchronously on every change
-    // - load_save: when a file is opened and every time it's saved
-    // - manual: only when calling the Lint This View command
-    // - save: only when a file is saved
-    "lint_mode": "background",
+    // Any combination of "on_load", "on_save", and "on_modified" is allowed
+    // here.
+    //
+    // For backwards compatibility, we still support named modes.
+    // These are defined as follows:
+    // - background: ["on_load", "on_save", "on_modified"]
+    // - load_save:  ["on_load", "on_save"]
+    // - save:       ["on_save"]
+    // - manual:     []  # Run only when calling the Lint This View command
+    // E.g.
+    //   "lint_mode": ["on_modified"]
+    //   "lint_mode": "background"
+    //   "lint_mode": []
+    "lint_mode": ["on_load", "on_modified"],
 
     // Linter-specific settings.
     // See also http://www.sublimelinter.com/en/stable/linter_settings.html
@@ -107,7 +116,8 @@
 
             // Lint mode determines when the linter is run. The linter setting
             // will take precedence over the global setting.
-            "lint_mode": "manual",
+            // Refer the detailed description in the global section.
+            "lint_mode": [],
 
             // Determines for which views this linter will run.
             "selector": "",

--- a/docs/linter_settings.rst
+++ b/docs/linter_settings.rst
@@ -207,11 +207,26 @@ patterns match, otherwise we keep it.
 lint_mode
 ---------
 Lint Mode determines when the linter is run.
+Any combination of "on_load", "on_save", and "on_modified" is allowed here.
 
-- `background`: asynchronously on every change
-- `load_save`: when a file is opened and every time it's saved
-- `manual`: only when calling the Lint This View command
-- `save`: only when a file is saved
+Some examples:
+
+.. code-block:: json
+
+    {
+        "lint_mode": ["on_load", "on_modified"],
+        "lint_mode": [],  // only run when manually triggered
+    }
+
+
+.. note::
+
+    Don't take the names literally, e.g. "on_modified" also triggers after
+    saving for linters that can only run on saved files.
+
+This used to be a string setting with the following valid values:
+"background", "load_save", "manual", and "save". These are still supported
+for backwards compatibility.
 
 
 .. _selector:

--- a/resources/settings-schema.json
+++ b/resources/settings-schema.json
@@ -1,6 +1,25 @@
 {
     "$schema":"http://json-schema.org/draft-04/schema#",
     "type":"object",
+    "definitions": {
+        "lint_mode": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "enum": ["background", "load_save", "manual", "save"]
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["on_save", "on_load", "on_modified"]
+                    },
+                    "uniqueItems": true,
+                    "minItems": 0
+                }
+            ]
+        }
+    },
     "properties":{
         "debug":{
             "type":"boolean"
@@ -31,10 +50,7 @@
                 "enum": ["phantoms", "squiggles"]
             }
         },
-        "lint_mode":{
-            "type":"string",
-            "enum":["background", "load_save", "manual", "save"]
-        },
+        "lint_mode": {"$ref": "#/definitions/lint_mode"},
         "linters":{
             "type":"object",
             "additionalProperties":{
@@ -64,10 +80,7 @@
                             "type": "string"
                         }
                     },
-                    "lint_mode":{
-                        "type":"string",
-                        "enum":["background", "load_save", "manual", "save"]
-                    },
+                    "lint_mode": {"$ref": "#/definitions/lint_mode"},
                     "selector": {
                         "type": "string"
                     },

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -280,7 +280,7 @@ class sublime_linter_lint(sublime_plugin.TextCommand):
         return (
             util.is_lintable(self.view)
             and any(
-                info.settings.get("lint_mode") != "background"
+                "on_modified" not in linter_module.get_effective_lint_mode(info.settings)
                 for info in elect.runnable_linters_for_view(self.view, "on_user_request")
             )
         ) if event else True

--- a/tests/test_command_generation.py
+++ b/tests/test_command_generation.py
@@ -355,13 +355,13 @@ class TestLintModeSetting(_BaseTestCase):
         settings = linter_module.get_linter_settings(FakeLinter, self.view)
         self.assertEqual(settings.get('lint_mode'), 'manual')
 
-    def test_use_fallback(self):
+    def test_fallback_to_global_setting(self):
         class FakeLinter(Linter):
             cmd = ('fake_linter_1',)
             defaults = {'selector': None}
 
         settings = linter_module.get_linter_settings(FakeLinter, self.view)
-        self.assertEqual(settings.get('lint_mode'), 'background')
+        self.assertEqual(settings.get('lint_mode'), ['on_load', 'on_modified'])
 
 
 class TestWorkingDirSetting(_BaseTestCase):


### PR DESCRIPTION
Fixes #1230

We always had lint modes like "background" or "load_save" which *describe* on which circumstances a linter may run but are relatively coarse-grained.  Let's allow a list here with the modes "on_save", "on_load", "on_modified" which can be combined as the user wishes.

E.g. a user could disable linting "on_load" but still having "on_modified" on.  This exact use-case was the initial driver for this change.  See #1230

Note that we need actually less modes (3) than before (4).

Also note that these are not literal trigger reasons or "events". We still apply some smartness to them.  E.g. "on_modified" runs linters that only can run after saving.  (The so-called "real-file-linters".)