### PR TITLE
Revert "Humanize column in the panel"

### DIFF
--- a/highlight_view.py
+++ b/highlight_view.py
@@ -760,7 +760,6 @@ def maybe_update_error_store(view: sublime.View) -> None:
     if not errors:
         return
 
-    tab_size = view.settings().get("tab_size", 4)
     region_keys = get_regions_keys(view)
     uid_key_map = {
         key.uid: key
@@ -794,13 +793,11 @@ def maybe_update_error_store(view: sublime.View) -> None:
             continue
 
         line, start = view.rowcol(region.begin())
-        line_content = view.substr(view.line(region.begin()))
-        column = start + line_content[:start].count("\t") * (tab_size - 1)
         error = error.copy()
         error.update({
             'region': region,
             'line': line,
-            'start': column,
+            'start': start,
         })
         new_errors.append(error)
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -407,7 +407,6 @@ def get_view_context(view: sublime.View, additional_context: Optional[Mapping] =
     context['view_id'] = str(view.id())
     context['canonical_filename'] = util.canonical_filename(view)
     context['short_canonical_filename'] = util.short_canonical_filename(view)
-    context['tab_size'] = str(view.settings().get('tab_size', 4))
 
     if additional_context:
         context.update(additional_context)
@@ -1405,15 +1404,12 @@ class Linter(metaclass=LinterMeta):
         normalized_region = sublime.Region(
             region.a, min(vv.size(), max(region.a + 1, region.b))
         )
-        line_content = vv.substr(line_region)
-        tab_size = int(self.context.get("tab_size", 4))
-        humanized_column = col + line_content[:col].count("\t") * (tab_size - 1)
         offending_text = vv.substr(normalized_region)
 
         return {
             "filename": filename,
             "line": line,
-            "start": humanized_column,
+            "start": col,
             "region": normalized_region,
             "error_type": error_type,
             "code": code,

--- a/tests/test_regex_parsing.py
+++ b/tests/test_regex_parsing.py
@@ -248,22 +248,6 @@ class TestRegexBasedParsing(_BaseTestCase):
 
         self.assertResult([{'code': CODE}], result)
 
-    def test_compute_humanized_column(self):
-        INPUT = "\t\tThis."  # Note the tabs!
-        OUTPUT = "stdin:1:3 ERROR: The message"
-        self.set_buffer_content(INPUT)
-        linter = self.create_linter()
-        when(linter)._communicate(['fake_linter_1'], INPUT).thenReturn(OUTPUT)
-
-        result = execute_lint_task(linter, INPUT)
-        drop_info_keys(result)
-
-        # Note that 'start' and `region.a` differ!
-        self.assertResult(
-            [{'line': 0, 'start': 8, 'region': sublime.Region(2, 6)}],
-            result,
-        )
-
     @p.expand(
         [
             ((0, 0), "stdin:0:0 ERROR: The message"),


### PR DESCRIPTION
From the perspective of Sublime Linter the "start" (or: "column") value is just a presentation value, precomputed for display in the panel.

However, the literal text in the panel is a "data" value when we bind "result_line_regex" to drive the global "F4" (`next_result`) location list.  For this feature, we can't have "humanized" columns as Sublime Text does not support this here.

We can at a later point fix this if we want to but do note that the behavior of the status bar column display is actually determined by a setting

```
// Controls what type of columns selection description ("Line X, Column Y"
// in the status bar) uses:
// - "virtual": Count virtual columns. Tabs count as their width in spaces.
// - "real": Count real columns. Tabs count as one column.
"selection_description_column_type": "virtual",
```

which we do not respect in this commit.

This reverts commit 22a0b52a9d3250b441ca6ad7a845dd0398fac738.