### PR TITLE
Allow running only requested linters

### DIFF
--- a/keymaps/Default (Linux).sublime-keymap
+++ b/keymaps/Default (Linux).sublime-keymap
@@ -1,7 +1,8 @@
 [
-	// Lint this view
+    // Lint this view
     { "keys": ["ctrl+k", "l"], "command": "sublime_linter_lint" },
-
+    // Supported args:
+    // * run: a list of linters to run. Defaults to all
 
     // Show all errors
     { "keys": ["ctrl+k", "a"], "command": "sublime_linter_panel_toggle" },

--- a/keymaps/Default (OSX).sublime-keymap
+++ b/keymaps/Default (OSX).sublime-keymap
@@ -1,6 +1,8 @@
 [
-	// Lint this view
+    // Lint this view
     { "keys": ["ctrl+super+l"], "command": "sublime_linter_lint" },
+    // Supported args:
+    // * run: a list of linters to run. Defaults to all
 
 
     // Show all errors

--- a/keymaps/Default (Windows).sublime-keymap
+++ b/keymaps/Default (Windows).sublime-keymap
@@ -1,6 +1,8 @@
 [
-	// Lint this view
+    // Lint this view
     { "keys": ["ctrl+k", "l"], "command": "sublime_linter_lint" },
+    // Supported args:
+    // * run: a list of linters to run. Defaults to all
 
 
     // Show all errors

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -652,7 +652,10 @@ def register_linter(name: str, cls: type[Linter]) -> None:
     # synthetic `on_activated_async` events on load.
     if persist.api_ready:
         deprecation_warning.cache_clear()
-        sublime.run_command('sublime_linter_config_changed')
+        sublime.run_command('sublime_linter_config_changed', {
+            'hint': 'relint',
+            'linter': [name]
+        })
         logger.info('{} linter reloaded'.format(name))
 
 

--- a/lint/util.py
+++ b/lint/util.py
@@ -127,6 +127,12 @@ def print_runtime(message):
     print('{} took {}ms [{}]'.format(message, duration, thread_name))
 
 
+def format_items(items: list[str], sep: str = ", ", last_sep: str = " and ") -> str:
+    if len(items) == 1:
+        return items[0]
+    return f"{sep.join(items[:-1])}{last_sep}{items[-1]}"
+
+
 def show_message(message: str, window: Optional[sublime.Window] = None) -> None:
     if window is None:
         window = sublime.active_window()

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -306,19 +306,19 @@ class sublime_linter_lint(sublime_plugin.TextCommand):
 
 
 class sublime_linter_config_changed(sublime_plugin.ApplicationCommand):
-    def run(self, hint=None, wid=None):
+    def run(self, hint: str = None, wid: sublime.WindowId = None, linter: list[LinterName] = []):
         if hint is None or hint == 'relint':
-            relint_views(wid)
+            relint_views(wid, linter)
         elif hint == 'redraw':
             force_redraw()
 
 
-def relint_views(wid=None):
+def relint_views(wid: sublime.WindowId = None, linter: list[LinterName] = []):
     windows = [sublime.Window(wid)] if wid else sublime.windows()
     for window in windows:
         for view in window.views():
             if view.buffer_id() in persist.assigned_linters and view.is_primary():
-                hit(view, 'relint_views')
+                hit(view, 'relint_views', only_run=linter)
 
 
 def hit(view: sublime.View, reason: Reason, only_run: list[LinterName] = []) -> None:

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -21,7 +21,7 @@ from .lint import reloader
 from .lint import settings
 from .lint import util
 from .lint.const import IS_ENABLED_SWITCH
-from .lint.util import flash
+from .lint.util import flash, format_items
 
 
 from typing import Callable, Optional
@@ -321,7 +321,7 @@ def relint_views(wid=None):
                 hit(view, 'relint_views')
 
 
-def hit(view: sublime.View, reason: Reason) -> None:
+def hit(view: sublime.View, reason: Reason, only_run: list[LinterName] = []) -> None:
     """Record an activity that could trigger a lint and enqueue a desire to lint."""
     bid = view.buffer_id()
 
@@ -332,11 +332,17 @@ def hit(view: sublime.View, reason: Reason) -> None:
     )
     lock = guard_check_linters_for_view[bid]
     view_has_changed = make_view_has_changed_fn(view)
-    fn = partial(lint, view, view_has_changed, lock, reason)
+    fn = partial(lint, view, view_has_changed, lock, reason, set(only_run))
     queue.debounce(fn, delay=delay, key=bid)
 
 
-def lint(view: sublime.View, view_has_changed: ViewChangedFn, lock: threading.Lock, reason: Reason) -> None:
+def lint(
+    view: sublime.View,
+    view_has_changed: ViewChangedFn,
+    lock: threading.Lock,
+    reason: Reason,
+    only_run: set[LinterName] = None
+) -> None:
     """Lint the view with the given id."""
     if view.settings().get(IS_ENABLED_SWITCH) is False:
         linters = []
@@ -345,8 +351,19 @@ def lint(view: sublime.View, view_has_changed: ViewChangedFn, lock: threading.Lo
         if not linters:
             logger.info("No installed linter matches the view.")
 
+    next_linter_names = {linter.name for linter in linters}
     with lock:
-        _assign_linters_to_view(view, {linter.name for linter in linters})
+        _assign_linters_to_view(view, next_linter_names)
+
+    if only_run:
+        linters = [linter for linter in linters if linter.name in only_run]
+        if expected_linters_not_actually_assigned := (only_run - next_linter_names):
+            s = "s" if len(expected_linters_not_actually_assigned) > 1 else ""
+            are = "are" if len(expected_linters_not_actually_assigned) > 1 else "is"
+            their_names = format_items(list(expected_linters_not_actually_assigned))
+            logger.info(
+                f"Requested linter{s} {their_names} {are} not assigned to the view."
+            )
 
     runnable_linters = list(elect.filter_runnable_linters(linters))
     if not runnable_linters:

--- a/tests/test_sublime_linter_entrypoint.py
+++ b/tests/test_sublime_linter_entrypoint.py
@@ -428,7 +428,7 @@ class TestLinterElection(_BaseTestCase):
         sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request', only_run=set(["fuke", "fork", "fark"]))
 
         verify(sublime_linter.logger).info(
-            "Requested linters fork, fuke and fark are not assigned to the view."
+            "Requested linters fark, fork and fuke are not assigned to the view."
         )
 
     def test_cells_dont_trigger_by_default(self):

--- a/tests/test_sublime_linter_entrypoint.py
+++ b/tests/test_sublime_linter_entrypoint.py
@@ -4,7 +4,7 @@ from threading import Lock
 
 from unittesting import DeferrableTestCase
 from SublimeLinter.tests.parameterized import parameterized as p
-from SublimeLinter.tests.mockito import unstub, verify, when
+from SublimeLinter.tests.mockito import captor, unstub, verify, when
 
 import sublime
 from SublimeLinter import sublime_linter
@@ -373,6 +373,62 @@ class TestLinterElection(_BaseTestCase):
 
         verify(sublime_linter.logger).info(
             "No installed linter matches the view."
+        )
+
+    def test_only_run_requested_linter(self):
+        class FakeLinter(Linter):
+            defaults = {'selector': ''}
+            cmd = 'fake_linter_1'
+
+        selected_linters = captor()
+        when(sublime_linter.backend).lint_view(...).thenReturn(None)
+
+        view = self.create_view(self.window)
+        sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request', only_run=set(["fakelinter"]))
+
+        verify(sublime_linter.backend).lint_view(selected_linters, ...)
+        self.assertEqual(selected_linters.value[0].name, "fakelinter")
+
+    def test_log_if_requested_linter_is_not_assigned(self):
+        class FakeLinter(Linter):
+            defaults = {'selector': ''}
+            cmd = 'fake_linter_1'
+
+        when(sublime_linter.logger).info(...).thenReturn(None)
+
+        view = self.create_view(self.window)
+        sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request', only_run=set(["fuke"]))
+
+        verify(sublime_linter.logger).info(
+            "Requested linter fuke is not assigned to the view."
+        )
+
+    def test_log_if_requested_linter_is_not_assigned_format2(self):
+        class FakeLinter(Linter):
+            defaults = {'selector': ''}
+            cmd = 'fake_linter_1'
+
+        when(sublime_linter.logger).info(...).thenReturn(None)
+
+        view = self.create_view(self.window)
+        sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request', only_run=set(["fuke", "fork"]))
+
+        verify(sublime_linter.logger).info(
+            "Requested linters fork and fuke are not assigned to the view."
+        )
+
+    def test_log_if_requested_linter_is_not_assigned_format3(self):
+        class FakeLinter(Linter):
+            defaults = {'selector': ''}
+            cmd = 'fake_linter_1'
+
+        when(sublime_linter.logger).info(...).thenReturn(None)
+
+        view = self.create_view(self.window)
+        sublime_linter.lint(view, lambda: False, Lock(), 'on_user_request', only_run=set(["fuke", "fork", "fark"]))
+
+        verify(sublime_linter.logger).info(
+            "Requested linters fork, fuke and fark are not assigned to the view."
         )
 
     def test_cells_dont_trigger_by_default(self):


### PR DESCRIPTION
Add an argument to `hit` and (the more internal) `lint` to restrict
the linters we want to run.

Use that when reloading a linter.  Previously we ran just all the registered linter, now we only re-run the specific linter that changed.

Expose this feature for `sublime_linter_lint`.  E.g.  the command

```
  { 
    "keys": ["ctrl+k", "ctrl+l"], 
    "command": "sublime_linter_lint", 
    "args": {"run": ["mypy"]} },
``` 

will only trigger *mypy*.  

