### PR TITLE
Refactor and expose `hit` as API

### DIFF
--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -104,10 +104,10 @@ def on_linter_assigned(filename: FileName, linter_names: set[LinterName]) -> Non
         on_attempted_linters_changed(filename)
 
 
-class sublime_linter_unassigned(sublime_plugin.WindowCommand):
-    def run(self, filename, linter_name):
-        State['assigned_linters_per_file'][filename].discard(linter_name)
-        State['failed_linters_per_file'][filename].discard(linter_name)
+@events.on(events.LINTER_UNASSIGNED)
+def on_linter_unassigned(filename: FileName, linter_name: LinterName) -> None:
+    State['assigned_linters_per_file'][filename].discard(linter_name)
+    State['failed_linters_per_file'][filename].discard(linter_name)
 
 
 class sublime_linter_failed(sublime_plugin.WindowCommand):

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -96,13 +96,12 @@ def _unset_expanded_ok(filename: FileName) -> None:
     redraw_file_(filename)
 
 
-class sublime_linter_assigned(sublime_plugin.WindowCommand):
-    def run(self, filename: FileName, linter_names: list[LinterName]) -> None:
-        State['assigned_linters_per_file'][filename] = set(linter_names)
-        State['failed_linters_per_file'][filename] = set()
-
-        if attempted_linters_changed(filename, linter_names):
-            on_attempted_linters_changed(filename)
+@events.on(events.LINTER_ASSIGNED)
+def on_linter_assigned(filename: FileName, linter_names: set[LinterName]) -> None:
+    State['assigned_linters_per_file'][filename] = linter_names
+    State['failed_linters_per_file'][filename] = set()
+    if attempted_linters_changed(filename, linter_names):
+        on_attempted_linters_changed(filename)
 
 
 class sublime_linter_unassigned(sublime_plugin.WindowCommand):

--- a/active_linters_view.py
+++ b/active_linters_view.py
@@ -110,9 +110,9 @@ def on_linter_unassigned(filename: FileName, linter_name: LinterName) -> None:
     State['failed_linters_per_file'][filename].discard(linter_name)
 
 
-class sublime_linter_failed(sublime_plugin.WindowCommand):
-    def run(self, filename, linter_name):
-        State['failed_linters_per_file'][filename].add(linter_name)
+@events.on(events.LINTER_FAILED)
+def on_linter_failed(filename: FileName, linter_name: LinterName) -> None:
+    State['failed_linters_per_file'][filename].add(linter_name)
 
 
 @events.on(events.LINT_RESULT)

--- a/lint/__init__.py
+++ b/lint/__init__.py
@@ -13,6 +13,7 @@ from .const import WARNING, ERROR
 from .util import STREAM_STDOUT, STREAM_STDERR, STREAM_BOTH
 
 from .linter import Linter, LintMatch, TransientError, PermanentError
+from .backend import hit
 from .base_linter.python_linter import PythonLinter
 from .base_linter.ruby_linter import RubyLinter
 from .base_linter.node_linter import NodeLinter

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -89,7 +89,7 @@ def lint(
 
     next_linter_names = {linter.name for linter in linters}
     with lock:
-        persist.assign_linters_to_view(view, next_linter_names)
+        persist.assign_linters_to_buffer(view, next_linter_names)
 
     if only_run:
         linters = [linter for linter in linters if linter.name in only_run]

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 MAX_CONCURRENT_TASKS = multiprocessing.cpu_count() or 1
 orchestrator = ThreadPoolExecutor(max_workers=MAX_CONCURRENT_TASKS)
 executor = ThreadPoolExecutor(max_workers=MAX_CONCURRENT_TASKS)
-guard_check_linters_for_view: defaultdict[Bid, threading.Lock] = defaultdict(threading.Lock)
+locks_per_buffer: defaultdict[Bid, threading.Lock] = defaultdict(threading.Lock)
 
 
 task_count = count(start=1)
@@ -66,7 +66,7 @@ def hit(view: sublime.View, reason: Reason, only_run: list[LinterName] = []) -> 
         "Delay linting '{}' for {:.2}s"
         .format(util.short_canonical_filename(view), delay)
     )
-    lock = guard_check_linters_for_view[bid]
+    lock = locks_per_buffer[bid]
     view_has_changed = make_view_has_changed_fn(view)
     fn = partial(lint, view, view_has_changed, lock, reason, set(only_run))
     queue.debounce(fn, delay=delay, key=bid)

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import sublime
 
-from collections import deque
+from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_EXCEPTION
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -15,24 +15,27 @@ import time
 import threading
 import traceback
 
-from . import events, linter as linter_module, persist, style, util
+from . import elect, events, linter as linter_module, persist, queue, style, util
+
+from .const import IS_ENABLED_SWITCH
+from .elect import LinterInfo
+from .linter import Linter, ViewContext
+from .persist import LintError
+from .util import format_items
 
 from typing import Callable, Iterator, TypeVar
-from typing_extensions import TypeAlias
-from .persist import LintError
-from .elect import LinterInfo
-from typing_extensions import ParamSpec
-Linter = linter_module.Linter
-LinterSettings = linter_module.LinterSettings
+from typing_extensions import ParamSpec, TypeAlias
+
 
 T = TypeVar('T')
 P = ParamSpec('P')
+Bid: TypeAlias = "sublime.BufferId"
 LintResult: TypeAlias[list] = "list[LintError]"
 Task = Callable[[], T]
 ViewChangedFn = Callable[[], bool]
 FileName = str
 LinterName = str
-ViewContext = linter_module.ViewContext
+Reason = str
 
 
 @dataclass(frozen=True)
@@ -47,10 +50,79 @@ logger = logging.getLogger(__name__)
 MAX_CONCURRENT_TASKS = multiprocessing.cpu_count() or 1
 orchestrator = ThreadPoolExecutor(max_workers=MAX_CONCURRENT_TASKS)
 executor = ThreadPoolExecutor(max_workers=MAX_CONCURRENT_TASKS)
+guard_check_linters_for_view: defaultdict[Bid, threading.Lock] = defaultdict(threading.Lock)
 
 
 task_count = count(start=1)
 counter_lock = threading.Lock()
+
+
+def hit(view: sublime.View, reason: Reason, only_run: list[LinterName] = []) -> None:
+    """Record an activity that could trigger a lint and enqueue a desire to lint."""
+    bid = view.buffer_id()
+
+    delay = get_delay() if reason == 'on_modified' else 0.0
+    logger.info(
+        "Delay linting '{}' for {:.2}s"
+        .format(util.short_canonical_filename(view), delay)
+    )
+    lock = guard_check_linters_for_view[bid]
+    view_has_changed = make_view_has_changed_fn(view)
+    fn = partial(lint, view, view_has_changed, lock, reason, set(only_run))
+    queue.debounce(fn, delay=delay, key=bid)
+
+
+def lint(
+    view: sublime.View,
+    view_has_changed: ViewChangedFn,
+    lock: threading.Lock,
+    reason: Reason,
+    only_run: set[LinterName] = None
+) -> None:
+    """Lint the view with the given id."""
+    if view.settings().get(IS_ENABLED_SWITCH) is False:
+        linters = []
+    else:
+        linters = list(elect.assignable_linters_for_view(view, reason))
+        if not linters:
+            logger.info("No installed linter matches the view.")
+
+    next_linter_names = {linter.name for linter in linters}
+    with lock:
+        persist.assign_linters_to_view(view, next_linter_names)
+
+    if only_run:
+        linters = [linter for linter in linters if linter.name in only_run]
+        if expected_linters_not_actually_assigned := (only_run - next_linter_names):
+            logger.info(
+                f"Requested {format_linter_availability_note(expected_linters_not_actually_assigned)} "
+                "not assigned to the view."
+            )
+
+    runnable_linters = list(elect.filter_runnable_linters(linters))
+    if not runnable_linters:
+        return
+
+    window = view.window()
+    bid = view.buffer_id()
+    filename = util.canonical_filename(view)
+
+    # Very, very unlikely that `view_has_changed` is already True at this
+    # point, but it also implements the kill_switch, so we ask here
+    if view_has_changed():  # abort early
+        return
+
+    assert window  # now that `view_has_changed` has been checked
+
+    if persist.settings.get('kill_old_processes'):
+        kill_active_popen_calls(bid)
+
+    def sink(linter: LinterName, errors: list[LintError]):
+        if view_has_changed():
+            return
+        persist.group_by_filename_and_update(window, filename, reason, linter, errors)
+
+    lint_view(runnable_linters, view, view_has_changed, sink)
 
 
 def lint_view(
@@ -255,6 +327,57 @@ def run_concurrently(tasks: list[Task[T]], executor: ThreadPoolExecutor) -> list
         future.cancel()
 
     return [future.result() for future in done]
+
+
+def format_linter_availability_note(unavailable_linters: set[LinterName]) -> str:
+    if not unavailable_linters:
+        return ""
+    s = "s" if len(unavailable_linters) > 1 else ""
+    are = "are" if len(unavailable_linters) > 1 else "is"
+    their_names = format_items(sorted(unavailable_linters))
+    return f"linter{s} {their_names} {are}"
+
+
+def make_view_has_changed_fn(view: sublime.View) -> ViewChangedFn:
+    initial_change_count = view.change_count()
+
+    def view_has_changed():
+        if persist.kill_switch:
+            window = sublime.active_window()
+            window.status_message(
+                'SublimeLinter upgrade in progress. Aborting lint.')
+            return True
+
+        if view.buffer_id() == 0:
+            logger.info('View detached (no buffer_id). Aborting lint.')
+            return True
+
+        if view.window() is None:
+            logger.info('View detached (no window). Aborting lint.')
+            return True
+
+        if view.change_count() != initial_change_count:
+            logger.info(
+                'Buffer {} inconsistent. Aborting lint.'
+                .format(view.buffer_id()))
+            return True
+
+        return False
+
+    return view_has_changed
+
+
+def kill_active_popen_calls(bid):
+    with persist.active_procs_lock:
+        procs = persist.active_procs[bid][:]
+
+    if procs:
+        logger.info('Friendly terminate: {}'.format(
+            ', '.join('<pid {}>'.format(proc.pid) for proc in procs)
+        ))
+    for proc in procs:
+        proc.terminate()
+        setattr(proc, 'friendly_terminated', True)
 
 
 global_lock = threading.RLock()

--- a/lint/backend.py
+++ b/lint/backend.py
@@ -79,7 +79,7 @@ def lint(
     reason: Reason,
     only_run: set[LinterName] = None
 ) -> None:
-    """Lint the view with the given id."""
+    """Lint the given view. """
     if view.settings().get(IS_ENABLED_SWITCH) is False:
         linters = []
     else:
@@ -122,22 +122,9 @@ def lint(
             return
         persist.group_by_filename_and_update(window, filename, reason, linter, errors)
 
-    lint_view(runnable_linters, view, view_has_changed, sink)
-
-
-def lint_view(
-    linters: list[LinterInfo],
-    view: sublime.View,
-    view_has_changed: ViewChangedFn,
-    sink: Callable[[LinterName, LintResult], None]
-) -> None:
-    """Lint the given view.
-
-    This is the top level lint dispatcher. It falls through.
-    """
     lint_jobs = [
         LintJob(linter.name, linter.context, tasks)
-        for linter in linters
+        for linter in runnable_linters
         if (tasks := list(tasks_per_linter(view, view_has_changed, linter)))
     ]
     warn_excessive_tasks(lint_jobs)

--- a/lint/events.py
+++ b/lint/events.py
@@ -14,6 +14,7 @@ ERROR_POSITIONS_CHANGED = 'error_positions_changed'
 SETTINGS_CHANGED = 'settings_changed'
 LINTER_ASSIGNED = 'linter_assigned'
 LINTER_UNASSIGNED = 'linter_unassigned'
+LINTER_FAILED = 'linter_failed'
 
 
 Handler = Callable[..., None]

--- a/lint/events.py
+++ b/lint/events.py
@@ -13,6 +13,7 @@ PLUGIN_LOADED = 'plugin_loaded'
 ERROR_POSITIONS_CHANGED = 'error_positions_changed'
 SETTINGS_CHANGED = 'settings_changed'
 LINTER_ASSIGNED = 'linter_assigned'
+LINTER_UNASSIGNED = 'linter_unassigned'
 
 
 Handler = Callable[..., None]

--- a/lint/events.py
+++ b/lint/events.py
@@ -12,6 +12,7 @@ FILE_RENAMED = 'file_renamed'
 PLUGIN_LOADED = 'plugin_loaded'
 ERROR_POSITIONS_CHANGED = 'error_positions_changed'
 SETTINGS_CHANGED = 'settings_changed'
+LINTER_ASSIGNED = 'linter_assigned'
 
 
 Handler = Callable[..., None]

--- a/lint/events.pyi
+++ b/lint/events.pyi
@@ -17,6 +17,7 @@ PLUGIN_LOADED: Literal['plugin_loaded']
 ERROR_POSITIONS_CHANGED: Literal['error_positions_changed']
 SETTINGS_CHANGED: Literal['settings_changed']
 LINTER_ASSIGNED: Literal['linter_assigned']
+LINTER_UNASSIGNED: Literal['linter_unassigned']
 
 
 class LintStartPayload(TypedDict):
@@ -49,6 +50,10 @@ class LinterAssignedPayload(TypedDict):
     filename: str
     linter_names: set[str]
 
+class LinterUnassignedPayload(TypedDict):
+    filename: str
+    linter_name: str
+
 
 class LintStartHandler(Protocol):
     def __call__(self, **kwargs: Unpack[LintStartPayload]) -> None: ...
@@ -74,12 +79,15 @@ class SettingsChangedHandler(Protocol):
 class LinterAssignedHandler(Protocol):
     def __call__(self, **kwargs: Unpack[LinterAssignedPayload]) -> None: ...
 
+class LinterUnassignedHandler(Protocol):
+    def __call__(self, **kwargs: Unpack[LinterUnassignedPayload]) -> None: ...
+
 
 Handler = Callable[..., None]
 AnyHandler = Union[
     LintStartHandler, LintResultHandler, LintEndHandler, FileRenamedHandler,
     PluginLoadedHandler, ErrorPositionsChangedHandler, SettingsChangedHandler,
-    LinterAssignedHandler,
+    LinterAssignedHandler, LinterUnassignedHandler
 ]
 
 @overload
@@ -99,6 +107,8 @@ def subscribe(topic: Literal['settings_changed'], fn: SettingsChangedHandler) ->
 @overload
 def subscribe(topic: Literal['linter_assigned'], fn: LinterAssignedHandler) -> None: ...
 @overload
+def subscribe(topic: Literal['linter_unassigned'], fn: LinterUnassignedHandler) -> None: ...
+@overload
 def subscribe(topic: str, fn: Handler) -> None: ...
 
 @overload
@@ -117,6 +127,8 @@ def unsubscribe(topic: Literal['error_positions_changed'], fn: ErrorPositionsCha
 def unsubscribe(topic: Literal['settings_changed'], fn: SettingsChangedHandler) -> None: ...
 @overload
 def unsubscribe(topic: Literal['linter_assigned'], fn: LinterAssignedHandler) -> None: ...
+@overload
+def unsubscribe(topic: Literal['linter_unassigned'], fn: LinterUnassignedHandler) -> None: ...
 @overload
 def unsubscribe(topic: str, fn: Handler) -> None: ...
 @overload
@@ -139,6 +151,8 @@ def broadcast(topic: Literal['settings_changed'], payload: SettingsChangedPayloa
 @overload
 def broadcast(topic: Literal['linter_assigned'], payload: LinterAssignedPayload) -> None: ...
 @overload
+def broadcast(topic: Literal['linter_unassigned'], payload: LinterUnassignedPayload) -> None: ...
+@overload
 def broadcast(topic: str, payload: dict[str, Any]) -> None: ...
 
 @overload
@@ -157,6 +171,8 @@ def on(topic: Literal['error_positions_changed']) -> Callable[[ErrorPositionsCha
 def on(topic: Literal['settings_changed']) -> Callable[[SettingsChangedHandler], SettingsChangedHandler]: ...
 @overload
 def on(topic: Literal['linter_assigned']) -> Callable[[LinterAssignedHandler], LinterAssignedHandler]: ...
+@overload
+def on(topic: Literal['linter_unassigned']) -> Callable[[LinterUnassignedHandler], LinterUnassignedHandler]: ...
 @overload
 def on(topic: str) -> Callable[[Handler], Handler]: ...
 

--- a/lint/events.pyi
+++ b/lint/events.pyi
@@ -16,6 +16,7 @@ FILE_RENAMED: Literal['file_renamed']
 PLUGIN_LOADED: Literal['plugin_loaded']
 ERROR_POSITIONS_CHANGED: Literal['error_positions_changed']
 SETTINGS_CHANGED: Literal['settings_changed']
+LINTER_ASSIGNED: Literal['linter_assigned']
 
 
 class LintStartPayload(TypedDict):
@@ -44,6 +45,10 @@ class ErrorPositionsChangedPayload(TypedDict):
 class SettingsChangedPayload(TypedDict):
     settings: Settings
 
+class LinterAssignedPayload(TypedDict):
+    filename: str
+    linter_names: set[str]
+
 
 class LintStartHandler(Protocol):
     def __call__(self, **kwargs: Unpack[LintStartPayload]) -> None: ...
@@ -66,11 +71,15 @@ class ErrorPositionsChangedHandler(Protocol):
 class SettingsChangedHandler(Protocol):
     def __call__(self, **kwargs: Unpack[SettingsChangedPayload]) -> None: ...
 
+class LinterAssignedHandler(Protocol):
+    def __call__(self, **kwargs: Unpack[LinterAssignedPayload]) -> None: ...
+
 
 Handler = Callable[..., None]
 AnyHandler = Union[
     LintStartHandler, LintResultHandler, LintEndHandler, FileRenamedHandler,
-    PluginLoadedHandler, ErrorPositionsChangedHandler, SettingsChangedHandler
+    PluginLoadedHandler, ErrorPositionsChangedHandler, SettingsChangedHandler,
+    LinterAssignedHandler,
 ]
 
 @overload
@@ -88,6 +97,8 @@ def subscribe(topic: Literal['error_positions_changed'], fn: ErrorPositionsChang
 @overload
 def subscribe(topic: Literal['settings_changed'], fn: SettingsChangedHandler) -> None: ...
 @overload
+def subscribe(topic: Literal['linter_assigned'], fn: LinterAssignedHandler) -> None: ...
+@overload
 def subscribe(topic: str, fn: Handler) -> None: ...
 
 @overload
@@ -104,6 +115,8 @@ def unsubscribe(topic: Literal['plugin_loaded'], fn: PluginLoadedHandler) -> Non
 def unsubscribe(topic: Literal['error_positions_changed'], fn: ErrorPositionsChangedHandler) -> None: ...
 @overload
 def unsubscribe(topic: Literal['settings_changed'], fn: SettingsChangedHandler) -> None: ...
+@overload
+def unsubscribe(topic: Literal['linter_assigned'], fn: LinterAssignedHandler) -> None: ...
 @overload
 def unsubscribe(topic: str, fn: Handler) -> None: ...
 @overload
@@ -124,6 +137,8 @@ def broadcast(topic: Literal['error_positions_changed'], payload: ErrorPositions
 @overload
 def broadcast(topic: Literal['settings_changed'], payload: SettingsChangedPayload) -> None: ...
 @overload
+def broadcast(topic: Literal['linter_assigned'], payload: LinterAssignedPayload) -> None: ...
+@overload
 def broadcast(topic: str, payload: dict[str, Any]) -> None: ...
 
 @overload
@@ -140,6 +155,8 @@ def on(topic: Literal['plugin_loaded']) -> Callable[[PluginLoadedHandler], Plugi
 def on(topic: Literal['error_positions_changed']) -> Callable[[ErrorPositionsChangedHandler], ErrorPositionsChangedHandler]: ...
 @overload
 def on(topic: Literal['settings_changed']) -> Callable[[SettingsChangedHandler], SettingsChangedHandler]: ...
+@overload
+def on(topic: Literal['linter_assigned']) -> Callable[[LinterAssignedHandler], LinterAssignedHandler]: ...
 @overload
 def on(topic: str) -> Callable[[Handler], Handler]: ...
 

--- a/lint/events.pyi
+++ b/lint/events.pyi
@@ -18,6 +18,7 @@ ERROR_POSITIONS_CHANGED: Literal['error_positions_changed']
 SETTINGS_CHANGED: Literal['settings_changed']
 LINTER_ASSIGNED: Literal['linter_assigned']
 LINTER_UNASSIGNED: Literal['linter_unassigned']
+LINTER_FAILED: Literal['linter_failed']
 
 
 class LintStartPayload(TypedDict):
@@ -54,6 +55,10 @@ class LinterUnassignedPayload(TypedDict):
     filename: str
     linter_name: str
 
+class LinterFailedPayload(TypedDict):
+    filename: str
+    linter_name: str
+
 
 class LintStartHandler(Protocol):
     def __call__(self, **kwargs: Unpack[LintStartPayload]) -> None: ...
@@ -82,12 +87,15 @@ class LinterAssignedHandler(Protocol):
 class LinterUnassignedHandler(Protocol):
     def __call__(self, **kwargs: Unpack[LinterUnassignedPayload]) -> None: ...
 
+class LinterFailedHandler(Protocol):
+    def __call__(self, **kwargs: Unpack[LinterFailedPayload]) -> None: ...
+
 
 Handler = Callable[..., None]
 AnyHandler = Union[
     LintStartHandler, LintResultHandler, LintEndHandler, FileRenamedHandler,
     PluginLoadedHandler, ErrorPositionsChangedHandler, SettingsChangedHandler,
-    LinterAssignedHandler, LinterUnassignedHandler
+    LinterAssignedHandler, LinterUnassignedHandler, LinterFailedHandler,
 ]
 
 @overload
@@ -109,6 +117,8 @@ def subscribe(topic: Literal['linter_assigned'], fn: LinterAssignedHandler) -> N
 @overload
 def subscribe(topic: Literal['linter_unassigned'], fn: LinterUnassignedHandler) -> None: ...
 @overload
+def subscribe(topic: Literal['linter_failed'], fn: LinterFailedHandler) -> None: ...
+@overload
 def subscribe(topic: str, fn: Handler) -> None: ...
 
 @overload
@@ -129,6 +139,8 @@ def unsubscribe(topic: Literal['settings_changed'], fn: SettingsChangedHandler) 
 def unsubscribe(topic: Literal['linter_assigned'], fn: LinterAssignedHandler) -> None: ...
 @overload
 def unsubscribe(topic: Literal['linter_unassigned'], fn: LinterUnassignedHandler) -> None: ...
+@overload
+def unsubscribe(topic: Literal['linter_failed'], fn: LinterFailedHandler) -> None: ...
 @overload
 def unsubscribe(topic: str, fn: Handler) -> None: ...
 @overload
@@ -153,6 +165,8 @@ def broadcast(topic: Literal['linter_assigned'], payload: LinterAssignedPayload)
 @overload
 def broadcast(topic: Literal['linter_unassigned'], payload: LinterUnassignedPayload) -> None: ...
 @overload
+def broadcast(topic: Literal['linter_failed'], payload: LinterFailedPayload) -> None: ...
+@overload
 def broadcast(topic: str, payload: dict[str, Any]) -> None: ...
 
 @overload
@@ -173,6 +187,8 @@ def on(topic: Literal['settings_changed']) -> Callable[[SettingsChangedHandler],
 def on(topic: Literal['linter_assigned']) -> Callable[[LinterAssignedHandler], LinterAssignedHandler]: ...
 @overload
 def on(topic: Literal['linter_unassigned']) -> Callable[[LinterUnassignedHandler], LinterUnassignedHandler]: ...
+@overload
+def on(topic: Literal['linter_failed']) -> Callable[[LinterFailedHandler], LinterFailedHandler]: ...
 @overload
 def on(topic: str) -> Callable[[Handler], Handler]: ...
 

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -15,7 +15,7 @@ import sys
 import tempfile
 
 import sublime
-from . import persist, util
+from . import events, persist, util
 from .const import WARNING, ERROR
 
 
@@ -805,12 +805,10 @@ class Linter(metaclass=LinterMeta):
 
     def notify_unassign(self):
         # Side-effect: the status bar will not show the linter at all
-        window = self.view.window()
-        if window:
-            window.run_command('sublime_linter_unassigned', {
-                'filename': util.canonical_filename(self.view),
-                'linter_name': self.name
-            })
+        events.broadcast(events.LINTER_UNASSIGNED, {
+            'filename': util.canonical_filename(self.view),
+            'linter_name': self.name
+        })
 
     def on_stderr(self, output):
         self.logger.warning('{} output:\n{}'.format(self.name, output))

--- a/lint/linter.py
+++ b/lint/linter.py
@@ -796,12 +796,10 @@ class Linter(metaclass=LinterMeta):
 
     def notify_failure(self):
         # Side-effect: the status bar will show `(erred)`
-        window = self.view.window()
-        if window:
-            window.run_command('sublime_linter_failed', {
-                'filename': util.canonical_filename(self.view),
-                'linter_name': self.name
-            })
+        events.broadcast(events.LINTER_FAILED, {
+            'filename': util.canonical_filename(self.view),
+            'linter_name': self.name
+        })
 
     def notify_unassign(self):
         # Side-effect: the status bar will not show the linter at all

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -57,7 +57,7 @@ active_procs: DefaultDict[Bid, list[subprocess.Popen]] = defaultdict(list)
 active_procs_lock = threading.Lock()
 
 
-def assign_linters_to_view(view: sublime.View, next_linters: set[LinterName]) -> None:
+def assign_linters_to_buffer(view: sublime.View, next_linters: set[LinterName]) -> None:
     # We do not want to update `assigned_linters` for detached views bc `on_close`
     # already has been called at this time.
     if not view.is_valid():

--- a/lint/persist.py
+++ b/lint/persist.py
@@ -57,6 +57,49 @@ active_procs: DefaultDict[Bid, list[subprocess.Popen]] = defaultdict(list)
 active_procs_lock = threading.Lock()
 
 
+def group_by_filename_and_update(
+    window: sublime.Window,
+    main_filename: FileName,
+    reason: Reason,
+    linter: LinterName,
+    errors: list[LintError]
+) -> None:
+    """Group lint errors by filename and update them."""
+    grouped: defaultdict[FileName, list[LintError]] = defaultdict(list)
+    for error in errors:
+        grouped[error['filename']].append(error)
+
+    # The contract for a simple linter is that it reports `[errors]` or an
+    # empty list `[]` if the buffer is clean. For linters that report errors
+    # for multiple files we collect information about which files are actually
+    # reported by a given linted file so that we can clean the results.
+    affected_filenames = affected_filenames_per_filename[main_filename]
+    previous_filenames = affected_filenames[linter]
+
+    current_filenames = set(grouped.keys()) - {main_filename}
+    affected_filenames[linter] = current_filenames
+
+    # Basically, we must fake a `[]` response for every filename that is no
+    # longer reported.
+    # For the main view we MUST *always* report an outcome. This is not for
+    # cleanup but functions as a signal that we're done. Merely for the status
+    # bar view.
+    clean_files = previous_filenames - current_filenames
+    for filename in clean_files | {main_filename}:
+        grouped[filename]  # For the side-effect of creating a new empty `list`
+
+    for filename, errors in grouped.items():
+        # Ignore errors of other files if their view is dirty; but still
+        # propagate if there are no errors, t.i. cleanup is allowed even
+        # then.
+        if filename != main_filename and errors:
+            view = window.find_open_file(filename)
+            if view and view.is_dirty():
+                continue
+
+        update_file_errors(filename, linter, errors, reason)
+
+
 def update_file_errors(
     filename: FileName,
     linter: LinterName,

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -229,7 +229,7 @@ class BackendController(sublime_plugin.EventListener):
             persist.file_errors.pop(fn, None)
 
         persist.assigned_linters.pop(bid, None)
-        backend.guard_check_linters_for_view.pop(bid, None)
+        backend.locks_per_buffer.pop(bid, None)
         buffer_filenames.pop(bid, None)
         buffer_base_scopes.pop(bid, None)
         queue.cleanup(bid)

--- a/sublime_linter.py
+++ b/sublime_linter.py
@@ -469,9 +469,9 @@ def _assign_linters_to_view(view: sublime.View, next_linters: set[LinterName]) -
     current_linters = persist.assigned_linters.get(bid, set())
 
     persist.assigned_linters[bid] = next_linters
-    window.run_command('sublime_linter_assigned', {
+    events.broadcast(events.LINTER_ASSIGNED, {
         'filename': filename,
-        'linter_names': list(next_linters)
+        'linter_names': next_linters
     })
 
     affected_files = persist.affected_filenames_per_filename[filename]


### PR DESCRIPTION
This is a bigger refactor and moves functions away from the root "sublime_linter.py".  E.g. `hit`lands in `backend` and is exposed in `lint.__init__`.

What's not in.  Ideally I would have likes that `hit` is in some way *awaitable*, i.e. if it would return a Future.  Anything so that the caller knows: ok that's done now.  But that is harder than one expect on first sight.

a) Any call to `hit` can be cancelled, because `hit` is debounced.  
b) `hit` does potentially a fan-out to multiple linters, the future as a boxed value can likely not represent that.  A Future[bool] then seems more appropriate: yes finished, no cancelled. 
c) Alternatively, a callback as an optional argument could accepted that is called on every lint result (zero to many).  Useful to get the lint results, not so useful to await it.  You never know when its finished.  

So, we have some options here, not yet decided.